### PR TITLE
Baseline Regexp parser

### DIFF
--- a/parser/registry/parser_registry/index.js
+++ b/parser/registry/parser_registry/index.js
@@ -26,7 +26,7 @@ module.exports = {
     "regexp": (token, query) => {
         const re = new RegExp(JSON.parse(token.Child("parameter").value));
         const getLabels = (m) => {
-            return m.groups || {};
+            return m && m.groups ? m.groups : {};
         }
         return {
             ...query,


### PR DESCRIPTION
Thanks @akvlad

- escape slashes inside quotes
- only named groups (as in Loki)
- JS regexp notation

Sample queries:
* Logs
  - `{type="clickhouse"} |~"Reserving" | regexp "Reserving (?<token>\\d+.\\d+)"`
* Metrics
  - `avg_over_time({type="clickhouse"} |~"Reserving" | regexp "Reserving (?<token>\\d+.\\d+)" | unwrap token[1s]) by (type)`