### PR TITLE
Fix issue with "snappy: corrupt input"

### DIFF
--- a/writer/controller/middleware.go
+++ b/writer/controller/middleware.go
@@ -6,15 +6,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/snappy"
-	"github.com/metrico/qryn/writer/ch_wrapper"
-	custom_errors "github.com/metrico/qryn/writer/utils/errors"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/golang/snappy"
+	"github.com/metrico/qryn/writer/ch_wrapper"
+	custom_errors "github.com/metrico/qryn/writer/utils/errors"
 )
 
 var DbClient ch_wrapper.IChClient
@@ -185,8 +186,9 @@ var WithOverallContextMiddleware = WithPreRequest(func(w http.ResponseWriter, r 
 		}
 		r.Body = readColser{reader}
 	case "snappy":
-		reader := snappy.NewReader(r.Body)
-		r.Body = readColser{reader}
+		// Disable snappy decoding because it handles in withUnsnappyRequest middleware
+		// reader := snappy.NewReader(r.Body)
+		// r.Body = readColser{reader}
 		// Handle snappy encoding if needed
 		break
 	default:


### PR DESCRIPTION
      
I encountered a problem where the Prometheus push endpoint wasn't working and returned the following error:
{"level":"error","msg":"snappy: corrupt input","time":"2025-05-01T12:43:09Z"}

I tested this using Alloy and Promtool.
After some research, I discovered that the problem occurred because it handled "snappy" multiple times.
Commenting out these lines fixed the issue.
However, I have only tested this with Prometheus, and I'm not sure if it might break other functionality. Please review and test.

    