### PR TITLE
Fixed incorrect key parameter passing to function os.Getenv

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func initFlags() {
 }
 
 func boolEnv(key string) (bool, error) {
-	val := os.Getenv("key")
+	val := os.Getenv(key)
 	for _, v := range []string{"true", "1", "yes", "y"} {
 		if v == val {
 			return true, nil


### PR DESCRIPTION
In the ```boolEnv``` function, the key parameter is passed to ```os.Getenv()``` in double quotes, which means that a string value is passed instead of a key variable. So the OMIT_CREATE_TABLES environment variable is not used.