### PR TITLE
feat: Add flexible validator package for HTTP request parsing and val…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/go-faster/jx v1.1.0
 	github.com/go-kit/kit v0.13.0
 	github.com/go-logfmt/logfmt v0.6.0
+	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/gofiber/websocket/v2 v2.2.1
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,8 @@ github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
+github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp4Mit+3FDh548oRqwVgNsHA=
+github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 h1:JVrqSeQfdhYRFk24TvhTZWU0q8lfCojxZQFi3Ou7+uY=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=

--- a/reader/controller/prom_query_instant.go
+++ b/reader/controller/prom_query_instant.go
@@ -1,11 +1,10 @@
 package controller
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/gorilla/schema"
+	"github.com/metrico/qryn/shared/validator"
 )
 
 type queryInstantProps struct {
@@ -17,6 +16,11 @@ type queryInstantProps struct {
 	Query string
 }
 
+type queryRequest struct {
+	Time  validator.FlexibleTime `json:"time" schema:"time" validate:"required"`
+	Query string                 `json:"query" schema:"query" validate:"required"`
+}
+
 func (q *PromQueryRangeController) QueryInstant(w http.ResponseWriter, r *http.Request) {
 	defer tamePanic(w, r)
 	ctx, err := RunPreRequestPlugins(r)
@@ -24,12 +28,12 @@ func (q *PromQueryRangeController) QueryInstant(w http.ResponseWriter, r *http.R
 		PromError(500, err.Error(), w)
 		return
 	}
-	req, err := parseQueryInstantProps(r)
+	p, err := validator.ValidateRequest[queryRequest](r)
 	if err != nil {
 		PromError(400, err.Error(), w)
 		return
 	}
-	promQuery, err := q.Api.QueryEngine.NewInstantQuery(q.Storage.SetOidAndDB(ctx), nil, req.Query, req.Time)
+	promQuery, err := q.Api.QueryEngine.NewInstantQuery(q.Storage.SetOidAndDB(ctx), nil, p.Query, p.Time.Time())
 	if err != nil {
 		PromError(500, err.Error(), w)
 		return
@@ -44,36 +48,4 @@ func (q *PromQueryRangeController) QueryInstant(w http.ResponseWriter, r *http.R
 		PromError(500, err.Error(), w)
 		return
 	}
-}
-
-func parseQueryInstantProps(r *http.Request) (queryInstantProps, error) {
-	res := queryInstantProps{}
-	var err error
-	if r.Method == "POST" && r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
-		err = r.ParseForm()
-		if err != nil {
-			return res, err
-		}
-
-		dec := schema.NewDecoder()
-		err = dec.Decode(&res.Raw, r.Form)
-		if err != nil {
-			return res, err
-		}
-	}
-	if res.Raw.Query == "" {
-		res.Raw.Query = r.URL.Query().Get("query")
-	}
-	if res.Raw.Time == "" {
-		res.Raw.Time = r.URL.Query().Get("time")
-	}
-	res.Time, err = ParseTimeSecOrRFC(res.Raw.Time, time.Now())
-	if err != nil {
-		return res, err
-	}
-	if res.Raw.Query == "" {
-		return res, fmt.Errorf("query is undefined")
-	}
-	res.Query = res.Raw.Query
-	return res, err
 }

--- a/shared/validator/timeparser.go
+++ b/shared/validator/timeparser.go
@@ -1,0 +1,120 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// FlexibleTime is a custom type that can parse time from either
+// an integer timestamp or an RFC3339 formatted string
+type FlexibleTime time.Time
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface
+// allowing FlexibleTime to be used with schema.Decoder
+func (ft *FlexibleTime) UnmarshalText(text []byte) error {
+	str := string(text)
+	// Try parsing as integer timestamp first
+	timestamp, err := strconv.ParseInt(str, 10, 64)
+	if err == nil {
+		*ft = FlexibleTime(time.Unix(timestamp, 0))
+		return nil
+	}
+	// If not an integer, try as RFC3339 string
+	t, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return fmt.Errorf("in FlexibleTime.UnmarshalText: failed to parse time parameter: must be either a unix timestamp or RFC3339 formatted string")
+	}
+	*ft = FlexibleTime(t)
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+// allowing FlexibleTime to be used with json.Decoder
+func (ft *FlexibleTime) UnmarshalJSON(data []byte) error {
+	// Handle null value
+	if string(data) == "null" {
+		return nil // Keep the zero value
+	}
+	// Try parsing as a JSON number (timestamp)
+	var timestamp int64
+	err := json.Unmarshal(data, &timestamp)
+	if err == nil {
+		*ft = FlexibleTime(time.Unix(timestamp, 0))
+		return nil
+	}
+	// Try parsing as a JSON string
+	var timeStr string
+	err = json.Unmarshal(data, &timeStr)
+	if err != nil {
+		return fmt.Errorf("in FlexibleTime.UnmarshalJSON: failed to parse time parameter: %w", err)
+	}
+	// Parse the time string
+	t, err := time.Parse(time.RFC3339, timeStr)
+	if err != nil {
+		return fmt.Errorf("in FlexibleTime.UnmarshalJSON: failed to parse time string: %w", err)
+	}
+	*ft = FlexibleTime(t)
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface
+// to properly convert FlexibleTime to JSON
+func (ft FlexibleTime) MarshalJSON() ([]byte, error) {
+	// Convert to RFC3339 string
+	return json.Marshal(ft.String())
+}
+
+// Time converts FlexibleTime back to time.Time
+func (ft FlexibleTime) Time() time.Time {
+	return time.Time(ft)
+}
+
+// IsZero reports whether FlexibleTime represents the zero time instant, January 1, year 1, 00:00:00 UTC.
+func (ft FlexibleTime) IsZero() bool {
+	return time.Time(ft).IsZero()
+}
+
+// String returns the RFC3339 representation of the time
+func (ft FlexibleTime) String() string {
+	return time.Time(ft).Format(time.RFC3339)
+}
+
+// SetDefaultIfZero sets the FlexibleTime value to a default if it is zero.
+// The default string can be "now", "now-<duration>", a unix timestamp, or an RFC3339 time.
+func (ft *FlexibleTime) SetDefaultIfZero(defaultStr string) {
+	if ft.IsZero() && defaultStr != "" {
+		// Handle common default cases (now, now-6h, RFC3339, unix)
+		now := time.Now()
+		switch {
+		case defaultStr == "now":
+			*ft = FlexibleTime(now)
+		case strings.HasPrefix(defaultStr, "now-"):
+			dur, err := time.ParseDuration("-" + strings.TrimPrefix(defaultStr, "now-"))
+			if err == nil {
+				*ft = FlexibleTime(now.Add(dur))
+			}
+		default:
+			_ = ft.UnmarshalText([]byte(defaultStr))
+		}
+	}
+}
+
+// applyFlexibleTimeDefaults applies default values to FlexibleTime fields in a struct pointer.
+// It looks for struct tags named "flexdefault" and sets zero FlexibleTime fields to the specified default.
+func applyFlexibleTimeDefaults(ptr any) {
+	v := reflect.ValueOf(ptr).Elem()
+	t := v.Type()
+	for i := range t.NumField() {
+		field := t.Field(i)
+		def := field.Tag.Get("flexdefault")
+		fv := v.Field(i)
+		if fv.CanAddr() && fv.Type() == reflect.TypeOf(FlexibleTime{}) {
+			ft := fv.Addr().Interface().(*FlexibleTime)
+			ft.SetDefaultIfZero(def)
+		}
+	}
+}

--- a/shared/validator/validator.go
+++ b/shared/validator/validator.go
@@ -1,0 +1,162 @@
+// Package validator provides utilities for validating and decoding JSON input
+// into strongly typed structs, using the go-playground/validator package.
+package validator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"reflect"
+
+	"github.com/gorilla/schema"
+
+	"github.com/go-playground/validator"
+)
+
+// schemaDecoder is a shared decoder configured to ignore unknown fields.
+var (
+	schemaDecoder *schema.Decoder
+	validate      *validator.Validate
+)
+
+func init() {
+	validate = validator.New()
+	schemaDecoder = schema.NewDecoder()
+	schemaDecoder.IgnoreUnknownKeys(true)
+	// Register FlexibleTime type with the decoder
+	schemaDecoder.RegisterConverter(FlexibleTime{}, func(s string) reflect.Value {
+		var ft FlexibleTime
+		if err := ft.UnmarshalText([]byte(s)); err != nil {
+			return reflect.Value{}
+		}
+		return reflect.ValueOf(ft)
+	})
+}
+
+// Validate decodes JSON data from the provided io.Reader into a struct of type T,
+// and validates the struct using the go-playground/validator package.
+//
+// It returns the decoded struct if successful, or an error if either the JSON is
+// malformed or the struct fails validation.
+//
+// Example usage:
+//
+//	type User struct {
+//	    Name  string `json:"name" validate:"required,min=3"`
+//	    Email string `json:"email" validate:"required,email"`
+//	}
+//
+//	user, err := validator.Validate\[User\](reader)
+//	if err != nil {
+//	    // Handle error
+//	}
+//	// Use 'user' which is the decoded and validated struct
+//
+// Parameters:
+//   - r: an io.Reader that contains the JSON data to be decoded and validated.
+//
+// Returns:
+//   - T: The decoded and validated struct of type T.
+//   - error: If the JSON is invalid or validation fails, an error is returned.
+func Validate[T any](r io.Reader) (T, error) {
+	var res T
+	var zero T
+	if err := json.NewDecoder(r).Decode(&res); err != nil {
+		return zero, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if err := validate.Struct(res); err != nil {
+		return zero, fmt.Errorf("validation failed: %w", err)
+	}
+	return res, nil
+}
+
+// ValidateBody decodes JSON from the request body into a struct of type T,
+// validates the struct using the go-playground/validator package, and resets the request body.
+//
+// It returns the decoded struct if successful, or an error if either the JSON is
+// malformed or validation fails.
+func ValidateBody[T any](r *http.Request) (T, error) {
+	var zero T
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return zero, err
+	}
+	// Reset the request body for subsequent reads
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	return Validate[T](bytes.NewReader(bodyBytes))
+}
+
+// ValidateQuery decodes URL query parameters into a struct of type T
+// and validates it using go-playground/validator.
+//
+// Example usage:
+//
+//	type Filters struct {
+//	    Limit int    `schema:"limit" validate:"gte=1,lte=100"`
+//	    Sort  string `schema:"sort" validate:"oneof=asc desc"`
+//	}
+//
+//	params := r.URL.Query()
+//	filters, err := validator.ValidateQuery\[Filters\](params)
+//
+// Parameters:
+//   - q: url.Values from r.URL.Query()
+//
+// Returns:
+//   - T: Decoded and validated struct.
+//   - error: If decoding or validation fails.
+func ValidateQuery[T any](q url.Values) (T, error) {
+	var res T
+	var empty T
+	if err := schemaDecoder.Decode(&res, q); err != nil {
+		return empty, fmt.Errorf("invalid query params: %w", err)
+	}
+	// Specific to any FlexibleTime fields, applies defaults if necessary
+	applyFlexibleTimeDefaults(&res)
+	if err := validate.Struct(res); err != nil {
+		return empty, fmt.Errorf("validation failed: %w", err)
+	}
+	return res, nil
+}
+
+// ValidateRequest parses and validates HTTP request parameters into a struct of type T.
+//
+// This generic function is designed to work with both GET and POST requests. It uses `r.ParseForm()`
+// to populate `r.Form` with all query parameters and (for POST, PUT, PATCH requests with the correct
+// content type) form body parameters. For overlapping keys, POST body parameters take precedence.
+//
+// The function then calls ValidateQuery to decode the merged parameters into a struct of type T and
+// validates it using go-playground/validator, returning either the decoded struct or an error.
+//
+// Returns:
+//   - T: The decoded and validated struct of type T.
+//   - error: An error if decoding or validation fails.
+//
+// Example:
+//
+//	type UserParams struct {
+//	    Name  string `schema:"name" validate:"required"`
+//	    Email string `schema:"email" validate:"required,email"`
+//	}
+//
+//	user, err := ValidateRequest[UserParams](r)
+//	if err != nil {
+//	    // handle error
+//	}
+func ValidateRequest[T any](r *http.Request) (T, error) {
+	if err := r.ParseForm(); err != nil {
+		var empty T
+		return empty, fmt.Errorf("in ValidateRequest: failed to parse form data: %w", err)
+	}
+	// ParseForm prioritizes PostForm over URL query parameters,
+	// however the schemaDecoder prioritizes the last slice value.
+	// see TestDecoderFormPrecedence
+	values := r.Form
+	// Overriding the keys with PostForm values
+	maps.Copy(values, r.PostForm)
+	return ValidateQuery[T](r.Form)
+}

--- a/shared/validator/validator_test.go
+++ b/shared/validator/validator_test.go
@@ -1,0 +1,737 @@
+package validator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/schema"
+)
+
+type TestStruct struct {
+	Name     string       `json:"name"  schema:"name"  validate:"required,min=1,max=8"`
+	Email    string       `json:"email" schema:"email" validate:"required,email,max=256"`
+	Age      int          `json:"age"   schema:"age"   validate:"required,gte=18"`
+	JoinedAt FlexibleTime `json:"joined_at" schema:"joined_at" validate:"required"`
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+	refTimeStr := "2023-01-15T10:30:00Z"
+	refTime, _ := time.Parse(time.RFC3339, refTimeStr)
+	type args struct {
+		Name     string       `json:"name"`
+		Email    string       `json:"email"`
+		Age      int          `json:"age"`
+		JoinedAt FlexibleTime `json:"joined_at"`
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    TestStruct
+	}{
+		{
+			name: "Valid input",
+			args: args{
+				Name:     "John Doe",
+				Email:    "john@example.com",
+				Age:      25,
+				JoinedAt: FlexibleTime(refTime),
+			},
+			wantErr: false,
+			want: TestStruct{
+				Name:     "John Doe",
+				Email:    "john@example.com",
+				Age:      25,
+				JoinedAt: FlexibleTime(refTime),
+			},
+		},
+		{
+			name: "Missing name",
+			args: args{
+				Name:  "",
+				Email: "john@example.com",
+				Age:   25,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid email",
+			args: args{
+				Name:  "John Doe",
+				Email: "invalid-email",
+				Age:   25,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Age below minimum",
+			args: args{
+				Name:  "John Doe",
+				Email: "john@example.com",
+				Age:   8,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			jsonData, err := json.Marshal(tt.args)
+			if err != nil {
+				t.Errorf("cound not marshal json: %v", err)
+				return
+			}
+			got, err := Validate[TestStruct](bytes.NewReader(jsonData))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			gotTime := got.JoinedAt.Time()
+			wantTime := tt.args.JoinedAt.Time()
+
+			if !gotTime.Equal(wantTime) {
+				t.Errorf("ValidateQuery() got JoinedAt = %v, want %v", gotTime, wantTime)
+			}
+			if got.Age != tt.want.Age {
+				t.Errorf("ValidateQuery() got Age = %d, want %d", got.Age, tt.want.Age)
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("ValidateQuery() got Name = %s, want %s", got.Name, tt.want.Name)
+			}
+			if got.Email != tt.want.Email {
+				t.Errorf("ValidateQuery() got Email = %s, want %s", got.Email, tt.want.Email)
+			}
+			t.Logf("Validate() = %+v", got)
+			t.Logf("Validate() error = %v", err)
+		})
+	}
+}
+
+func TestValidate_JSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "Valid json",
+			input:   `{"name": "John Doe", "email": "john@example.com", "age":25}`,
+			wantErr: false,
+		},
+		{
+			name:    "Invalid json",
+			input:   `{"name": "John Doe", "email": "john@example.com", "age":}`,
+			wantErr: true,
+		},
+		{
+			name:    "Empty json",
+			input:   `{}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Validate[TestStruct](bytes.NewReader([]byte(tt.input)))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateQuery(t *testing.T) {
+	t.Parallel()
+	refTimeStr := "2023-01-15T10:30:00Z"
+	refTime, _ := time.Parse(time.RFC3339, refTimeStr)
+	refTimeUnix := refTime.Unix()
+	type ts struct {
+		Name     string       `schema:"name" validate:"required"`
+		Email    string       `schema:"email" validate:"required,email"`
+		Age      int          `schema:"age" validate:"required,gte=18"`
+		JoinedAt FlexibleTime `schema:"joined_at" validate:"required"`
+	}
+	tests := []struct {
+		name    string
+		query   url.Values
+		want    ts
+		wantErr bool
+	}{
+		{
+			name: "Valid input with rfc time",
+			query: func() url.Values {
+				q := make(url.Values)
+				q.Set("name", "John")
+				q.Set("email", "john@example.com")
+				q.Set("age", "25")
+				q.Set("joined_at", refTimeStr)
+				return q
+			}(),
+			wantErr: false,
+			want: ts{
+				Name:     "John",
+				Email:    "john@example.com",
+				Age:      25,
+				JoinedAt: FlexibleTime(refTime),
+			},
+		},
+		{
+			name: "Valid input with timestamp",
+			query: func() url.Values {
+				q := make(url.Values)
+				q.Set("name", "Jane")
+				q.Set("email", "jane@example.com")
+				q.Set("age", "30")
+				q.Set("joined_at", strconv.FormatInt(refTimeUnix, 10))
+				return q
+			}(),
+			wantErr: false,
+			want: ts{
+				Name:     "Jane",
+				Email:    "jane@example.com",
+				Age:      30,
+				JoinedAt: FlexibleTime(refTime),
+			},
+		},
+		{
+			name: "Invalid time format",
+			query: func() url.Values {
+				q := make(url.Values)
+				q.Set("name", "Bob")
+				q.Set("email", "bob@example.com")
+				q.Set("age", "35")
+				q.Set("joined_at", "not-a-time-value")
+				return q
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "Missing name",
+			query: func() url.Values {
+				q := make(url.Values)
+				q.Set("email", "john@example.com")
+				q.Set("age", "25")
+				q.Set("joined_at", refTimeStr)
+				return q
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "Invalid email",
+			query: func() url.Values {
+				q := make(url.Values)
+				q.Set("name", "John")
+				q.Set("email", "invalid-email")
+				q.Set("age", "25")
+				q.Set("joined_at", refTimeStr)
+				return q
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "Age below minimum",
+			query: func() url.Values {
+				q := make(url.Values)
+				q.Set("name", "John")
+				q.Set("email", "john@example.com")
+				q.Set("age", "10")
+				q.Set("joined_at", refTimeStr)
+				return q
+			}(),
+			wantErr: true,
+		},
+		{
+			name:    "Missing all fields",
+			query:   make(url.Values),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateQuery[ts](tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateQuery() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotTime := got.JoinedAt.Time()
+			wantTime := tt.want.JoinedAt.Time()
+
+			if !gotTime.Equal(wantTime) {
+				t.Errorf("ValidateQuery() got JoinedAt = %v, want %v", gotTime, wantTime)
+			}
+			if got.Age != tt.want.Age {
+				t.Errorf("ValidateQuery() got Age = %d, want %d", got.Age, tt.want.Age)
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("ValidateQuery() got Name = %s, want %s", got.Name, tt.want.Name)
+			}
+			if got.Email != tt.want.Email {
+				t.Errorf("ValidateQuery() got Email = %s, want %s", got.Email, tt.want.Email)
+			}
+
+			t.Logf("ValidateQuery() = %+v", got)
+			t.Logf("ValidateQuery() error = %v", err)
+		})
+	}
+}
+
+func TestValidateBody(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    TestStruct
+		want    TestStruct
+		wantErr bool
+	}{
+		{
+			name: "Valid input",
+			args: TestStruct{
+				Name:  "John Doe",
+				Email: "john@example.com",
+				Age:   25,
+			},
+			want: TestStruct{
+				Name:  "John Doe",
+				Email: "john@example.com",
+				Age:   25,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing name",
+			args: TestStruct{
+				Name:  "",
+				Email: "john@example.com",
+				Age:   25,
+			},
+			want:    TestStruct{},
+			wantErr: true,
+		},
+		{
+			name: "Invalid email",
+			args: TestStruct{
+				Name:  "John Doe",
+				Email: "invalid-email",
+				Age:   25,
+			},
+			want:    TestStruct{},
+			wantErr: true,
+		},
+		{
+			name: "Age below minimum",
+			args: TestStruct{
+				Name:  "John Doe",
+				Email: "john@example.com",
+				Age:   8,
+			},
+			want:    TestStruct{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			jsonData, err := json.Marshal(tt.args)
+			if err != nil {
+				t.Fatalf("could not marshal json: %v", err)
+			}
+			req := &http.Request{
+				Body: io.NopCloser(bytes.NewReader(jsonData)),
+			}
+			got, err := ValidateBody[TestStruct](req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateFromRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateFromRequest() = %v, want %v", got, tt.want)
+			}
+			// Ensure body can still be read and matches the original
+			bodyAfter, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Errorf("could not read reset request body: %v", err)
+			}
+			if !bytes.Equal(bodyAfter, jsonData) {
+				t.Errorf("request body not properly reset, got %s, want %s", string(bodyAfter), string(jsonData))
+			}
+		})
+	}
+}
+
+func TestValidateRequest(t *testing.T) {
+	t.Parallel()
+	// Define a reference time for testing
+	refTimeStr := "2023-01-15T10:30:00Z"
+	refTime, _ := time.Parse(time.RFC3339, refTimeStr)
+	refTimeUnix := refTime.Unix()
+	type TestParams struct {
+		Name     string       `schema:"name" validate:"required"`
+		Email    string       `schema:"email" validate:"required,email"`
+		Age      int          `schema:"age" validate:"required,gte=18"`
+		JoinedAt FlexibleTime `schema:"joined_at" validate:"required"`
+	}
+	tests := []struct {
+		name    string
+		setup   func() *http.Request
+		want    TestParams
+		wantErr bool
+	}{
+		{
+			name: "GET with valid parameters",
+			setup: func() *http.Request {
+				// URL with query parameters
+				url := "http://example.com/api?name=John&email=john@example.com&age=25&joined_at=" + refTimeStr
+
+				req, _ := http.NewRequest(http.MethodGet, url, nil)
+				return req
+			},
+			want: TestParams{
+				Name:     "John",
+				Email:    "john@example.com",
+				Age:      25,
+				JoinedAt: FlexibleTime(refTime),
+			},
+			wantErr: false,
+		},
+		{
+			name: "GET with timestamp for time",
+			setup: func() *http.Request {
+				// URL with query parameters, using timestamp for joined_at
+				url := "http://example.com/api?name=Jane&email=jane@example.com&age=30&joined_at=" + fmt.Sprintf("%d", refTimeUnix)
+
+				req, _ := http.NewRequest(http.MethodGet, url, nil)
+				return req
+			},
+			want: TestParams{
+				Name:     "Jane",
+				Email:    "jane@example.com",
+				Age:      30,
+				JoinedAt: FlexibleTime(refTime),
+			},
+			wantErr: false,
+		},
+		{
+			name: "POST with form encoded data only",
+			setup: func() *http.Request {
+				// Form data only
+				formData := url.Values{}
+				formData.Set("name", "Bob")
+				formData.Set("email", "bob@example.com")
+				formData.Set("age", "40")
+				formData.Set("joined_at", refTimeStr)
+
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"http://example.com/api",
+					strings.NewReader(formData.Encode()),
+				)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+			want: TestParams{
+				Name:     "Bob",
+				Email:    "bob@example.com",
+				Age:      40,
+				JoinedAt: FlexibleTime(refTime),
+			},
+			wantErr: false,
+		},
+		{
+			name: "POST with combined query and form parameters",
+			setup: func() *http.Request {
+				// URL with query parameters
+				reqUrl := "http://example.com/api?name=Alice&age=35"
+				formData := url.Values{}
+				formData.Set("email", "alice@example.com")
+				formData.Set("joined_at", refTimeStr)
+
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					reqUrl,
+					strings.NewReader(formData.Encode()),
+				)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+			want: TestParams{
+				Name:     "Alice",
+				Email:    "alice@example.com",
+				Age:      35,
+				JoinedAt: FlexibleTime(refTime),
+			},
+			wantErr: false,
+		},
+		{
+			name: "GET with missing required field",
+			setup: func() *http.Request {
+				// URL missing the required name field
+				url := "http://example.com/api?email=missing@example.com&age=25"
+
+				req, _ := http.NewRequest(http.MethodGet, url, nil)
+				return req
+			},
+			want:    TestParams{},
+			wantErr: true,
+		},
+		{
+			name: "POST with invalid email",
+			setup: func() *http.Request {
+				// Form data with invalid email
+				formData := url.Values{}
+				formData.Set("name", "Jane")
+				formData.Set("email", "not-an-email")
+				formData.Set("age", "25")
+
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"http://example.com/api",
+					strings.NewReader(formData.Encode()),
+				)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+			want:    TestParams{},
+			wantErr: true,
+		},
+		{
+			name: "POST with invalid age",
+			setup: func() *http.Request {
+				// Form data with invalid age (too young)
+				formData := url.Values{}
+				formData.Set("name", "Young")
+				formData.Set("email", "young@example.com")
+				formData.Set("age", "17") // Under 18, validation should fail
+
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					"http://example.com/api",
+					strings.NewReader(formData.Encode()),
+				)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+			want:    TestParams{},
+			wantErr: true,
+		},
+		{
+			name: "GET with invalid time format",
+			setup: func() *http.Request {
+				// URL with invalid time format
+				url := "http://example.com/api?name=TimeError&email=time@example.com&age=25&joined_at=not-a-time"
+
+				req, _ := http.NewRequest(http.MethodGet, url, nil)
+				return req
+			},
+			want:    TestParams{},
+			wantErr: true,
+		},
+		{
+			name: "POST with invalid content type",
+			setup: func() *http.Request {
+				// URL with query parameters
+				reqUrl := "http://example.com/api?name=ContentType&email=content@example.com&age=30"
+
+				// Form data that won't be parsed due to wrong content type
+				formData := url.Values{}
+				formData.Set("joined_at", refTimeStr)
+
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					reqUrl,
+					strings.NewReader(formData.Encode()),
+				)
+				req.Header.Set("Content-Type", "text/plain") // Not application/x-www-form-urlencoded
+				return req
+			},
+			want: TestParams{
+				Name:  "ContentType",
+				Email: "content@example.com",
+				Age:   30,
+				// JoinedAt will be zero since form wasn't parsed
+			},
+			wantErr: false,
+		},
+		{
+			name: "POST with combined parameters and override",
+			setup: func() *http.Request {
+				// URL with all parameters
+				reqUrl := "http://example.com/api?name=OriginalName&email=original@example.com&age=50&joined_at=" + fmt.Sprintf("%d", refTimeUnix)
+				// Form data that will override all parameters
+				formData := url.Values{}
+				formData.Set("name", "OverrideName")
+				formData.Set("email", "override@example.com")
+				formData.Set("age", "45")
+				formData.Set("joined_at", refTimeStr)
+
+				req, _ := http.NewRequest(
+					http.MethodPost,
+					reqUrl,
+					strings.NewReader(formData.Encode()),
+				)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+			want: TestParams{
+				Name:     "OverrideName",
+				Email:    "override@example.com",
+				Age:      45,
+				JoinedAt: FlexibleTime(refTime),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := tt.setup()
+			got, err := ValidateRequest[TestParams](req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// Compare results
+			if got.Name != tt.want.Name {
+				t.Errorf("ValidateRequest() Name got = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.Email != tt.want.Email {
+				t.Errorf("ValidateRequest() Email got = %v, want %v", got.Email, tt.want.Email)
+			}
+			if got.Age != tt.want.Age {
+				t.Errorf("ValidateRequest() Age got = %v, want %v", got.Age, tt.want.Age)
+			}
+			// For time fields, check if times are equal within a small tolerance
+			gotTime := got.JoinedAt.Time()
+			wantTime := tt.want.JoinedAt.Time()
+			if !gotTime.Equal(wantTime) {
+				t.Errorf("ValidateRequest() JoinedAt got = %v, want %v", gotTime, wantTime)
+			}
+
+			t.Logf("ValidateRequest() = %+v", got)
+			t.Logf("ValidateRequest() error = %+v", err)
+		})
+	}
+}
+
+func TestValidateQuery_OptionalFields(t *testing.T) {
+	refTimeStr := "2023-01-15T10:30:00Z"
+	refTime, _ := time.Parse(time.RFC3339, refTimeStr)
+	refTimeUnix := refTime.Unix()
+	type ts struct {
+		Start FlexibleTime `schema:"start" flexdefault:"now-6h"`
+		End   FlexibleTime `schema:"end" flexdefault:"now"`
+	}
+	now := time.Now()
+	const tolerance = 2 * time.Second
+	tests := []struct {
+		name      string
+		values    url.Values
+		wantStart FlexibleTime
+		wantEnd   FlexibleTime
+		wantErr   bool
+	}{
+		{
+			name: "Both provided (RFC3339 and unix)",
+			values: func() url.Values {
+				v := make(url.Values)
+				v.Set("start", refTimeStr)
+				v.Set("end", strconv.FormatInt(refTimeUnix, 10))
+				return v
+			}(),
+			wantStart: FlexibleTime(refTime),
+			wantEnd:   FlexibleTime(refTime),
+			wantErr:   false,
+		},
+		{
+			name: "Only start provided",
+			values: func() url.Values {
+				v := make(url.Values)
+				v.Set("start", refTimeStr)
+				return v
+			}(),
+			wantStart: FlexibleTime(refTime),
+			wantEnd:   FlexibleTime(now), // will fill during test
+			wantErr:   false,
+		},
+		{
+			name: "Only end provided",
+			values: func() url.Values {
+				v := make(url.Values)
+				v.Set("end", strconv.FormatInt(refTimeUnix, 10))
+				return v
+			}(),
+			wantStart: FlexibleTime(now.Add(-6 * time.Hour)),
+			wantEnd:   FlexibleTime(refTime),
+			wantErr:   false,
+		},
+		{
+			name:      "Neither provided (defaults expected)",
+			values:    make(url.Values),
+			wantStart: FlexibleTime(now.Add(-6 * time.Hour)),
+			wantEnd:   FlexibleTime(now),
+			wantErr:   false,
+		},
+		{
+			name: "Invalid end format",
+			values: func() url.Values {
+				v := make(url.Values)
+				v.Set("end", "not-a-time")
+				return v
+			}(),
+			wantStart: FlexibleTime{},
+			wantEnd:   FlexibleTime{},
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateQuery[ts](tt.values)
+			t.Logf("ValidateQuery() = %+v", got)
+			t.Logf("ValidateQuery() error = %v", err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateQuery() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotStart := got.Start.Time()
+			gotEnd := got.End.Time()
+			if !timeAlmostEqual(gotStart, tt.wantStart.Time(), tolerance) {
+				t.Errorf("Start mismatch: got %v, want %v", gotStart, tt.wantStart.Time())
+			}
+			if !timeAlmostEqual(gotEnd, tt.wantEnd.Time(), tolerance) {
+				t.Errorf("End mismatch: got %v, want %v", gotEnd, tt.wantEnd.Time())
+			}
+		})
+	}
+}
+
+func timeAlmostEqual(a, b time.Time, tolerance time.Duration) bool {
+	diff := a.Sub(b)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= tolerance
+}
+
+func TestDecoderFormPrecedence(t *testing.T) {
+	decoder := schema.NewDecoder()
+	data := url.Values{}
+	data["name"] = []string{"post", "query"}
+	var s struct{ Name string }
+	// decore
+	if err := decoder.Decode(&s, data); err != nil {
+		panic(err)
+	}
+	if s.Name != "query" {
+		t.Errorf("expected name to be 'query', got '%s'", s.Name)
+	}
+	t.Logf("Decoded struct: %+v", s)
+}


### PR DESCRIPTION
This pull request refactors the request validation process in the `reader/controller` package by introducing a new `validator` package. The changes simplify validation logic, improve code readability, and enhance flexibility in handling time formats. Key updates include the addition of a custom `FlexibleTime` type, the removal of redundant parsing logic, and the adoption of a centralized validation utility.

### Validation Refactor and Simplification:
- **Introduction of `validator` package**: Added a new `validator` package that provides utilities for validating and decoding JSON, query parameters, and form data into strongly typed structs. It leverages the `go-playground/validator` library for validation. (`shared/validator/validator.go`, `[shared/validator/validator.goR1-R175](diffhunk://#diff-bd091221028b1932f2c87fd522c4ad9de029dad61ec490a94ad0f8ab8ac23ba2R1-R175)`)
- **Custom `FlexibleTime` type**: Implemented the `FlexibleTime` type to handle time parsing from either Unix timestamps or RFC3339 strings, with support for JSON and schema decoding. (`shared/validator/timeparser.go`, `[shared/validator/timeparser.goR1-R84](diffhunk://#diff-dc9ea357b1cbc71384bbfce57d4ded6929e94bb71fad789eddc52dde7e070b92R1-R84)`)

### Codebase Cleanup:
- **Removal of `parseQueryInstantProps`**: Eliminated the custom parsing logic for `queryInstantProps` in favor of the new `ValidateRequest` utility. (`reader/controller/prom_query_instant.go`, `[reader/controller/prom_query_instant.goL48-L79](diffhunk://#diff-684294b3d259983f37f52721e0c3be8506a0a05b43c10d82e10b291e18c0d484L48-L79)`)
- **Refactored `QueryInstant` method**: Updated the `QueryInstant` method to use the `queryRequest` struct and the `validator.ValidateRequest` function for request validation. (`reader/controller/prom_query_instant.go`, `[reader/controller/prom_query_instant.goR19-R36](diffhunk://#diff-684294b3d259983f37f52721e0c3be8506a0a05b43c10d82e10b291e18c0d484R19-R36)`)

### Dependency Updates:
- **Added `go-playground/validator`**: Included the `go-playground/validator` library in `go.mod` to enable validation capabilities. (`go.mod`, `[go.modR39](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R39)`)