### PR TITLE
Fix/empty label values v2

### DIFF
--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -142,6 +142,11 @@ func portCHEnv(cfg *clconfig.ClokiConfig) error {
 		cfg.Setting.DATABASE_DATA[0].StoragePolicy = os.Getenv("STORAGE_POLICY")
 	}
 
+	cfg.Setting.ClokiReader.OmitEmptyValues, err = boolEnv("ADVANCED_OMIT_EMPTY_VALUES")
+	if err != nil {
+		return fmt.Errorf("invalid ADVANCED_OMIT_EMPTY_VALUES value: %w", err)
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/m3db/prometheus_remote_client_golang v0.4.4
-	github.com/metrico/cloki-config v0.0.86
+	github.com/metrico/cloki-config v0.0.88
 	github.com/mochi-co/mqtt v1.3.2
 	github.com/openzipkin/zipkin-go v0.4.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,8 @@ github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
 github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
-github.com/metrico/cloki-config v0.0.86 h1:QCxYuk/303mRXSYAFsFSc55t8FM7+Ejk/pow2EwHvG4=
-github.com/metrico/cloki-config v0.0.86/go.mod h1:zjxnDFtbyI08jMKjy12sleeQZjbJM2Vpngf+8gwm/4I=
+github.com/metrico/cloki-config v0.0.88 h1:HPmup42uY+mszV+GNckVv+TtTmA/0lBL0qcmhTahlgM=
+github.com/metrico/cloki-config v0.0.88/go.mod h1:zjxnDFtbyI08jMKjy12sleeQZjbJM2Vpngf+8gwm/4I=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_stream_select.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_stream_select.go
@@ -35,6 +35,15 @@ func (s *StreamSelectPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, 
 	if s.Offset != nil {
 		from = from.Add(*s.Offset)
 	}
+	var emptyLabels []string
+	for i := len(s.LabelNames) - 1; i >= 0; i-- {
+		if s.Ops[i] == "=" && s.Values[i] == "" {
+			emptyLabels = append(emptyLabels, s.LabelNames[i])
+			s.LabelNames = append(s.LabelNames[:i], s.LabelNames[i+1:]...)
+			s.Ops = append(s.Ops[:i], s.Ops[i+1:]...)
+			s.Values = append(s.Values[:i], s.Values[i+1:]...)
+		}
+	}
 	clauses := make([]sql.SQLCondition, len(s.LabelNames))
 	for i, name := range s.LabelNames {
 		var valClause sql.SQLCondition
@@ -68,7 +77,42 @@ func (s *StreamSelectPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, 
 			sql.Or(clauses...)).
 		GroupBy(sql.NewRawObject("fingerprint")).
 		AndHaving(sql.Eq(&SqlBitSetAnd{clauses}, sql.NewIntVal((1<<len(clauses))-1)))
-	return fpRequest, nil
+	return s.processEmptyLabels(ctx, fpRequest, emptyLabels)
+}
+
+func (s *StreamSelectPlanner) processEmptyLabels(ctx *shared.PlannerContext,
+	req sql.ISelect, emptyLabels []string) (sql.ISelect, error) {
+	if len(emptyLabels) == 0 {
+		return req, nil
+	}
+	var withFpPreRequest *sql.With
+	if len(s.LabelNames) > 0 {
+		withFpPreRequest = sql.NewWith(req, "fp_pre_req")
+	}
+	var emptyClauses []sql.SQLCondition
+	for _, label := range emptyLabels {
+		_l := label
+		c := sql.Eq(sql.NewCustomCol(func(ctx *sql.Ctx, options ...int) (string, error) {
+			strL, err := sql.NewStringVal(_l).String(ctx, options...)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("simpleJSONHas(labels, %s)", strL), nil
+		}), sql.NewIntVal(0))
+		emptyClauses = append(emptyClauses, c)
+	}
+	res := sql.NewSelect().
+		Select(sql.NewSimpleCol("fingerprint", "fingerprint")).
+		From(sql.NewRawObject(ctx.TimeSeriesTableName)).
+		AndWhere(
+			sql.Ge(sql.NewRawObject("date"), sql.NewStringVal(FormatFromDate(ctx.From))),
+			sql.And(emptyClauses...))
+	if len(s.LabelNames) > 0 {
+		res = res.
+			With(withFpPreRequest).
+			AndWhere(sql.NewIn(sql.NewRawObject("fingerprint"), sql.NewWithRef(withFpPreRequest)))
+	}
+	return res, nil
 }
 
 type SqlBitSetAnd struct {

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_stream_select.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_stream_select.go
@@ -2,6 +2,7 @@ package clickhouse_planner
 
 import (
 	"fmt"
+	"github.com/metrico/qryn/writer/config"
 	"strings"
 	"time"
 
@@ -37,6 +38,9 @@ func (s *StreamSelectPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, 
 	}
 	var emptyLabels []string
 	for i := len(s.LabelNames) - 1; i >= 0; i-- {
+		if !config.Cloki.Setting.ClokiReader.OmitEmptyValues {
+			break
+		}
 		if s.Ops[i] == "=" && s.Values[i] == "" {
 			emptyLabels = append(emptyLabels, s.LabelNames[i])
 			s.LabelNames = append(s.LabelNames[:i], s.LabelNames[i+1:]...)


### PR DESCRIPTION
For #716 

## Breaking changes

The way gigapipe treats expressions like `{a=""}` is changed.
Please use `ADVANCED_OMIT_EMPTY_VALUES=y` to fallback