### PR TITLE
fix: correct ALTER TABLE in ClickHouse

### DIFF
--- a/ctrl/qryn/sql/log.sql
+++ b/ctrl/qryn/sql/log.sql
@@ -160,16 +160,16 @@ GROUP BY fingerprint, timestamp_ns, type;
 DROP TABLE IF EXISTS {{.DB}}.metrics_15s_mv_bak {{.OnCluster}};
 
 ALTER TABLE time_series
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 ALTER TABLE time_series_gin
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 ALTER TABLE samples_v3
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 ALTER TABLE metrics_15s
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 CREATE TABLE IF NOT EXISTS {{.DB}}.patterns {{.OnCluster}}(
     timestamp_10m UInt32,

--- a/ctrl/qryn/sql/log_dist.sql
+++ b/ctrl/qryn/sql/log_dist.sql
@@ -53,16 +53,16 @@ ALTER TABLE {{.DB}}.time_series_dist {{.OnCluster}} ADD COLUMN IF NOT EXISTS `ty
 ALTER TABLE {{.DB}}.time_series_gin_dist {{.OnCluster}} ADD COLUMN IF NOT EXISTS `type` UInt8;
 
 ALTER TABLE time_series_dist
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 ALTER TABLE time_series_gin_dist
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 ALTER TABLE samples_v3_dist
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 ALTER TABLE metrics_15s_dist
-    (ADD COLUMN `type_v2` UInt8 ALIAS type);
+    ADD COLUMN `type_v2` UInt8 ALIAS type;
 
 CREATE TABLE IF NOT EXISTS {{.DB}}.patterns_dist {{.OnCluster}}(
     timestamp_10m UInt32,


### PR DESCRIPTION
These changes will resolve the following error:
```
time="2025-10-14T11:18:42Z" level=info msg="Creating database: CREATE DATABASE IF NOT EXISTS `gigapipe`  "
time="2025-10-14T11:18:42Z" level=info msg="CREATE DATABASE gigapipe\nENGINE = Atomic"
time="2025-10-14T11:18:42Z" level=info msg="Upgrading 10.220.1.10:9000/gigapipe"
time="2025-10-14T11:18:42Z" level=info msg="Upgrade v.24 to v.25 "
time="2025-10-14T11:18:42Z" level=error msg="ALTER TABLE time_series\n    (ADD COLUMN `type_v2` UInt8 ALIAS type)"
time="2025-10-14T11:18:42Z" level=error msg="ALTER TABLE time_series\n    (ADD COLUMN `type_v2` UInt8 ALIAS type)"
panic: code: 62, message: Syntax error: failed at position 29 ('(') (line 2, col 5): (ADD COLUMN `type_v2` UInt8 ALIAS type). Expected one of: ON, a list of ALTER commands, ALTER command, ADD COLUMN, RENAME COLUMN, MATERIALIZE COLUMN, DROP PARTITION, DROP PART, DROP DETACHED PARTITION, DROP DETACHED PART, DROP COLUMN, CLEAR COLUMN, ADD INDEX, DROP INDEX, CLEAR INDEX, MATERIALIZE INDEX, ADD PROJECTION, DROP PROJECTION, CLEAR PROJECTION, MATERIALIZE PROJECTION, MOVE PART, MOVE PARTITION, ADD CONSTRAINT, DROP CONSTRAINT, DETACH PARTITION, DETACH PART, ATTACH PARTITION, REPLACE PARTITION, ATTACH PART, FETCH PARTITION, FETCH PART, FREEZE, UNFREEZE, MODIFY COLUMN, ALTER COLUMN, MODIFY ORDER BY, MODIFY SAMPLE BY, REMOVE SAMPLE BY, DELETE, UPDATE, COMMENT COLUMN, MODIFY TTL, REMOVE TTL, MATERIALIZE TTL, MODIFY SETTING, RESET SETTING, MODIFY QUERY, MODIFY COMMENT

goroutine 1 [running]:
main.initDB(0xc000780c30)
	/src/cmd/gigapipe/main.go:68 +0x85
main.main()
	/src/cmd/gigapipe/main.go:271 +0x11a
```