### PR TITLE
feat: update live-tail reliability, add index/stats endpoint

### DIFF
--- a/reader/controller/query_range.go
+++ b/reader/controller/query_range.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	tailDefaultLimit uint64 = 100  // lines returned when no ?limit= is supplied
-	tailMaxLimit     uint64 = 5000 // hard cap to prevent excessive memory use
+	tailDefaultLimit int64 = 100  // lines returned when no ?limit= is supplied
+	tailMaxLimit     int64 = 5000 // hard cap to prevent excessive memory use
 )
 
 type QueryRangeController struct {
@@ -170,7 +170,7 @@ func (q *QueryRangeController) Tail(w http.ResponseWriter, r *http.Request) {
 
 	tailLimit := tailDefaultLimit
 	if _tl := r.URL.Query().Get("limit"); _tl != "" {
-		if parsed, parseErr := strconv.ParseUint(_tl, 10, 64); parseErr == nil && parsed > 0 {
+		if parsed, parseErr := strconv.ParseInt(_tl, 10, 64); parseErr == nil && parsed > 0 {
 			tailLimit = parsed
 		}
 	}

--- a/reader/controller/query_range.go
+++ b/reader/controller/query_range.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -11,6 +12,11 @@ import (
 	"github.com/metrico/qryn/v4/reader/model"
 	"github.com/metrico/qryn/v4/reader/service"
 	"github.com/metrico/qryn/v4/reader/utils/logger"
+)
+
+const (
+	tailDefaultLimit uint64 = 100  // lines returned when no ?limit= is supplied
+	tailMaxLimit     uint64 = 5000 // hard cap to prevent excessive memory use
 )
 
 type QueryRangeController struct {
@@ -145,6 +151,7 @@ func (q *QueryRangeController) Query(w http.ResponseWriter, r *http.Request) {
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
+	CheckOrigin:     func(r *http.Request) bool { return true },
 }
 
 func (q *QueryRangeController) Tail(w http.ResponseWriter, r *http.Request) {
@@ -157,14 +164,32 @@ func (q *QueryRangeController) Tail(w http.ResponseWriter, r *http.Request) {
 	}
 	query := r.URL.Query().Get("query")
 	if query == "" {
-		logger.Error("query parameter is required")
+		logger.Error("tail: query parameter is required")
 		return
 	}
-	defer cancel()
+
+	tailLimit := tailDefaultLimit
+	if _tl := r.URL.Query().Get("limit"); _tl != "" {
+		if parsed, parseErr := strconv.ParseUint(_tl, 10, 64); parseErr == nil && parsed > 0 {
+			tailLimit = parsed
+		}
+	}
+	if tailLimit > tailMaxLimit {
+		tailLimit = tailMaxLimit
+	}
+
+	var startNs int64
+	if _s := r.URL.Query().Get("start"); _s != "" {
+		if parsed, parseErr := strconv.ParseInt(_s, 10, 64); parseErr == nil && parsed > 0 {
+			startNs = parsed
+		}
+	}
+
 	var watcher model.IWatcher
-	watcher, err = q.QueryRangeService.Tail(internalCtx, query)
+	watcher, err = q.QueryRangeService.Tail(internalCtx, query, tailLimit, startNs)
 	if err != nil {
-		logger.Error(err)
+		logger.Error("tail: watcher create failed:", err)
+		cancel()
 		return
 	}
 	defer func() {
@@ -181,34 +206,80 @@ func (q *QueryRangeController) Tail(w http.ResponseWriter, r *http.Request) {
 	}
 	defer con.Close()
 	con.SetCloseHandler(func(code int, text string) error {
+		msg := websocket.FormatCloseMessage(code, "")
+		_ = con.WriteControl(websocket.CloseMessage, msg, time.Now().Add(time.Second))
 		watcher.Close()
 		cancel()
 		return nil
 	})
 	go func() {
-		_, _, err := con.ReadMessage()
-		for err == nil {
-			_, _, err = con.ReadMessage()
+		_, _, readErr := con.ReadMessage()
+		for readErr == nil {
+			_, _, readErr = con.ReadMessage()
 		}
+		watcher.Close()
+		cancel()
 	}()
-	pingTimer := time.NewTicker(time.Second)
-	defer pingTimer.Stop()
 	for {
 		select {
 		case <-watchCtx.Done():
 			return
-		case <-pingTimer.C:
-			err := con.WriteMessage(websocket.TextMessage, []byte(`{"streams":[]}`))
-			if err != nil {
-				logger.Error(err)
+		case str, ok := <-watcher.GetRes():
+			if !ok {
 				return
 			}
-		case str := <-watcher.GetRes():
-			err = con.WriteMessage(websocket.TextMessage, []byte(str.Str))
-			if err != nil {
-				logger.Error(err)
+			if str.Err != nil {
+				logger.Error("tail: ws stream error:", str.Err)
+				msg := websocket.FormatCloseMessage(websocket.CloseInternalServerErr, str.Err.Error())
+				_ = con.WriteControl(websocket.CloseMessage, msg, time.Now().Add(time.Second))
+				return
+			}
+			if err = con.WriteMessage(websocket.TextMessage, []byte(str.Str)); err != nil {
+				logger.Error("tail: data write failed:", err)
 				return
 			}
 		}
 	}
+}
+
+// IndexStats handles GET /loki/api/v1/index/stats.
+// Grafana Live tail calls this on activation to populate stream statistics.
+func (q *QueryRangeController) IndexStats(w http.ResponseWriter, r *http.Request) {
+	defer tamePanic(w, r)
+	internalCtx, err := RunPreRequestPlugins(r)
+	if err != nil {
+		PromError(500, err.Error(), w)
+		return
+	}
+
+	query := r.URL.Query().Get("query")
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+
+	var fromNs, toNs int64
+	if startStr != "" {
+		if parsed, parseErr := strconv.ParseInt(startStr, 10, 64); parseErr == nil {
+			fromNs = parsed
+		}
+	}
+	if endStr != "" {
+		if parsed, parseErr := strconv.ParseInt(endStr, 10, 64); parseErr == nil {
+			toNs = parsed
+		}
+	}
+	if toNs == 0 {
+		toNs = time.Now().UnixNano()
+	}
+	if fromNs == 0 {
+		fromNs = toNs - int64(time.Hour)
+	}
+
+	result, err := q.QueryRangeService.QueryIndexStats(internalCtx, query, fromNs, toNs)
+	if err != nil {
+		PromError(500, err.Error(), w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
 }

--- a/reader/model/services.go
+++ b/reader/model/services.go
@@ -33,7 +33,8 @@ type IQueryRangeService interface {
 		limit int64, forward bool) (chan QueryRangeOutput, error)
 	QueryInstant(ctx context.Context, query string, timeNs int64, stepMs int64,
 		limit int64) (chan QueryRangeOutput, error)
-	Tail(ctx context.Context, query string) (IWatcher, error)
+	Tail(ctx context.Context, query string, tailLimit uint64, startNs int64) (IWatcher, error)
+	QueryIndexStats(ctx context.Context, query string, fromNs, toNs int64) (*IndexStatsResult, error)
 }
 
 // Service : here you tell us what Salutation is

--- a/reader/model/services.go
+++ b/reader/model/services.go
@@ -33,7 +33,7 @@ type IQueryRangeService interface {
 		limit int64, forward bool) (chan QueryRangeOutput, error)
 	QueryInstant(ctx context.Context, query string, timeNs int64, stepMs int64,
 		limit int64) (chan QueryRangeOutput, error)
-	Tail(ctx context.Context, query string, tailLimit uint64, startNs int64) (IWatcher, error)
+	Tail(ctx context.Context, query string, tailLimit int64, startNs int64) (IWatcher, error)
 	QueryIndexStats(ctx context.Context, query string, fromNs, toNs int64) (*IndexStatsResult, error)
 }
 

--- a/reader/model/watcher.go
+++ b/reader/model/watcher.go
@@ -10,3 +10,11 @@ type IWatcher interface {
 	GetRes() chan QueryRangeOutput
 	Done() <-chan struct{}
 }
+
+// IndexStatsResult holds the response for GET /loki/api/v1/index/stats.
+type IndexStatsResult struct {
+	Streams int64 `json:"streams"`
+	Chunks  int64 `json:"chunks"`
+	Bytes   int64 `json:"bytes"`
+	Entries int64 `json:"entries"`
+}

--- a/reader/plugins/service_plugins.go
+++ b/reader/plugins/service_plugins.go
@@ -42,7 +42,7 @@ func GetQueryLabelsServicePlugin() *QueryLabelsServicePlugin {
 
 type QueryRangeServicePlugin interface {
 	SetServiceData(data *model.ServiceData)
-	Tail(ctx context.Context, query string) (model.IWatcher, error)
+	Tail(ctx context.Context, query string, tailLimit uint64, startNs int64) (model.IWatcher, error)
 }
 
 var queryRangeServicePlugin *QueryRangeServicePlugin

--- a/reader/plugins/service_plugins.go
+++ b/reader/plugins/service_plugins.go
@@ -42,7 +42,7 @@ func GetQueryLabelsServicePlugin() *QueryLabelsServicePlugin {
 
 type QueryRangeServicePlugin interface {
 	SetServiceData(data *model.ServiceData)
-	Tail(ctx context.Context, query string, tailLimit uint64, startNs int64) (model.IWatcher, error)
+	Tail(ctx context.Context, query string, tailLimit int64, startNs int64) (model.IWatcher, error)
 }
 
 var queryRangeServicePlugin *QueryRangeServicePlugin

--- a/reader/router/query_range.go
+++ b/reader/router/query_range.go
@@ -20,6 +20,7 @@ func RouteQueryRangeApis(app *mux.Router, dataSession model.IDBRegistry) {
 	app.HandleFunc("/loki/api/v1/query_range", qrCtrl.QueryRange).Methods("GET", "OPTIONS")
 	app.HandleFunc("/loki/api/v1/query", qrCtrl.Query).Methods("GET", "OPTIONS")
 	app.HandleFunc("/loki/api/v1/tail", qrCtrl.Tail).Methods("GET", "OPTIONS")
+	app.HandleFunc("/loki/api/v1/index/stats", qrCtrl.IndexStats).Methods("GET", "OPTIONS")
 
 	if config.Cloki.Setting.DRILLDOWN_SETTINGS.LogDrilldown {
 		vCtrl := &controllerv1.VolumeController{

--- a/reader/service/query_range.go
+++ b/reader/service/query_range.go
@@ -667,7 +667,7 @@ func (q *QueryRangeService) QueryInstant(ctx context.Context, query string, time
 	return res, nil
 }
 
-func (q *QueryRangeService) Tail(ctx context.Context, query string, tailLimit uint64, startNs int64) (model.IWatcher, error) {
+func (q *QueryRangeService) Tail(ctx context.Context, query string, tailLimit int64, startNs int64) (model.IWatcher, error) {
 	if q.plugin != nil {
 		return q.plugin.Tail(ctx, query, tailLimit, startNs)
 	}
@@ -715,8 +715,8 @@ func (q *QueryRangeService) Tail(ctx context.Context, query string, tailLimit ui
 			}
 
 			limit := int64(tailIncrementalLimit)
-			if tailLimit > 0 && tailLimit < uint64(limit) {
-				limit = int64(tailLimit)
+			if tailLimit > 0 && tailLimit < limit {
+				limit = tailLimit
 			}
 			out, err := sqlQuery[0].Process(tables.PopulateTableNames(&shared.PlannerContext{
 				IsCluster:  conn.Config.ClusterName != "",

--- a/reader/service/query_range.go
+++ b/reader/service/query_range.go
@@ -16,7 +16,7 @@ import (
 	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
 	"github.com/metrico/qryn/v4/reader/model"
 	"github.com/metrico/qryn/v4/reader/plugins"
-	"github.com/metrico/qryn/v4/reader/utils/dbVersion"
+	dbversion "github.com/metrico/qryn/v4/reader/utils/dbVersion"
 	"github.com/metrico/qryn/v4/reader/utils/logger"
 	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
 	"github.com/metrico/qryn/v4/reader/utils/tables"
@@ -54,7 +54,8 @@ func onErr(err error, res chan model.QueryRangeOutput) {
 }
 
 func (q *QueryRangeService) exportStreamsValue(out chan []shared.LogEntry,
-	res chan model.QueryRangeOutput) {
+	res chan model.QueryRangeOutput,
+) {
 	defer close(res)
 
 	json := jsoniter.ConfigFastest
@@ -163,7 +164,8 @@ type QueryVolumeResult struct {
 }
 
 func (q *QueryRangeService) QueryVolume(ctx context.Context, query string, fromNs int64, toNs int64,
-	stepMs int64, aggregateByLabels []string) ([]QueryVolumeResult, error) {
+	stepMs int64, aggregateByLabels []string,
+) ([]QueryVolumeResult, error) {
 	var err error
 	if len(aggregateByLabels) == 0 {
 		aggregateByLabels, err = q.getLabelsForVolume(query)
@@ -218,7 +220,8 @@ type QueryDetectedLabelsResult struct {
 }
 
 func (q *QueryRangeService) QueryDetectedLabels(ctx context.Context, query string, fromNs int64,
-	toNs int64) ([]QueryDetectedLabelsResult, error) {
+	toNs int64,
+) ([]QueryDetectedLabelsResult, error) {
 	conn, err := q.Session.GetDB(ctx)
 	if err != nil {
 		return nil, err
@@ -294,7 +297,8 @@ type PatternsResult struct {
 }
 
 func (q *QueryRangeService) QueryPatterns(ctx context.Context, query string, fromNs int64, toNs int64,
-	stepMs int64, limit int64) ([]PatternsResult, error) {
+	stepMs int64, limit int64,
+) ([]PatternsResult, error) {
 	conn, err := q.Session.GetDB(ctx)
 	if err != nil {
 		return nil, err
@@ -382,7 +386,8 @@ func (q *QueryRangeService) scan(rows *databaseSql.Rows) (PatternsResult, error)
 		for _, s := range samplesV1 {
 			res.Samples = append(res.Samples, [2]int32{
 				int32(s["timestamp_s"].(uint64)),
-				int32(s["count"].(uint64))})
+				int32(s["count"].(uint64)),
+			})
 		}
 		return res, nil
 	}
@@ -401,13 +406,15 @@ func (q *QueryRangeService) scan(rows *databaseSql.Rows) (PatternsResult, error)
 	for _, s := range samplesV2 {
 		res.Samples = append(res.Samples, [2]int32{
 			int32(s[0].(uint64)),
-			int32(s[1].(uint64))})
+			int32(s[1].(uint64)),
+		})
 	}
 	return res, nil
 }
 
 func (q *QueryRangeService) QueryRange(ctx context.Context, query string, fromNs int64, toNs int64, stepMs int64,
-	limit int64, forward bool) (chan model.QueryRangeOutput, error) {
+	limit int64, forward bool,
+) (chan model.QueryRangeOutput, error) {
 	out, isMatrix, err := q.prepareOutput(ctx, query, fromNs, toNs, stepMs, limit, forward)
 	if err != nil {
 		return nil, err
@@ -521,7 +528,8 @@ func (q *QueryRangeService) QueryRange(ctx context.Context, query string, fromNs
 }
 
 func (q *QueryRangeService) prepareOutput(ctx context.Context, query string, fromNs int64, toNs int64, stepMs int64,
-	limit int64, forward bool) (chan []shared.LogEntry, bool, error) {
+	limit int64, forward bool,
+) (chan []shared.LogEntry, bool, error) {
 	conn, err := q.Session.GetDB(ctx)
 	if err != nil {
 		return nil, false, err
@@ -557,8 +565,10 @@ func (q *QueryRangeService) prepareOutput(ctx context.Context, query string, fro
 	res, err := chain[0].Process(plannerCtx, nil)
 	return res, chain[0].IsMatrix(), err
 }
+
 func (q *QueryRangeService) QueryInstant(ctx context.Context, query string, timeNs int64, stepMs int64,
-	limit int64) (chan model.QueryRangeOutput, error) {
+	limit int64,
+) (chan model.QueryRangeOutput, error) {
 	out, isMatrix, err := q.prepareOutput(ctx, query, timeNs-300000000000, timeNs, stepMs, limit, false)
 	if err != nil {
 		return nil, err
@@ -705,7 +715,7 @@ func (q *QueryRangeService) Tail(ctx context.Context, query string, tailLimit ui
 			}
 
 			limit := int64(tailIncrementalLimit)
-			if tailLimit > 0 && int64(tailLimit) < limit {
+			if tailLimit > 0 && tailLimit < uint64(limit) {
 				limit = int64(tailLimit)
 			}
 			out, err := sqlQuery[0].Process(tables.PopulateTableNames(&shared.PlannerContext{

--- a/reader/service/query_range.go
+++ b/reader/service/query_range.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -19,6 +20,12 @@ import (
 	"github.com/metrico/qryn/v4/reader/utils/logger"
 	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
 	"github.com/metrico/qryn/v4/reader/utils/tables"
+)
+
+const (
+	tailPollInterval     = time.Second // how often new entries are fetched from ClickHouse
+	tailIncrementalLimit = 1000        // max entries per poll tick
+	tailWatcherBufSize   = 10          // channel buffer between poller and WebSocket handler
 )
 
 type QueryRangeService struct {
@@ -650,9 +657,9 @@ func (q *QueryRangeService) QueryInstant(ctx context.Context, query string, time
 	return res, nil
 }
 
-func (q *QueryRangeService) Tail(ctx context.Context, query string) (model.IWatcher, error) {
+func (q *QueryRangeService) Tail(ctx context.Context, query string, tailLimit uint64, startNs int64) (model.IWatcher, error) {
 	if q.plugin != nil {
-		return q.plugin.Tail(ctx, query)
+		return q.plugin.Tail(ctx, query, tailLimit, startNs)
 	}
 
 	conn, err := q.Session.GetDB(ctx)
@@ -664,14 +671,19 @@ func (q *QueryRangeService) Tail(ctx context.Context, query string) (model.IWatc
 		return nil, err
 	}
 
-	res := NewWatcher(make(chan model.QueryRangeOutput))
+	res := NewWatcher(make(chan model.QueryRangeOutput, tailWatcherBufSize))
 
-	from := time.Now().Add(time.Minute * -5)
+	var from time.Time
+	if startNs > 0 {
+		from = time.Unix(0, startNs)
+	} else {
+		from = time.Now().Add(-1 * time.Hour)
+	}
 
 	_ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
-		ticker := time.NewTicker(time.Second)
+		ticker := time.NewTicker(tailPollInterval)
 		defer cancel()
 		defer close(res.GetRes())
 		defer ticker.Stop()
@@ -692,12 +704,16 @@ func (q *QueryRangeService) Tail(ctx context.Context, query string) (model.IWatc
 			default:
 			}
 
+			limit := int64(tailIncrementalLimit)
+			if tailLimit > 0 && int64(tailLimit) < limit {
+				limit = int64(tailLimit)
+			}
 			out, err := sqlQuery[0].Process(tables.PopulateTableNames(&shared.PlannerContext{
 				IsCluster:  conn.Config.ClusterName != "",
 				From:       from,
 				To:         time.Now(),
 				OrderASC:   false,
-				Limit:      0,
+				Limit:      limit,
 				Ctx:        _ctx,
 				CHDb:       conn.Session,
 				CHFinalize: true,
@@ -763,6 +779,10 @@ func (q *QueryRangeService) Tail(ctx context.Context, query string) (model.IWatc
 				stream.WriteObjectEnd()
 			}
 			stream.WriteArrayEnd()
+			stream.WriteMore()
+			stream.WriteObjectField("dropped_entries")
+			stream.WriteArrayStart()
+			stream.WriteArrayEnd()
 			stream.WriteObjectEnd()
 			res.GetRes() <- model.QueryRangeOutput{Str: string(stream.Buffer())}
 			stream.Reset(nil)
@@ -771,10 +791,102 @@ func (q *QueryRangeService) Tail(ctx context.Context, query string) (model.IWatc
 	return res, nil
 }
 
+// QueryIndexStats returns stream statistics for GET /loki/api/v1/index/stats.
+// streams = distinct fingerprints, entries = total log lines, bytes = uncompressed volume,
+// chunks = distinct (stream, day) pairs (proxy for object-storage chunk count).
+func (q *QueryRangeService) QueryIndexStats(ctx context.Context, query string, fromNs, toNs int64) (*model.IndexStatsResult, error) {
+	conn, err := q.Session.GetDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	versionInfo, err := dbversion.GetVersionInfo(ctx, conn.Config.ClusterName != "", conn.Session)
+	if err != nil {
+		return nil, err
+	}
+
+	var script *logql_parser.LogQLScript
+	if query != "" {
+		script, err = logql_parser.Parse(query)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	_ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	plannerCtx := tables.PopulateTableNames(&shared.PlannerContext{
+		IsCluster:  conn.Config.ClusterName != "",
+		From:       time.Unix(0, fromNs),
+		To:         time.Unix(0, toNs),
+		Ctx:        _ctx,
+		CancelCtx:  cancel,
+		CHDb:       conn.Session,
+		CHFinalize: true,
+		CHSqlCtx: &sql.Ctx{
+			Params: map[string]sql.SQLObject{},
+			Result: map[string]sql.SQLObject{},
+		},
+		VersionInfo: versionInfo,
+	}, conn)
+
+	statsQuery := sql.NewSelect().
+		Select(
+			sql.NewRawObject("toInt64(uniqExact(fingerprint))"),
+			sql.NewRawObject("toInt64(COUNT(*))"),
+			sql.NewRawObject("toInt64(SUM(length(string)))"),
+			sql.NewRawObject("toInt64(uniqExact(fingerprint, toDate(toDateTime(intDiv(timestamp_ns, 1000000000)))))"),
+		).
+		From(sql.NewRawObject(plannerCtx.SamplesDistTableName)).
+		AndPreWhere(
+			sql.Ge(sql.NewRawObject("timestamp_ns"), sql.NewIntVal(fromNs)),
+			sql.Lt(sql.NewRawObject("timestamp_ns"), sql.NewIntVal(toNs)),
+			sql.NewIn(sql.NewRawObject("type_v2"), sql.NewIntVal(0), sql.NewIntVal(1)),
+		)
+
+	if script != nil && script.StrSelector != nil && len(script.StrSelector.StrSelCmds) > 0 {
+		fpPlanner, err := logql_transpiler.PlanFingerprints(script)
+		if err != nil {
+			return nil, err
+		}
+		fpSelect, err := fpPlanner.Process(plannerCtx)
+		if err != nil {
+			return nil, err
+		}
+		fpWith := sql.NewWith(fpSelect, "fp_sel")
+		statsQuery = statsQuery.
+			With(fpWith).
+			AndWhere(sql.NewIn(sql.NewRawObject("fingerprint"), sql.NewWithRef(fpWith)))
+	}
+
+	var opts []int
+	if plannerCtx.IsCluster {
+		opts = append(opts, sql.STRING_OPT_INLINE_WITH)
+	}
+	strQuery, err := statsQuery.String(plannerCtx.CHSqlCtx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := conn.Session.QueryCtx(_ctx, strQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result model.IndexStatsResult
+	if rows.Next() {
+		if err = rows.Scan(&result.Streams, &result.Entries, &result.Bytes, &result.Chunks); err != nil {
+			return nil, err
+		}
+	}
+	return &result, nil
+}
+
 type Watcher struct {
-	res    chan model.QueryRangeOutput
-	ctx    context.Context
-	cancel context.CancelFunc
+	res       chan model.QueryRangeOutput
+	ctx       context.Context
+	cancel    context.CancelFunc
+	closeOnce sync.Once
 }
 
 func NewWatcher(res chan model.QueryRangeOutput) model.IWatcher {
@@ -795,7 +907,7 @@ func (w *Watcher) GetRes() chan model.QueryRangeOutput {
 }
 
 func (w *Watcher) Close() {
-	w.cancel()
+	w.closeOnce.Do(w.cancel)
 }
 
 func writeMap(stream *jsoniter.Stream, m map[string]string) {


### PR DESCRIPTION
- Add GET /loki/api/v1/index/stats endpoint
- Add QueryIndexStats service method: queries ClickHouse for stream count, entry count, byte volume, and chunk count; supports LogQL stream selector
- Update Tail service: add tailLimit/startNs params, buffered watcher channel, tailPollInterval/tailIncrementalLimit/tailWatcherBufSize constants
- Add dropped_entries field to tail WebSocket responses
- Fix Tail controller: parse ?limit= and ?start=, fix goroutine leak in read pump, remove redundant ping timer, handle channel close and stream errors
- Fix WebSocket Upgrader: allow cross-origin connections (CheckOrigin)
- Add closeOnce to Watcher for idempotent Close() calls
- Add IndexStatsResult struct to model