### PR TITLE
fix: remove dead qryn_fingerprints table variable in writer init

### DIFF
--- a/writer/plugin/qryn_writer_db.go
+++ b/writer/plugin/qryn_writer_db.go
@@ -219,10 +219,6 @@ func (p *QrynWriterPlugin) CreateStaticServiceRegistry(config config.ClokiBaseSe
 		SplSvcs[node.Node].Init()
 		go SplSvcs[node.Node].Run()
 
-		table := "qryn_fingerprints"
-		if node.ClusterName != "" {
-			table += "_dist"
-		}
 	}
 
 	ServiceRegistry = registry.NewStaticServiceRegistry(registry.StaticServiceRegistryOpts{


### PR DESCRIPTION
## Summary

Removes a dead code block in writer plugin init: the `table` variable (set to `qryn_fingerprints` or `qryn_fingerprints_dist`) was computed but never used.

## Test plan
- [ ] Verify writer builds and initialises cleanly