### PR TITLE
fix: limit handling in /query_range (default + planner)

### DIFF
--- a/reader/controller/query_range.go
+++ b/reader/controller/query_range.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	tailDefaultLimit int64 = 100  // lines returned when no ?limit= is supplied
-	tailMaxLimit     int64 = 5000 // hard cap to prevent excessive memory use
+	tailDefaultLimit  int64 = 100  // lines returned when no ?limit= is supplied
+	tailMaxLimit      int64 = 5000 // hard cap to prevent excessive memory use
+	queryDefaultLimit int64 = 100  // matches Loki API default for /query and /query_range
 )
 
 type QueryRangeController struct {
@@ -45,7 +46,7 @@ func (q *QueryRangeController) QueryRange(w http.ResponseWriter, r *http.Request
 	//	direction = "backward"
 	//}
 	_limit := r.URL.Query().Get("limit")
-	limit := int64(0)
+	limit := queryDefaultLimit
 	if _limit != "" {
 		limit, _ = strconv.ParseInt(_limit, 10, 64)
 	}
@@ -131,7 +132,7 @@ func (q *QueryRangeController) Query(w http.ResponseWriter, r *http.Request) {
 
 	step, err := getRequiredDuration(r, "step", "1", err)
 	_limit := r.URL.Query().Get("limit")
-	limit := int64(100)
+	limit := queryDefaultLimit
 	if _limit != "" {
 		limit, _ = strconv.ParseInt(_limit, 10, 64)
 	}

--- a/reader/logql/logql_transpiler/internal/planner/limit.go
+++ b/reader/logql/logql_transpiler/internal/planner/limit.go
@@ -15,10 +15,10 @@ func (a *LimitPlanner) Process(ctx *shared.PlannerContext,
 			return nil
 		},
 		OnAfterEntriesSlice: func(entries []shared.LogEntry, c chan []shared.LogEntry) error {
-			if sent >= limit {
+			if limit > 0 && sent >= limit {
 				return nil
 			}
-			if sent+len(entries) < limit {
+			if limit == 0 || sent+len(entries) < limit {
 				c <- entries
 				sent += len(entries)
 				return nil

--- a/reader/logql/logql_transpiler/internal/planner/limit_test.go
+++ b/reader/logql/logql_transpiler/internal/planner/limit_test.go
@@ -1,0 +1,81 @@
+package planner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
+)
+
+type passthroughProcessor struct {
+	in chan []shared.LogEntry
+}
+
+func (p *passthroughProcessor) Process(_ *shared.PlannerContext, _ chan []shared.LogEntry) (chan []shared.LogEntry, error) {
+	return p.in, nil
+}
+
+func (p *passthroughProcessor) IsMatrix() bool { return false }
+
+func feedEntries(n int) chan []shared.LogEntry {
+	ch := make(chan []shared.LogEntry, 1)
+	go func() {
+		entries := make([]shared.LogEntry, n)
+		for i := range entries {
+			entries[i] = shared.LogEntry{TimestampNS: int64(i)}
+		}
+		ch <- entries
+		close(ch)
+	}()
+	return ch
+}
+
+func collectEntries(ch chan []shared.LogEntry) []shared.LogEntry {
+	var result []shared.LogEntry
+	for batch := range ch {
+		result = append(result, batch...)
+	}
+	return result
+}
+
+func TestLimitPlannerZeroMeansNoLimit(t *testing.T) {
+	ctx := &shared.PlannerContext{Limit: 0, Ctx: context.Background()}
+	in := feedEntries(500)
+	p := &LimitPlanner{GenericPlanner{&passthroughProcessor{in}}}
+	out, err := p.Process(ctx, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectEntries(out)
+	if len(got) != 500 {
+		t.Errorf("limit=0 should return all entries; got %d, want 500", len(got))
+	}
+}
+
+func TestLimitPlannerRespectsNonZeroLimit(t *testing.T) {
+	ctx := &shared.PlannerContext{Limit: 10, Ctx: context.Background()}
+	in := feedEntries(500)
+	p := &LimitPlanner{GenericPlanner{&passthroughProcessor{in}}}
+	out, err := p.Process(ctx, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectEntries(out)
+	if len(got) != 10 {
+		t.Errorf("limit=10 should return 10 entries; got %d", len(got))
+	}
+}
+
+func TestLimitPlannerLimitLargerThanInput(t *testing.T) {
+	ctx := &shared.PlannerContext{Limit: 1000, Ctx: context.Background()}
+	in := feedEntries(50)
+	p := &LimitPlanner{GenericPlanner{&passthroughProcessor{in}}}
+	out, err := p.Process(ctx, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collectEntries(out)
+	if len(got) != 50 {
+		t.Errorf("limit=1000 with 50 entries should return 50; got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary
Two related fixes for log query limit handling:

1. **Default `?limit=` to 100 in `/loki/api/v1/query_range`** — matches the Loki API spec. Previously defaulted to 0, which combined with the planner bug below produced empty results for clients that omit `limit`.

2. **`LimitPlanner` treats `limit=0` as "no limit"** — previously, when `ctx.Limit=0`, the in-memory planner returned zero entries because `sent >= limit` was true on the first iteration. This now matches the existing convention in `MainLimitPlanner` (SQL side), where `limit=0` means no LIMIT clause.

## Test plan
- [ ] `go test ./reader/logql/logql_transpiler/internal/planner/ -run TestLimitPlanner` — 3 new tests cover limit=0, limit<input, limit>input
- [ ] Manual: `curl ".../loki/api/v1/query_range?query={app=\"foo\"}&start=...&end=..."` (no limit param) returns up to 100 entries
- [ ] Manual: same query with `&limit=0` returns all entries (no cap)
