### PR TITLE
Enable @ modifier (#769)

### DIFF
--- a/reader/router/prometheus_query_range.go
+++ b/reader/router/prometheus_query_range.go
@@ -38,7 +38,7 @@ func NewPromEngine(maxSamples int) *promql.Engine {
 		NoStepSubqueryIntervalFn: func(int64) int64 {
 			return defaultSubqueryInterval.Milliseconds()
 		},
-		EnableAtModifier:     false,
+		EnableAtModifier:     true,
 		EnableNegativeOffset: false,
 	})
 }


### PR DESCRIPTION
#769 

Enablind `@` modifier for the metrics queries.