### PR TITLE
Support __line__ & __timestamp__ functions in Logql + add Keep label pipeline

### DIFF
--- a/reader/logql/logql_parser/.snapshots/TestParser
+++ b/reader/logql/logql_parser/.snapshots/TestParser
@@ -1,4 +1,4 @@
-([]*logql_parser.LogQLScript) (len=39) {
+([]*logql_parser.LogQLScript) (len=41) {
   (*logql_parser.LogQLScript)({test_id="${testID}"}),
   (*logql_parser.LogQLScript)({test_id="${testID}",freq="2"}),
   (*logql_parser.LogQLScript)({test_id="${testID}",freq="2"}|~ "2[0-9]$"),
@@ -37,5 +37,7 @@
   (*logql_parser.LogQLScript)({test_id="${testID}_json"}| json sid = "str_id" | sid >= 598 or sid < 2 and sid > 0),
   (*logql_parser.LogQLScript)({test_id="${testID}_json"}| json | str_id < 2 or str_id >= 598 and str_id > 0),
   (*logql_parser.LogQLScript)({test_id="${testID}_json"}| json | drop a,b,__C__,d="e"),
+  (*logql_parser.LogQLScript)({k8s_object_kind="Node",k8s_event_reason="ScaleDown",signoz_component="otel-deployment"}| keep k8s_object_kind),
+  (*logql_parser.LogQLScript)({test_id="${testID}_json"}| json | keep level,method="GET"),
   (*logql_parser.LogQLScript)(count_over_time ({test_id="${testID}_json"}[1m] offset 1m))
 }

--- a/reader/logql/logql_parser/.snapshots/TestParser
+++ b/reader/logql/logql_parser/.snapshots/TestParser
@@ -1,4 +1,4 @@
-([]*logql_parser.LogQLScript) (len=41) {
+([]*logql_parser.LogQLScript) (len=42) {
   (*logql_parser.LogQLScript)({test_id="${testID}"}),
   (*logql_parser.LogQLScript)({test_id="${testID}",freq="2"}),
   (*logql_parser.LogQLScript)({test_id="${testID}",freq="2"}|~ "2[0-9]$"),
@@ -39,5 +39,6 @@
   (*logql_parser.LogQLScript)({test_id="${testID}_json"}| json | drop a,b,__C__,d="e"),
   (*logql_parser.LogQLScript)({k8s_object_kind="Node",k8s_event_reason="ScaleDown",signoz_component="otel-deployment"}| keep k8s_object_kind),
   (*logql_parser.LogQLScript)({test_id="${testID}_json"}| json | keep level,method="GET"),
+  (*logql_parser.LogQLScript)({k8s_object_kind="Node"}| line_format `{{.k8s_object_name}} - {{__line__}}`),
   (*logql_parser.LogQLScript)(count_over_time ({test_id="${testID}_json"}[1m] offset 1m))
 }

--- a/reader/logql/logql_parser/model.go
+++ b/reader/logql/logql_parser/model.go
@@ -134,6 +134,7 @@ type StrSelectorPipeline struct {
 	LabelFormat *LabelFormat `| "|" @@ `
 	Unwrap      *Unwrap      `| "|" @@ `
 	Drop        *Drop        `| "|" @@ `
+	Keep        *Keep        `| "|" @@ `
 }
 
 func (s *StrSelectorPipeline) String() string {
@@ -161,7 +162,11 @@ func (s *StrSelectorPipeline) String() string {
 		return s.Unwrap.String()
 	}
 
-	return s.Drop.String()
+	if s.Drop != nil {
+		return s.Drop.String()
+	}
+
+	return s.Keep.String()
 }
 
 type LineFilter struct {
@@ -359,6 +364,34 @@ func (d *DropParam) String() string {
 	if d.Val != nil {
 		bld.WriteString("=")
 		bld.WriteString(d.Val.String())
+	}
+	return bld.String()
+}
+
+type Keep struct {
+	Fn     string      `@("keep")`
+	Params []KeepParam `@@? ("," @@)*`
+}
+
+func (k *Keep) String() string {
+	params := make([]string, len(k.Params))
+	for i, param := range k.Params {
+		params[i] = param.String()
+	}
+	return fmt.Sprintf("| %s %s", k.Fn, strings.Join(params, ","))
+}
+
+type KeepParam struct {
+	Label LabelName     `@@`
+	Val   *QuotedString `("=" @@)?`
+}
+
+func (k *KeepParam) String() string {
+	bld := strings.Builder{}
+	bld.WriteString(k.Label.String())
+	if k.Val != nil {
+		bld.WriteString("=")
+		bld.WriteString(k.Val.String())
 	}
 	return bld.String()
 }

--- a/reader/logql/logql_parser/parser.go
+++ b/reader/logql/logql_parser/parser.go
@@ -65,7 +65,7 @@ func FindFirst[T any](node any) *T {
 		return findFirstIn[T](children...)
 	case *StrSelectorPipeline:
 		return findFirstIn[T](_node.LineFilter, _node.LabelFilter,
-			_node.Parser, _node.LineFormat, _node.LabelFormat, _node.Unwrap, _node.Drop)
+			_node.Parser, _node.LineFormat, _node.LabelFormat, _node.Unwrap, _node.Drop, _node.Keep)
 	case *LabelFilter:
 		return findFirstIn[T](_node.Head, _node.Tail)
 	case *Head:
@@ -95,6 +95,14 @@ func FindFirst[T any](node any) *T {
 		}
 		return findFirstIn[T](children...)
 	case *DropParam:
+		return findFirstIn[T](_node.Val, &_node.Label)
+	case *Keep:
+		var children []any
+		for _, c := range _node.Params {
+			children = append(children, &c)
+		}
+		return findFirstIn[T](children...)
+	case *KeepParam:
 		return findFirstIn[T](_node.Val, &_node.Label)
 	case *LRAOrUnwrap:
 		return findFirstIn[T](&_node.StrSel, _node.ByOrWithoutPrefix, _node.ByOrWithoutSuffix)

--- a/reader/logql/logql_parser/parser_test.go
+++ b/reader/logql/logql_parser/parser_test.go
@@ -47,6 +47,8 @@ func TestParser(t *testing.T) {
 		"{test_id=\"${testID}_json\"} | json sid=\"str_id\" | sid >= 598 or sid < 2 and sid > 0",
 		"{test_id=\"${testID}_json\"} | json | str_id < 2 or str_id >= 598 and str_id > 0",
 		"{test_id=\"${testID}_json\"} | json | drop a, b, __C__, d=\"e\"",
+		"{k8s_object_kind=\"Node\", k8s_event_reason=\"ScaleDown\", signoz_component=\"otel-deployment\"} | keep k8s_object_kind",
+		"{test_id=\"${testID}_json\"} | json | keep level, method=\"GET\"",
 		"count_over_time({test_id=\"${testID}_json\"} [1m] offset 1m)",
 	}
 	asts := make([]*LogQLScript, len(tests))

--- a/reader/logql/logql_parser/parser_test.go
+++ b/reader/logql/logql_parser/parser_test.go
@@ -49,6 +49,7 @@ func TestParser(t *testing.T) {
 		"{test_id=\"${testID}_json\"} | json | drop a, b, __C__, d=\"e\"",
 		"{k8s_object_kind=\"Node\", k8s_event_reason=\"ScaleDown\", signoz_component=\"otel-deployment\"} | keep k8s_object_kind",
 		"{test_id=\"${testID}_json\"} | json | keep level, method=\"GET\"",
+		"{k8s_object_kind=\"Node\"} | line_format `{{.k8s_object_name}} - {{__line__}}`",
 		"count_over_time({test_id=\"${testID}_json\"} [1m] offset 1m)",
 	}
 	asts := make([]*LogQLScript, len(tests))

--- a/reader/logql/logql_transpiler/clickhouse_planner/analyze.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/analyze.go
@@ -50,6 +50,10 @@ func (p *planner) analyzeScript() {
 			p.labelsJoinIdx = i
 			break
 		}
+		if ppl.Keep != nil {
+			p.labelsJoinIdx = i
+			break
+		}
 	}
 
 	p.renewMainAfter = make([]bool, len(pipeline))
@@ -116,6 +120,9 @@ func AnalyzeMetrics15sShortcut(script *logql_parser.LogQLScript) bool {
 			return false
 		}
 		if ppl.Drop != nil {
+			return false
+		}
+		if ppl.Keep != nil {
 			return false
 		}
 		if ppl.LineFilter != nil && lineFilterHasContent(ppl.LineFilter) {
@@ -259,6 +266,7 @@ func findFirst[T any](nodes ...any) *T {
 				_n.LineFormat,
 				_n.LabelFormat,
 				_n.Drop,
+				_n.Keep,
 			)
 		case *logql_parser.ByOrWithout:
 			children := make([]any, len(_n.Labels))

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner.go
@@ -283,6 +283,8 @@ func (p *planner) planSpl() error {
 			err = p.planUnwrap(&ppl)
 		} else if ppl.Drop != nil {
 			err = p.planDrop(i, &ppl)
+		} else if ppl.Keep != nil {
+			err = p.planKeep(i, &ppl)
 		}
 
 		if err != nil {
@@ -310,6 +312,25 @@ func (p *planner) planDrop(i int, ppl *logql_parser.StrSelectorPipeline) error {
 		return err
 	}
 	p.samplesPlanner = &PlannerDrop{
+		Labels:      labels,
+		Vals:        values,
+		LabelsCache: &p.labelsCache,
+		fpCache:     &p.fpCache,
+		Main:        p.samplesPlanner,
+	}
+	return nil
+}
+
+func (p *planner) planKeep(i int, ppl *logql_parser.StrSelectorPipeline) error {
+	if p.simpleLabelOperation[i] {
+		return nil
+	}
+
+	labels, values, err := getLabelsAndValuesFromKeep(ppl.Keep)
+	if err != nil {
+		return err
+	}
+	p.samplesPlanner = &PlannerKeep{
 		Labels:      labels,
 		Vals:        values,
 		LabelsCache: &p.labelsCache,
@@ -556,16 +577,30 @@ func getStreamSelector(script *logql_parser.LogQLScript) *logql_parser.StrSelect
 }
 
 func getLabelsAndValuesFromDrop(drop *logql_parser.Drop) ([]string, []string, error) {
-	labels := make([]string, len(drop.Params))
-	vals := make([]string, len(drop.Params))
-	for i, l := range drop.Params {
-		labels[i] = l.Label.Name
+	return getLabelsAndValuesFromLabelParams(len(drop.Params), func(i int) (logql_parser.LabelName, *logql_parser.QuotedString) {
+		return drop.Params[i].Label, drop.Params[i].Val
+	})
+}
+
+func getLabelsAndValuesFromKeep(keep *logql_parser.Keep) ([]string, []string, error) {
+	return getLabelsAndValuesFromLabelParams(len(keep.Params), func(i int) (logql_parser.LabelName, *logql_parser.QuotedString) {
+		return keep.Params[i].Label, keep.Params[i].Val
+	})
+}
+
+func getLabelsAndValuesFromLabelParams(count int,
+	getParam func(i int) (logql_parser.LabelName, *logql_parser.QuotedString)) ([]string, []string, error) {
+	labels := make([]string, count)
+	vals := make([]string, count)
+	for i := 0; i < count; i++ {
+		label, valParam := getParam(i)
+		labels[i] = label.Name
 		var (
 			err error
 			val string
 		)
-		if l.Val != nil {
-			val, err = l.Val.Unquote()
+		if valParam != nil {
+			val, err = valParam.Unquote()
 			if err != nil {
 				return nil, nil, err
 			}

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_keep.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_keep.go
@@ -1,0 +1,75 @@
+package clickhouse_planner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
+	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
+)
+
+type PlannerKeep struct {
+	Labels      []string
+	Vals        []string
+	LabelsCache **sql.With
+	fpCache     **sql.With
+	Main        shared.SQLRequestPlanner
+}
+
+func (k *PlannerKeep) Process(ctx *shared.PlannerContext) (sql.ISelect, error) {
+	main, err := k.Main.Process(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cols, err := patchCol(main.GetSelect(), "labels", func(labels sql.SQLObject) (sql.SQLObject, error) {
+		return &mapKeepFilter{
+			col:    labels,
+			labels: k.Labels,
+			values: k.Vals,
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	main.Select(cols...)
+	return main, nil
+}
+
+type mapKeepFilter struct {
+	col    sql.SQLObject
+	labels []string
+	values []string
+}
+
+func (m mapKeepFilter) String(ctx *sql.Ctx, options ...int) (string, error) {
+	str, err := m.col.String(ctx, options...)
+	if err != nil {
+		return "", err
+	}
+	fn, err := m.genFilterFn(ctx, options...)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("mapFilter(%s, %s)", fn, str), nil
+}
+
+func (m mapKeepFilter) genFilterFn(ctx *sql.Ctx, options ...int) (string, error) {
+	clauses := make([]string, len(m.labels))
+	for i, l := range m.labels {
+		quoteKey, err := sql.NewStringVal(l).String(ctx, options...)
+		if err != nil {
+			return "", err
+		}
+		if m.values[i] == "" {
+			clauses[i] = fmt.Sprintf("k==%s", quoteKey)
+			continue
+		}
+		quoteVal, err := sql.NewStringVal(m.values[i]).String(ctx, options...)
+		if err != nil {
+			return "", err
+		}
+		clauses[i] = fmt.Sprintf("(k, v)==(%s, %s)", quoteKey, quoteVal)
+	}
+	return fmt.Sprintf("(k,v) -> %s",
+		strings.Join(clauses, " or ")), nil
+}

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_keep_test.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_keep_test.go
@@ -1,0 +1,35 @@
+package clickhouse_planner
+
+import (
+	"strings"
+	"testing"
+
+	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
+)
+
+func TestMapKeepFilter(t *testing.T) {
+	filter := mapKeepFilter{
+		col:    sql.NewRawObject("labels"),
+		labels: []string{"k8s_object_kind", "method"},
+		values: []string{"", "GET"},
+	}
+
+	ctx := &sql.Ctx{Params: map[string]sql.SQLObject{}, Result: map[string]sql.SQLObject{}}
+	got, err := filter.String(ctx)
+	if err != nil {
+		t.Fatalf("String() error = %v", err)
+	}
+
+	if !strings.Contains(got, "mapFilter") {
+		t.Fatalf("expected mapFilter expression, got %q", got)
+	}
+	if !strings.Contains(got, "k=='k8s_object_kind'") {
+		t.Fatalf("expected unconditional keep for k8s_object_kind, got %q", got)
+	}
+	if !strings.Contains(got, "(k, v)==('method', 'GET')") {
+		t.Fatalf("expected conditional keep for method=GET, got %q", got)
+	}
+	if !strings.Contains(got, " or ") {
+		t.Fatalf("expected OR-combined keep clauses, got %q", got)
+	}
+}

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_line_format.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_line_format.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"text/template"
 	"text/template/parse"
+	"time"
 
 	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
 	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
@@ -41,7 +42,7 @@ func (l *LineFormatPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, er
 }
 
 func (l *LineFormatPlanner) ProcessTpl(ctx *shared.PlannerContext) error {
-	tpl, err := template.New(fmt.Sprintf("tpl%d", ctx.Id())).Parse(l.Template)
+	tpl, err := template.New(fmt.Sprintf("tpl%d", ctx.Id())).Funcs(lineFormatParseFuncs()).Parse(l.Template)
 	if err != nil {
 		return err
 	}
@@ -50,7 +51,7 @@ func (l *LineFormatPlanner) ProcessTpl(ctx *shared.PlannerContext) error {
 }
 
 func (l *LineFormatPlanner) IsSupported() bool {
-	tpl, err := template.New("tpl1").Parse(l.Template)
+	tpl, err := template.New("tpl1").Funcs(lineFormatParseFuncs()).Parse(l.Template)
 	if err != nil {
 		return false
 	}
@@ -103,6 +104,8 @@ func (l *LineFormatPlanner) node(n parse.Node) error {
 		l.textNode(n)
 	case parse.NodeField:
 		l.fieldNode(n)
+	case parse.NodeAction:
+		l.actionNode(n)
 	}
 	return nil
 }
@@ -112,9 +115,56 @@ func (l *LineFormatPlanner) textNode(n parse.Node) {
 }
 
 func (l *LineFormatPlanner) fieldNode(n parse.Node) {
+	switch n.(*parse.FieldNode).Ident[0] {
+	case "__line__", "_entry":
+		l.appendLineArg()
+	case "__timestamp__":
+		l.appendTimestampArg()
+	default:
+		l.appendLabelArg(n.(*parse.FieldNode).Ident[0])
+	}
+}
+
+func (l *LineFormatPlanner) actionNode(n parse.Node) {
+	action := n.(*parse.ActionNode)
+	if len(action.Pipe.Cmds) != 1 {
+		return
+	}
+	cmd := action.Pipe.Cmds[0]
+	if len(cmd.Args) != 1 {
+		return
+	}
+	if ident, ok := cmd.Args[0].(*parse.IdentifierNode); ok {
+		switch ident.Ident {
+		case "__line__", "_entry":
+			l.appendLineArg()
+		case "__timestamp__":
+			l.appendTimestampArg()
+		}
+	}
+}
+
+func (l *LineFormatPlanner) appendLabelArg(label string) {
 	l.formatStr += fmt.Sprintf("{%d}", len(l.args))
 	l.args = append(l.args, sql.NewCustomCol(func(ctx *sql.Ctx, options ...int) (string, error) {
-		lbl, err := sql.NewStringVal(n.(*parse.FieldNode).Ident[0]).String(ctx, options...)
+		lbl, err := sql.NewStringVal(label).String(ctx, options...)
 		return fmt.Sprintf("labels[%s]", lbl), err
 	}))
+}
+
+func (l *LineFormatPlanner) appendLineArg() {
+	l.formatStr += fmt.Sprintf("{%d}", len(l.args))
+	l.args = append(l.args, sql.NewRawObject("string"))
+}
+
+func (l *LineFormatPlanner) appendTimestampArg() {
+	l.formatStr += fmt.Sprintf("{%d}", len(l.args))
+	l.args = append(l.args, sql.NewRawObject("fromUnixTimestamp64Nano(timestamp_ns)"))
+}
+
+func lineFormatParseFuncs() template.FuncMap {
+	funcs := shared.BaseTemplateFuncs()
+	funcs["__line__"] = func() string { return "" }
+	funcs["__timestamp__"] = func() time.Time { return time.Time{} }
+	return funcs
 }

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_line_format_test.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_line_format_test.go
@@ -1,0 +1,63 @@
+package clickhouse_planner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
+	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
+)
+
+func TestLineFormatPlannerBuiltins(t *testing.T) {
+	planner := LineFormatPlanner{
+		Template: `{{.k8s_object_name}} - {{__line__}}`,
+	}
+
+	ctx := &shared.PlannerContext{}
+	if err := planner.ProcessTpl(ctx); err != nil {
+		t.Fatalf("ProcessTpl() error = %v", err)
+	}
+
+	sqlCtx := &sql.Ctx{Params: map[string]sql.SQLObject{}, Result: map[string]sql.SQLObject{}}
+	got, err := (&sqlFormat{
+		format: planner.formatStr,
+		args:   planner.args,
+	}).String(sqlCtx)
+	if err != nil {
+		t.Fatalf("String() error = %v", err)
+	}
+
+	if !strings.Contains(got, "format(") {
+		t.Fatalf("expected format() SQL, got %q", got)
+	}
+	if !strings.Contains(got, "labels['k8s_object_name']") {
+		t.Fatalf("expected label reference, got %q", got)
+	}
+	if !strings.Contains(got, "string") {
+		t.Fatalf("expected log line column reference, got %q", got)
+	}
+}
+
+func TestLineFormatPlannerTimestampBuiltin(t *testing.T) {
+	planner := LineFormatPlanner{
+		Template: `{{ __timestamp__ }}`,
+	}
+
+	ctx := &shared.PlannerContext{}
+	if err := planner.ProcessTpl(ctx); err != nil {
+		t.Fatalf("ProcessTpl() error = %v", err)
+	}
+
+	sqlCtx := &sql.Ctx{Params: map[string]sql.SQLObject{}, Result: map[string]sql.SQLObject{}}
+	got, err := (&sqlFormat{
+		format: planner.formatStr,
+		args:   planner.args,
+	}).String(sqlCtx)
+	if err != nil {
+		t.Fatalf("String() error = %v", err)
+	}
+
+	if !strings.Contains(got, "fromUnixTimestamp64Nano(timestamp_ns)") {
+		t.Fatalf("expected timestamp conversion, got %q", got)
+	}
+}

--- a/reader/logql/logql_transpiler/internal/planner/keep.go
+++ b/reader/logql/logql_transpiler/internal/planner/keep.go
@@ -1,0 +1,60 @@
+package planner
+
+import "github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
+
+type KeepPlanner struct {
+	GenericPlanner
+	Labels []string
+	Values []string
+}
+
+func (a *KeepPlanner) Process(ctx *shared.PlannerContext,
+	in chan []shared.LogEntry) (chan []shared.LogEntry, error) {
+
+	return a.WrapProcess(ctx, in, GenericPlannerOps{
+		OnEntry: a.filterLabels,
+		OnAfterEntriesSlice: func(entries []shared.LogEntry, out chan []shared.LogEntry) error {
+			out <- entries
+			return nil
+		},
+		OnAfterEntries: func(c chan []shared.LogEntry) error {
+			return nil
+		},
+	})
+}
+
+func (a *KeepPlanner) filterLabels(e *shared.LogEntry) error {
+	if e.Labels == nil {
+		return nil
+	}
+	recountFP := false
+	for k, v := range e.Labels {
+		if isSpecialKeepLabel(k) {
+			continue
+		}
+		if !shouldKeepLabel(k, v, a.Labels, a.Values) {
+			delete(e.Labels, k)
+			recountFP = true
+		}
+	}
+	if recountFP {
+		e.Fingerprint = fingerprint(e.Labels)
+	}
+	return nil
+}
+
+func shouldKeepLabel(k, v string, labels, values []string) bool {
+	for i, l := range labels {
+		if k != l {
+			continue
+		}
+		if values[i] == "" || values[i] == v {
+			return true
+		}
+	}
+	return false
+}
+
+func isSpecialKeepLabel(name string) bool {
+	return name == "__error__" || name == "__error_details__"
+}

--- a/reader/logql/logql_transpiler/internal/planner/keep_test.go
+++ b/reader/logql/logql_transpiler/internal/planner/keep_test.go
@@ -1,0 +1,89 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
+)
+
+func TestShouldKeepLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		val    string
+		labels []string
+		values []string
+		want   bool
+	}{
+		{
+			name:   "keep label without value constraint",
+			key:    "level",
+			val:    "info",
+			labels: []string{"level"},
+			values: []string{""},
+			want:   true,
+		},
+		{
+			name:   "keep label with matching value",
+			key:    "method",
+			val:    "GET",
+			labels: []string{"method"},
+			values: []string{"GET"},
+			want:   true,
+		},
+		{
+			name:   "keep label with non-matching value",
+			key:    "method",
+			val:    "POST",
+			labels: []string{"method"},
+			values: []string{"GET"},
+			want:   false,
+		},
+		{
+			name:   "label not in keep list",
+			key:    "path",
+			val:    "/",
+			labels: []string{"level"},
+			values: []string{""},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldKeepLabel(tt.key, tt.val, tt.labels, tt.values); got != tt.want {
+				t.Fatalf("shouldKeepLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeepPlannerFilterLabels(t *testing.T) {
+	planner := KeepPlanner{
+		Labels: []string{"k8s_object_kind", "method"},
+		Values: []string{"", "GET"},
+	}
+
+	entry := shared.LogEntry{
+		Labels: map[string]string{
+			"k8s_object_kind": "Node",
+			"method":          "POST",
+			"path":            "/",
+		},
+		Fingerprint: 123,
+	}
+
+	if err := planner.filterLabels(&entry); err != nil {
+		t.Fatalf("filterLabels() error = %v", err)
+	}
+
+	if _, ok := entry.Labels["k8s_object_kind"]; !ok {
+		t.Fatalf("expected k8s_object_kind to be kept")
+	}
+	if _, ok := entry.Labels["method"]; ok {
+		t.Fatalf("expected method to be dropped when value does not match")
+	}
+	if _, ok := entry.Labels["path"]; ok {
+		t.Fatalf("expected path to be dropped")
+	}
+}

--- a/reader/logql/logql_transpiler/internal/planner/line_format.go
+++ b/reader/logql/logql_transpiler/internal/planner/line_format.go
@@ -1,48 +1,8 @@
 package planner
 
 import (
-	"bytes"
-	"regexp"
-	"strings"
-	"text/template"
-
-	"github.com/Masterminds/sprig"
 	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
 )
-
-var functionMap = func() template.FuncMap {
-	res := template.FuncMap{
-		"ToLower":    strings.ToLower,
-		"ToUpper":    strings.ToUpper,
-		"Replace":    strings.Replace,
-		"Trim":       strings.Trim,
-		"TrimLeft":   strings.TrimLeft,
-		"TrimRight":  strings.TrimRight,
-		"TrimPrefix": strings.TrimPrefix,
-		"TrimSuffix": strings.TrimSuffix,
-		"TrimSpace":  strings.TrimSpace,
-		"regexReplaceAll": func(regex string, s string, repl string) string {
-			r := regexp.MustCompile(regex)
-			return r.ReplaceAllString(s, repl)
-		},
-		"regexReplaceAllLiteral": func(regex string, s string, repl string) string {
-			r := regexp.MustCompile(regex)
-			return r.ReplaceAllLiteralString(s, repl)
-		},
-	}
-	sprigFuncMap := sprig.GenericFuncMap()
-	for _, addFn := range []string{"lower", "upper", "title", "trunc", "substr", "contains",
-		"hasPrefix", "hasSuffix", "indent", "nindent", "replace", "repeat", "trim",
-		"trimAll", "trimSuffix", "trimPrefix", "int", "float64", "add", "sub", "mul",
-		"div", "mod", "addf", "subf", "mulf", "divf", "max", "min", "maxf", "minf", "ceil", "floor",
-		"round", "fromJson", "date", "toDate", "now", "unixEpoch",
-	} {
-		if function, ok := sprigFuncMap[addFn]; ok {
-			res[addFn] = function
-		}
-	}
-	return res
-}()
 
 type LineFormatterPlanner struct {
 	GenericPlanner
@@ -51,7 +11,7 @@ type LineFormatterPlanner struct {
 
 func (l *LineFormatterPlanner) Process(ctx *shared.PlannerContext,
 	in chan []shared.LogEntry) (chan []shared.LogEntry, error) {
-	tpl, err := template.New("line").Option("missingkey=zero").Funcs(functionMap).Parse(l.Template)
+	tpl, bind, err := shared.PrepareLineFormatTemplate(l.Template)
 	if err != nil {
 		return nil, err
 	}
@@ -60,16 +20,11 @@ func (l *LineFormatterPlanner) Process(ctx *shared.PlannerContext,
 	i := 0
 	return l.WrapProcess(ctx, in, GenericPlannerOps{
 		OnEntry: func(entry *shared.LogEntry) error {
-			var buf bytes.Buffer
-			_labels := make(map[string]string)
-			for k, v := range entry.Labels {
-				_labels[k] = v
+			message, err := shared.ExecuteLineFormatTemplate(tpl, bind, *entry)
+			if err != nil {
+				return err
 			}
-			_labels["_entry"] = entry.Message
-			if err := tpl.Execute(&buf, _labels); err != nil {
-				return nil
-			}
-			entry.Message = buf.String()
+			entry.Message = message
 			_entries = append(_entries, *entry)
 			return nil
 		},

--- a/reader/logql/logql_transpiler/internal/planner/planner.go
+++ b/reader/logql/logql_transpiler/internal/planner/planner.go
@@ -93,6 +93,30 @@ func Plan(script *logql_parser.LogQLScript,
 				Labels:         names,
 				Values:         vals,
 			}
+			continue
+		}
+		if ppl.Keep != nil {
+			names := make([]string, len(ppl.Keep.Params))
+			vals := make([]string, len(ppl.Keep.Params))
+			for i, param := range ppl.Keep.Params {
+				names[i] = param.Label.Name
+				var (
+					err error
+					val string
+				)
+				if param.Val != nil {
+					val, err = param.Val.Unquote()
+					if err != nil {
+						return nil, err
+					}
+				}
+				vals[i] = val
+			}
+			in = &KeepPlanner{
+				GenericPlanner: GenericPlanner{in},
+				Labels:         names,
+				Values:         vals,
+			}
 		}
 	}
 	in, err := planAggregators(script, in)

--- a/reader/logql/logql_transpiler/shared/template_funcs.go
+++ b/reader/logql/logql_transpiler/shared/template_funcs.go
@@ -1,0 +1,101 @@
+package shared
+
+import (
+	"regexp"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/Masterminds/sprig"
+)
+
+type lineFormatBindings struct {
+	line string
+	ts   time.Time
+}
+
+func (b *lineFormatBindings) register(funcs template.FuncMap) {
+	funcs["__line__"] = func() string { return b.line }
+	funcs["__timestamp__"] = func() time.Time { return b.ts }
+}
+
+func (b *lineFormatBindings) bind(entry LogEntry) {
+	b.line = entry.Message
+	b.ts = time.Unix(0, entry.TimestampNS).UTC()
+}
+
+// BaseTemplateFuncs returns the shared LogQL template functions used by line_format
+// and label_format, excluding per-entry builtins such as __line__ and __timestamp__.
+func BaseTemplateFuncs() template.FuncMap {
+	res := template.FuncMap{
+		"ToLower":    strings.ToLower,
+		"ToUpper":    strings.ToUpper,
+		"Replace":    strings.Replace,
+		"Trim":       strings.Trim,
+		"TrimLeft":   strings.TrimLeft,
+		"TrimRight":  strings.TrimRight,
+		"TrimPrefix": strings.TrimPrefix,
+		"TrimSuffix": strings.TrimSuffix,
+		"TrimSpace":  strings.TrimSpace,
+		"regexReplaceAll": func(regex string, s string, repl string) string {
+			r := regexp.MustCompile(regex)
+			return r.ReplaceAllString(s, repl)
+		},
+		"regexReplaceAllLiteral": func(regex string, s string, repl string) string {
+			r := regexp.MustCompile(regex)
+			return r.ReplaceAllLiteralString(s, repl)
+		},
+	}
+	sprigFuncMap := sprig.GenericFuncMap()
+	for _, addFn := range []string{"lower", "upper", "title", "trunc", "substr", "contains",
+		"hasPrefix", "hasSuffix", "indent", "nindent", "replace", "repeat", "trim",
+		"trimAll", "trimSuffix", "trimPrefix", "int", "float64", "add", "sub", "mul",
+		"div", "mod", "addf", "subf", "mulf", "divf", "max", "min", "maxf", "minf", "ceil", "floor",
+		"round", "fromJson", "date", "toDate", "toDateInZone", "now", "unixEpoch",
+		"duration", "duration_seconds", "len", "eq", "ne", "and", "or", "not",
+	} {
+		if function, ok := sprigFuncMap[addFn]; ok {
+			res[addFn] = function
+		}
+	}
+	if divFn, ok := res["div"]; ok {
+		res["divide"] = divFn
+	}
+	return res
+}
+
+// EntryTemplateLabels returns label values available to line_format templates.
+func EntryTemplateLabels(entry LogEntry) map[string]string {
+	labels := make(map[string]string, len(entry.Labels)+2)
+	for k, v := range entry.Labels {
+		labels[k] = v
+	}
+	labels["_entry"] = entry.Message
+	labels["__line__"] = entry.Message
+	return labels
+}
+
+// PrepareLineFormatTemplate parses a line_format/label_format template and returns
+// a binder that must be called before each Execute with the current log entry.
+func PrepareLineFormatTemplate(templateStr string) (*template.Template, func(LogEntry), error) {
+	bindings := &lineFormatBindings{}
+	funcs := BaseTemplateFuncs()
+	bindings.register(funcs)
+
+	tpl, err := template.New("line").Option("missingkey=zero").Funcs(funcs).Parse(templateStr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tpl, bindings.bind, nil
+}
+
+// ExecuteLineFormatTemplate renders a parsed template for a single log entry.
+func ExecuteLineFormatTemplate(tpl *template.Template, bind func(LogEntry), entry LogEntry) (string, error) {
+	bind(entry)
+	var buf strings.Builder
+	if err := tpl.Execute(&buf, EntryTemplateLabels(entry)); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/reader/logql/logql_transpiler/shared/template_funcs_test.go
+++ b/reader/logql/logql_transpiler/shared/template_funcs_test.go
@@ -1,0 +1,53 @@
+package shared
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestPrepareLineFormatTemplateBuiltins(t *testing.T) {
+	tpl, bind, err := PrepareLineFormatTemplate(`{{.k8s_object_name}} - {{__line__}}`)
+	if err != nil {
+		t.Fatalf("PrepareLineFormatTemplate() error = %v", err)
+	}
+
+	entry := LogEntry{
+		TimestampNS: time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC).UnixNano(),
+		Labels: map[string]string{
+			"k8s_object_name": "worker-1",
+		},
+		Message: "original log line",
+	}
+
+	got, err := ExecuteLineFormatTemplate(tpl, bind, entry)
+	if err != nil {
+		t.Fatalf("ExecuteLineFormatTemplate() error = %v", err)
+	}
+	want := "worker-1 - original log line"
+	if got != want {
+		t.Fatalf("ExecuteLineFormatTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestPrepareLineFormatTemplateTimestamp(t *testing.T) {
+	tpl, bind, err := PrepareLineFormatTemplate(`{{ __timestamp__ | unixEpoch }}`)
+	if err != nil {
+		t.Fatalf("PrepareLineFormatTemplate() error = %v", err)
+	}
+
+	ts := time.Date(2024, 6, 1, 12, 34, 56, 0, time.UTC)
+	entry := LogEntry{
+		TimestampNS: ts.UnixNano(),
+		Message:     "line",
+	}
+
+	got, err := ExecuteLineFormatTemplate(tpl, bind, entry)
+	if err != nil {
+		t.Fatalf("ExecuteLineFormatTemplate() error = %v", err)
+	}
+	if got != fmt.Sprintf("%d", ts.Unix()) {
+		t.Fatalf("ExecuteLineFormatTemplate() = %q, want %q", got, fmt.Sprintf("%d", ts.Unix()))
+	}
+}
+


### PR DESCRIPTION
**Disclaimer:** Co-Authored with AI agent.

### Fixes 2 issues:
1. `| line_format` pipeline doesn't support `__line__`
```logql
{k8s_object_kind="Node", k8s_event_reason="ScaleDown", signoz_component="otel-deployment"} | line_format `{{.k8s_object_name}} - {{__line__}}`
```
I get the error:
```
{"error":"template: line:1: function \"__line__\" not defined","errorType":"error","status":"error"}
```
But Logql-compatible API should support all of the functions defined here: https://grafana.com/docs/loki/latest/query/template_functions/

2. `| keep` is not supported
```logql
{k8s_object_kind="Node", k8s_event_reason="ScaleDown", signoz_component="otel-deployment"} | keep k8s_object_kind
```
and got this error:
```
{"error":"1:99: unexpected token \"k8s_object_kind\" (expected (\"=\" | \"!=\" | \"!~\" | \"==\" | \"\u003e=\" | \"\u003e\" | \"\u003c=\" | \"\u003c\" | \"=~\") (QuotedString | (\u003cinteger\u003e \".\"? \u003cinteger\u003e*)))","errorType":"error","status":"error"}
```

### Proof of success
Both 
```logql
{k8s_object_kind="Node", k8s_event_reason="ScaleDown", signoz_component="otel-deployment"} | line_format `{{.k8s_object_name}} - {{__line__}}`
```
and
```logql
{k8s_object_kind="Node", k8s_event_reason="ScaleDown", signoz_component="otel-deployment"} | keep k8s_object_kind
```
are working
<img width="841" height="745" alt="image" src="https://github.com/user-attachments/assets/fc9c6fd9-5edf-449a-b644-8f888cc984be" />
