### PR TITLE
feat(logql): emit __error__/__error_details__ on parser failure

### DIFF
--- a/reader/logql/logql_transpiler/clickhouse_planner/planner.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner.go
@@ -47,6 +47,7 @@ type planner struct {
 	metrics15Shortcut        bool
 	offsetModifier           *time.Duration
 	noStreamSelect           bool
+	jsonParserSeen           bool // a json parser has been planned, so __error__ may be set
 
 	//SQL Planners
 	fpPlanner      shared.SQLRequestPlanner
@@ -488,8 +489,9 @@ func (p *planner) planLabelFilter(ppl *logql_parser.StrSelectorPipeline, idx int
 		return nil
 	}
 	p.samplesPlanner = &LabelFilterPlanner{
-		Expr: ppl.LabelFilter,
-		Main: p.samplesPlanner,
+		Expr:           ppl.LabelFilter,
+		Main:           p.samplesPlanner,
+		JSONParserSeen: p.jsonParserSeen,
 	}
 	return nil
 }
@@ -530,6 +532,9 @@ func (p *planner) planParser(ppl *logql_parser.StrSelectorPipeline) error {
 			return err
 		}
 		vals = append(vals, val)
+	}
+	if ppl.Parser.Fn == "json" {
+		p.jsonParserSeen = true
 	}
 	p.samplesPlanner = &ParserPlanner{
 		Op:     ppl.Parser.Fn,

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_keep.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_keep.go
@@ -54,21 +54,34 @@ func (m mapKeepFilter) String(ctx *sql.Ctx, options ...int) (string, error) {
 }
 
 func (m mapKeepFilter) genFilterFn(ctx *sql.Ctx, options ...int) (string, error) {
-	clauses := make([]string, len(m.labels))
+	clauses := make([]string, 0, len(m.labels)+2)
+
+	// Preserve synthetic parser-error labels regardless of the keep list,
+	// mirroring the in-memory KeepPlanner and Loki semantics. Otherwise a
+	// `| json | keep <label>` chain would silently strip the error context
+	// emitted by the parser on a failed line.
+	for _, name := range []string{shared.ErrorLabel, shared.ErrorDetailsLabel} {
+		q, err := sql.NewStringVal(name).String(ctx, options...)
+		if err != nil {
+			return "", err
+		}
+		clauses = append(clauses, fmt.Sprintf("k==%s", q))
+	}
+
 	for i, l := range m.labels {
 		quoteKey, err := sql.NewStringVal(l).String(ctx, options...)
 		if err != nil {
 			return "", err
 		}
 		if m.values[i] == "" {
-			clauses[i] = fmt.Sprintf("k==%s", quoteKey)
+			clauses = append(clauses, fmt.Sprintf("k==%s", quoteKey))
 			continue
 		}
 		quoteVal, err := sql.NewStringVal(m.values[i]).String(ctx, options...)
 		if err != nil {
 			return "", err
 		}
-		clauses[i] = fmt.Sprintf("(k, v)==(%s, %s)", quoteKey, quoteVal)
+		clauses = append(clauses, fmt.Sprintf("(k, v)==(%s, %s)", quoteKey, quoteVal))
 	}
 	return fmt.Sprintf("(k,v) -> %s",
 		strings.Join(clauses, " or ")), nil

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_keep_test.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_keep_test.go
@@ -33,3 +33,24 @@ func TestMapKeepFilter(t *testing.T) {
 		t.Fatalf("expected OR-combined keep clauses, got %q", got)
 	}
 }
+
+func TestMapKeepFilterPreservesErrorLabels(t *testing.T) {
+	filter := mapKeepFilter{
+		col:    sql.NewRawObject("labels"),
+		labels: []string{"level"},
+		values: []string{""},
+	}
+
+	ctx := &sql.Ctx{Params: map[string]sql.SQLObject{}, Result: map[string]sql.SQLObject{}}
+	got, err := filter.String(ctx)
+	if err != nil {
+		t.Fatalf("String() error = %v", err)
+	}
+
+	if !strings.Contains(got, "k=='__error__'") {
+		t.Fatalf("expected __error__ to be preserved unconditionally, got %q", got)
+	}
+	if !strings.Contains(got, "k=='__error_details__'") {
+		t.Fatalf("expected __error_details__ to be preserved unconditionally, got %q", got)
+	}
+}

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_label_filter.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_label_filter.go
@@ -16,6 +16,10 @@ type LabelFilterPlanner struct {
 	Main           shared.SQLRequestPlanner
 	MainReq        sql.ISelect
 	LabelValGetter func(string) sql.SQLObject
+	// JSONParserSeen is set when a json parser precedes this filter, so an
+	// __error__ filter can be rewritten to a check on the raw line instead of
+	// reading the materialized label map (which can't be pushed past the parse).
+	JSONParserSeen bool
 }
 
 func (s *LabelFilterPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, error) {
@@ -77,7 +81,58 @@ func (s *LabelFilterPlanner) makeSimpleSqlCond(ctx *shared.PlannerContext, expr 
 	return s.makeSimpleStrSqlCond(ctx, expr)
 }
 
+// makeErrorLabelCond rewrites an `__error__` equality filter that follows a json
+// parser into a check on the raw line (JSONType(string)='Object' marks a cleanly
+// parsed entry). This references a base column instead of the materialized label
+// map, so the predicate filters rows before the labels are built. handled is
+// false for filters this cannot rewrite (regex ops, no preceding json parser),
+// which then fall back to the generic label-map condition.
+func (s *LabelFilterPlanner) makeErrorLabelCond(expr *logql_parser.SimpleLabelFilter) (sql.SQLCondition, bool, error) {
+	if !s.JSONParserSeen || expr.Label.Name != shared.ErrorLabel {
+		return nil, false, nil
+	}
+	if (expr.Fn != "=" && expr.Fn != "!=") || expr.StrVal == nil {
+		return nil, false, nil
+	}
+	val, err := expr.StrVal.Unquote()
+	if err != nil {
+		return nil, false, err
+	}
+
+	jsonType := sql.NewRawObject("JSONType(string)")
+	object := sql.NewStringVal("Object")
+	noError := sql.Eq(jsonType, object)  // line is a json object: parsed cleanly
+	isError := sql.Neq(jsonType, object) // line is not a json object: JSONParserErr
+
+	var selectErrored bool
+	switch val {
+	case "":
+		// __error__="" keeps clean lines; __error__!="" keeps errored lines.
+		selectErrored = expr.Fn == "!="
+	case shared.JSONParserErr:
+		selectErrored = expr.Fn == "="
+	default:
+		// No other error value is ever produced: ="X" matches nothing, !="X" all.
+		matchNone := sql.Eq(sql.NewIntVal(1), sql.NewIntVal(0))
+		matchAll := sql.Eq(sql.NewIntVal(1), sql.NewIntVal(1))
+		if expr.Fn == "=" {
+			return matchNone, true, nil
+		}
+		return matchAll, true, nil
+	}
+	if selectErrored {
+		return isError, true, nil
+	}
+	return noError, true, nil
+}
+
 func (s *LabelFilterPlanner) makeSimpleStrSqlCond(_ *shared.PlannerContext, expr *logql_parser.SimpleLabelFilter) (sql.SQLCondition, error) {
+	if cond, handled, err := s.makeErrorLabelCond(expr); err != nil {
+		return nil, err
+	} else if handled {
+		return cond, nil
+	}
+
 	var label sql.SQLObject = sql.NewRawObject(fmt.Sprintf("labels['%s']", expr.Label.Name))
 	if s.LabelValGetter != nil {
 		label = s.LabelValGetter(expr.Label.Name)

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_parser_json.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_parser_json.go
@@ -25,10 +25,15 @@ func (p *ParserPlanner) json(ctx *shared.PlannerContext) (sql.ISelect, error) {
 	sel, err := patchCol(req.GetSelect(), "labels", func(object sql.SQLObject) (sql.SQLObject, error) {
 		return &sqlMapUpdate{
 			object,
-			&sqlJsonParser{
-				col:    sql.NewRawObject("string"),
-				labels: p.labels,
-				paths:  jsonPaths,
+			&sqlParserError{
+				col:     sql.NewRawObject("string"),
+				errType: shared.JSONParserErr,
+				detail:  "line is not a valid json object",
+				success: &sqlJsonParser{
+					col:    sql.NewRawObject("string"),
+					labels: p.labels,
+					paths:  jsonPaths,
+				},
 			},
 		}, nil
 	})

--- a/reader/logql/logql_transpiler/clickhouse_planner/sql_misc.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/sql_misc.go
@@ -50,6 +50,37 @@ func (s *sqlMapUpdate) String(ctx *sql.Ctx, opts ...int) (string, error) {
 	return fmt.Sprintf("mapUpdate(%s, %s)", str1, str2), nil
 }
 
+// sqlParserError emits the success-case label map when col parses cleanly, and
+// otherwise a map carrying the synthetic __error__/__error_details__ labels.
+// The validity check is JSON-object specific, covering the only SQL-path parser
+// (json) that flags runtime errors.
+type sqlParserError struct {
+	col     sql.SQLObject
+	success sql.SQLObject
+	errType string
+	detail  string
+}
+
+func (s *sqlParserError) String(ctx *sql.Ctx, opts ...int) (string, error) {
+	col, err := s.col.String(ctx, opts...)
+	if err != nil {
+		return "", err
+	}
+	success, err := s.success.String(ctx, opts...)
+	if err != nil {
+		return "", err
+	}
+	parts := make([]string, 4)
+	for i, v := range []string{shared.ErrorLabel, s.errType, shared.ErrorDetailsLabel, s.detail} {
+		parts[i], err = sql.NewStringVal(v).String(ctx, opts...)
+		if err != nil {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("if(JSONType(%s) = 'Object', %s, map(%s))",
+		col, success, strings.Join(parts, ", ")), nil
+}
+
 func patchCol(cols []sql.SQLObject, name string,
 	patch func(sql.SQLObject) (sql.SQLObject, error)) ([]sql.SQLObject, error) {
 	_cols := make([]sql.SQLObject, len(cols))

--- a/reader/logql/logql_transpiler/internal/planner/keep.go
+++ b/reader/logql/logql_transpiler/internal/planner/keep.go
@@ -56,5 +56,5 @@ func shouldKeepLabel(k, v string, labels, values []string) bool {
 }
 
 func isSpecialKeepLabel(name string) bool {
-	return name == "__error__" || name == "__error_details__"
+	return name == shared.ErrorLabel || name == shared.ErrorDetailsLabel
 }

--- a/reader/logql/logql_transpiler/internal/planner/keep_test.go
+++ b/reader/logql/logql_transpiler/internal/planner/keep_test.go
@@ -87,3 +87,33 @@ func TestKeepPlannerFilterLabels(t *testing.T) {
 		t.Fatalf("expected path to be dropped")
 	}
 }
+
+func TestKeepPlannerPreservesErrorLabels(t *testing.T) {
+	planner := KeepPlanner{
+		Labels: []string{"level"},
+		Values: []string{""},
+	}
+
+	entry := shared.LogEntry{
+		Labels: map[string]string{
+			"level":                  "info",
+			"path":                   "/",
+			shared.ErrorLabel:        shared.JSONParserErr,
+			shared.ErrorDetailsLabel: "boom",
+		},
+	}
+
+	if err := planner.filterLabels(&entry); err != nil {
+		t.Fatalf("filterLabels() error = %v", err)
+	}
+
+	if _, ok := entry.Labels[shared.ErrorLabel]; !ok {
+		t.Fatalf("expected %s to survive keep", shared.ErrorLabel)
+	}
+	if _, ok := entry.Labels[shared.ErrorDetailsLabel]; !ok {
+		t.Fatalf("expected %s to survive keep", shared.ErrorDetailsLabel)
+	}
+	if _, ok := entry.Labels["path"]; ok {
+		t.Fatalf("expected path to be dropped")
+	}
+}

--- a/reader/logql/logql_transpiler/internal/planner/parser.go
+++ b/reader/logql/logql_transpiler/internal/planner/parser.go
@@ -58,16 +58,23 @@ func (p *ParserPlanner) Process(ctx *shared.PlannerContext,
 		return nil, &shared.NotSupportedError{Msg: fmt.Sprintf("%s not supported", p.Op)}
 	}
 
+	errType := shared.ParserErrorType[p.Op]
+
 	return p.WrapProcess(ctx, in, GenericPlannerOps{
 		OnEntry: func(entry *shared.LogEntry) error {
 			if entry.Err != nil {
 				return nil
 			}
-			var err error
 			parser.setLabels(&entry.Labels)
-			err = parser.parse(entry.Message)
-			if err != nil {
-				return err
+			if err := parser.parse(entry.Message); err != nil {
+				// A failed parse does not abort the query: flag the entry with
+				// the synthetic error labels and keep whatever was extracted
+				// before the failure, matching Loki.
+				if entry.Labels == nil {
+					entry.Labels = map[string]string{}
+				}
+				entry.Labels[shared.ErrorLabel] = errType
+				entry.Labels[shared.ErrorDetailsLabel] = err.Error()
 			}
 			entry.Fingerprint = fingerprint(entry.Labels)
 			return nil

--- a/reader/logql/logql_transpiler/internal/planner/parser_helpers.go
+++ b/reader/logql/logql_transpiler/internal/planner/parser_helpers.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"errors"
 	"regexp"
 	"strconv"
 
@@ -8,6 +9,10 @@ import (
 	"github.com/kr/logfmt"
 	"golang.org/x/exp/slices"
 )
+
+// errNotJSONObject is returned when a `json` parser is applied to a line whose
+// root value is not a JSON object, surfaced to the caller as a JSONParserErr.
+var errNotJSONObject = errors.New("expecting json object")
 
 type plainJsonParserHelper struct {
 	lbls *map[string]string
@@ -20,7 +25,7 @@ func (p *plainJsonParserHelper) setLabels(m *map[string]string) {
 func (p *plainJsonParserHelper) parse(line string) error {
 	dec := jx.DecodeStr(line)
 	if dec.Next() != jx.Object {
-		return nil
+		return errNotJSONObject
 	}
 	return dec.Obj(func(d *jx.Decoder, key string) error {
 		return p.dec(key, d)
@@ -71,7 +76,7 @@ func (p *parameterJsonHelper) setLabels(m *map[string]string) {
 func (p *parameterJsonHelper) parse(line string) error {
 	dec := jx.DecodeStr(line)
 	if dec.Next() != jx.Object {
-		return nil
+		return errNotJSONObject
 	}
 	return dec.Obj(func(d *jx.Decoder, key string) error {
 		return p.dec([]string{key}, d)

--- a/reader/logql/logql_transpiler/shared/parser_errors.go
+++ b/reader/logql/logql_transpiler/shared/parser_errors.go
@@ -1,0 +1,22 @@
+package shared
+
+// Synthetic labels injected onto a log entry when a parser stage fails to
+// process its line, mirroring Loki's behavior. They are ordinary labels and so
+// are filterable with the usual label filters (e.g. `| __error__=""`).
+const (
+	ErrorLabel        = "__error__"
+	ErrorDetailsLabel = "__error_details__"
+)
+
+// Values set in ErrorLabel, one per parser kind.
+const (
+	JSONParserErr   = "JSONParserErr"
+	LogfmtParserErr = "LogfmtParserErr"
+)
+
+// ParserErrorType maps a parser op name to the ErrorLabel value it emits on
+// failure. Parsers absent from the map (e.g. regexp) do not flag runtime errors.
+var ParserErrorType = map[string]string{
+	"json":   JSONParserErr,
+	"logfmt": LogfmtParserErr,
+}


### PR DESCRIPTION
Mirror Loki's behavior of flagging entries with synthetic __error__ and __error_details__ labels when a parser stage fails, instead of either silently producing empty labels (SQL path) or aborting the whole query (in-process path).

- shared: define the __error__/__error_details__ label names and the JSONParserErr/LogfmtParserErr values, shared by both execution paths.
- in-process (json/logfmt): on a parse error, set the error labels and continue rather than failing the query; treat a non-object top-level json line as a JSONParserErr.
- ClickHouse (json foo="..."): wrap extraction in if(JSONType(string)='Object', <extract>, <error map>).
- __error__="" pushdown: a json parser sets a flag so a following __error__ equality filter is rewritten to a JSONType(string)='Object' check on the raw line, letting ClickHouse filter rows before building the label map instead of reading the materialized labels['__error__'].

Filtering needs no new code: existing label filters read labels['__error__'] (SQL) and m["__error__"] (Go), both defaulting absent keys to "".