### PR TITLE
fix: count_over_time should not transpile to a range query

### DIFF
--- a/reader/promql/promql_transpiler/planner/downsample_hints.go
+++ b/reader/promql/promql_transpiler/planner/downsample_hints.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"fmt"
+
 	"github.com/metrico/qryn/v4/reader/config"
 	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
 	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
@@ -30,7 +31,7 @@ func (d *DownsampleHintsPlanner) Process(ctx *shared.PlannerContext) (sql.ISelec
 		"present_over_time": true, "delta": true, "increase": true, "avg_over_time": true,
 	}
 
-	patchField(query, "value",
+	patchField(query, "val",
 		sql.NewSimpleCol(d.getValueMerge(hints.Func), "val").(sql.Aliased))
 	if rangeVectors[hints.Func] && hints.Step > hints.Range {
 		timeField := fmt.Sprintf("intDiv(samples.timestamp_ns + %d * 1000000, %d * 1000000) * %d",
@@ -52,25 +53,8 @@ func (d *DownsampleHintsPlanner) Process(ctx *shared.PlannerContext) (sql.ISelec
 		patchField(query, "timestamp_ms",
 			sql.NewSimpleCol(timeField, "timestamp_ms").(sql.Aliased))
 	}
-	if d.Hints.Func == "count_over_time" {
-		query = d.countOverTime(query)
-	}
 
 	return query, nil
-}
-
-func (d *DownsampleHintsPlanner) countOverTime(query sql.ISelect) sql.ISelect {
-	query.Select(append(query.GetSelect(), sql.NewSimpleCol("range(toInt64(val))", "arr"))...)
-	withQuery := sql.NewWith(query, "pre_count_over_time")
-	res := sql.NewSelect().
-		With(withQuery).
-		Select(
-			sql.NewSimpleCol("fingerprint", "fingerprint"),
-			sql.NewSimpleCol("1", "val"),
-			sql.NewSimpleCol("timestamp_ms", "timestamp_ms")).
-		From(sql.NewWithRef(withQuery)).
-		Join(sql.NewJoin("array", sql.NewSimpleCol("arr", "arr"), nil))
-	return res
 }
 
 func (d *DownsampleHintsPlanner) getValueMerge(fn string) string {

--- a/reader/promql/promql_transpiler/transpiler_test.go
+++ b/reader/promql/promql_transpiler/transpiler_test.go
@@ -2,13 +2,17 @@ package promql_transpiler
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	clconfig "github.com/metrico/cloki-config"
+	"github.com/metrico/qryn/v4/reader/config"
 	"github.com/metrico/qryn/v4/reader/logql/logql_transpiler/shared"
 	"github.com/metrico/qryn/v4/reader/promql/promql_parser"
 	sql "github.com/metrico/qryn/v4/reader/utils/sql_select"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"testing"
-	"time"
 )
 
 func TestTranspilerV2(t *testing.T) {
@@ -84,4 +88,80 @@ func TestTranspilerV1(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println(strQ)
+}
+
+func TestCountOverTime_DoesNotGenerateRange(t *testing.T) {
+	// Initialize config to avoid nil pointer dereference in StreamSelectPlanner.
+	if config.Cloki == nil {
+		config.Cloki = clconfig.New(clconfig.CLOKI_READER, nil, "", "")
+	}
+
+	// Reproduces a bug where count_over_time with a large range (e.g. 14d)
+	// generates range(toInt64(val)) in ClickHouse SQL. ClickHouse's range(N)
+	// creates an array [0..N-1] which is then ARRAY JOINed to expand rows.
+	// For large counts (14d window at 15s scrape = ~80k elements per bucket),
+	// this crashes ClickHouse or causes OOM.
+	now := time.Now()
+	ctx := &shared.PlannerContext{
+		IsCluster:               false,
+		From:                    now.Add(-14 * 24 * time.Hour),
+		To:                      now,
+		TimeSeriesGinTableName:  "time_series_gin",
+		SamplesTableName:        "samples_v3",
+		SamplesDistTableName:    "samples_v3",
+		TimeSeriesTableName:     "time_series",
+		TimeSeriesDistTableName: "time_series",
+		Metrics15sTableName:     "metrics_15s",
+		Metrics15sDistTableName: "metrics_15s",
+		Step:                    time.Minute,
+		Type:                    2,
+	}
+
+	hints := &storage.SelectHints{
+		Step:  (time.Minute).Milliseconds(),
+		Func:  "count_over_time",
+		Range: (14 * 24 * time.Hour).Milliseconds(),
+		Start: ctx.From.UnixMilli(),
+		End:   ctx.To.UnixMilli(),
+	}
+
+	q, err := TranspileLabelMatchersDownsample(hints, ctx,
+		&labels.Matcher{
+			Type:  labels.MatchEqual,
+			Name:  "__name__",
+			Value: "start_time",
+		},
+		&labels.Matcher{
+			Type:  labels.MatchEqual,
+			Name:  "job",
+			Value: "metric_exporter",
+		},
+	)
+	if err != nil {
+		t.Fatalf("TranspileLabelMatchersDownsample() returned error: %v", err)
+	}
+
+	strQ, err := q.Query.String(sql.DefaultCtx())
+	if err != nil {
+		t.Fatalf("Query.String() returned error: %v", err)
+	}
+
+	// The generated SQL must NOT contain range(toInt64(...)) which creates
+	// arrays that can be enormous and crash ClickHouse.
+	if strings.Contains(strQ, "range(toInt64") {
+		t.Errorf("generated SQL contains range(toInt64(...)) which is incorrect "+
+			"for count_over_time with large ranges.\n"+
+			"range(N) generates an array of N elements; for 14d of data this can be "+
+			"tens of thousands of elements per row, causing OOM or crashes.\n"+
+			"Got SQL:\n%s", strQ)
+	}
+
+	// The generated SQL should NOT use ARRAY JOIN for count_over_time.
+	// The pre-aggregated count from countMerge(count) already IS the count.
+	if strings.Contains(strings.ToLower(strQ), "array join") {
+		t.Errorf("generated SQL uses ARRAY JOIN which is incorrect for count_over_time.\n"+
+			"The pre-aggregated count from countMerge(count) should be used directly "+
+			"as the sample value rather than being expanded into individual rows.\n"+
+			"Got SQL:\n%s", strQ)
+	}
 }


### PR DESCRIPTION
1. Alias mismatch: patchField(query, "value", ...) searches for a SELECT
field with alias "value", but DownsampleValuesPlanner creates the field
with alias "val". The patch silently fails, so countMerge(count) never
replaces the default argMaxMerge(last).

2. countOverTime() method: Used range(toInt64(val)) + ARRAY JOIN to
expand a count into individual rows. Even if Bug 1 were fixed, this
approach is dangerous for large counts (e.g., 80,640 samples in a 14-day
window at 15s scrape interval = 80k-element arrays per row). With Bug
1 unfixed, val is the raw metric value (e.g., 1.7B), creating impossibly
large arrays.

Fixes: #863
