### PR TITLE
fix(reader): detect epoch magnitude when parsing time parameters

### DIFF
--- a/reader/controller/tempo.go
+++ b/reader/controller/tempo.go
@@ -477,7 +477,7 @@ func parseTraceSearchParams(r *http.Request) (*traceSearchParams, error) {
 	if err != nil {
 		return nil, fmt.Errorf("start: %v", err)
 	}
-	res.Start = epochToTime(startS)
+	res.Start = epochToTime(startS, 0)
 	if startS == 0 {
 		res.Start = time.Now().Add(time.Hour * -6)
 	}
@@ -485,23 +485,11 @@ func parseTraceSearchParams(r *http.Request) (*traceSearchParams, error) {
 	if err != nil {
 		return nil, fmt.Errorf("end: %v", err)
 	}
-	res.End = epochToTime(endS)
+	res.End = epochToTime(endS, 0)
 	if endS == 0 {
 		res.End = time.Now()
 	}
 	return &res, nil
-}
-
-// epochToTime converts an epoch timestamp to time.Time, handling seconds, milliseconds, and nanoseconds.
-func epochToTime(v int64) time.Time {
-	switch {
-	case v >= 1e18:
-		return time.Unix(0, v)
-	case v >= 1e12:
-		return time.Unix(0, v*int64(time.Millisecond))
-	default:
-		return time.Unix(v, 0)
-	}
 }
 
 func orDefault(str string, def string) string {

--- a/reader/controller/utils.go
+++ b/reader/controller/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"regexp"
 	"runtime/debug"
@@ -62,15 +63,57 @@ func getRequiredI64(ctx *http.Request, name string, def string, err error) (int6
 	return iRes, err
 }
 
+// Epoch magnitude thresholds. Each value is the epoch of ~1973-03-03 expressed
+// in the corresponding unit, so any realistic timestamp (past or future) maps to
+// exactly one unit and the ranges never overlap.
+const (
+	epochMilliMin = int64(1e11)
+	epochMicroMin = int64(1e14)
+	epochNanoMin  = int64(1e17)
+)
+
+var numericEpoch = regexp.MustCompile(`^[0-9.]+$`)
+
+// ParseTimeSecOrRFC parses a time parameter that may be an RFC3339 string or a
+// numeric UNIX epoch. Numeric epochs are disambiguated by magnitude: Prometheus
+// clients send (fractional) seconds while Loki clients (e.g. Grafana Logs
+// Drilldown) send nanoseconds. Treating nanoseconds as seconds produced
+// astronomically distant time ranges, causing full table scans and
+// "makeslice: len out of range" panics in downstream planners.
 func ParseTimeSecOrRFC(raw string, def time.Time) (time.Time, error) {
 	if raw == "" {
 		return def, nil
 	}
-	if regexp.MustCompile("^[0-9.]+$").MatchString(raw) {
-		t, _ := strconv.ParseFloat(raw, 64)
-		return time.Unix(int64(t), 0), nil
+	if !numericEpoch.MatchString(raw) {
+		return time.Parse(time.RFC3339, raw)
 	}
-	return time.Parse(time.RFC3339, raw)
+	// Integer epochs are parsed exactly: nanosecond values exceed the 53-bit
+	// mantissa of a float64, so a float round-trip would lose precision.
+	if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return epochToTime(i, 0), nil
+	}
+	t, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return def, err
+	}
+	sec, frac := math.Modf(t)
+	return epochToTime(int64(sec), frac), nil
+}
+
+// epochToTime converts a UNIX epoch of unknown resolution (seconds, milli-,
+// micro- or nanoseconds), plus an optional fractional part of the same unit,
+// into a time.Time. Shared by the Loki, Prometheus and Tempo query paths.
+func epochToTime(v int64, frac float64) time.Time {
+	switch {
+	case v >= epochNanoMin:
+		return time.Unix(v/1e9, v%1e9)
+	case v >= epochMicroMin:
+		return time.Unix(v/1e6, v%1e6*1e3+int64(frac*1e3))
+	case v >= epochMilliMin:
+		return time.Unix(v/1e3, v%1e3*1e6+int64(frac*1e6))
+	default:
+		return time.Unix(v, int64(frac*1e9))
+	}
 }
 
 func tamePanic(w http.ResponseWriter, r *http.Request) {

--- a/reader/controller/utils_test.go
+++ b/reader/controller/utils_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseTimeSecOrRFCMagnitudes(t *testing.T) {
+	def := time.Unix(0, 0)
+	cases := []struct {
+		raw  string
+		want time.Time
+	}{
+		{"1785416892", time.Unix(1785416892, 0)},                                // seconds
+		{"1785416892.5", time.Unix(1785416892, 500000000)},                      // fractional seconds
+		{"1785416892000", time.Unix(1785416892, 0)},                             // milliseconds
+		{"1785416892123", time.Unix(1785416892, 123000000)},                     // milliseconds, sub-second
+		{"1785416892000000", time.Unix(1785416892, 0)},                          // microseconds
+		{"1785416892123456", time.Unix(1785416892, 123456000)},                  // microseconds, sub-second
+		{"1785416892000000000", time.Unix(0, 1785416892000000000)},              // nanoseconds
+		{"1785416892123456789", time.Unix(0, 1785416892123456789)},              // nanoseconds, exact
+		{"2026-07-30T13:00:00Z", time.Date(2026, 7, 30, 13, 0, 0, 0, time.UTC)}, // RFC3339
+	}
+	for _, c := range cases {
+		got, err := ParseTimeSecOrRFC(c.raw, def)
+		if err != nil {
+			t.Fatalf("%s: %v", c.raw, err)
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("%s: got %v want %v", c.raw, got.UTC(), c.want.UTC())
+		}
+	}
+	got, _ := ParseTimeSecOrRFC("", def)
+	if !got.Equal(def) {
+		t.Errorf("empty: got %v", got)
+	}
+}
+
+// epochToTime is shared with the Tempo query path, which previously used a
+// coarser variant that misread microsecond epochs as milliseconds and
+// nanosecond epochs below 1e18 as milliseconds.
+func TestEpochToTimeSharedWithTempo(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want time.Time
+	}{
+		{1785416892, time.Unix(1785416892, 0)},
+		{1785416892123, time.Unix(1785416892, 123000000)},
+		{1785416892123456, time.Unix(1785416892, 123456000)},
+		{1785416892123456789, time.Unix(0, 1785416892123456789)},
+		{999999999123456789, time.Unix(0, 999999999123456789)}, // ns epoch < 1e18
+		{0, time.Unix(0, 0)},
+	}
+	for _, c := range cases {
+		if got := epochToTime(c.in, 0); !got.Equal(c.want) {
+			t.Errorf("%d: got %v want %v", c.in, got.UTC(), c.want.UTC())
+		}
+	}
+}


### PR DESCRIPTION
Fixes #885.

### Problem

`ParseTimeSecOrRFC` (`reader/controller/utils.go`) assumes every numeric time
parameter is expressed in **seconds**. Loki clients send **nanoseconds** —
Grafana Logs Drilldown (`grafana-lokiexplore-app`) calls
`/loki/api/v1/index/volume` with ns epochs:

```
GET /loki/api/v1/index/volume?query={host_name=~".+"}&start=1785416892000000000&end=1785417792000000000&limit=3
```

`1785416892000000000` read as seconds lands around the year 56,558,000, so the
query degenerates into a full table scan and `FixPeriodPlanner` sizes a slice
from that range:

```
panic: makeslice: len out of range
  reader/plannerV2.(*FixPeriodPlanner).Process.func2
```

Measured on a small dataset: the ns request returned 200 after **39.2s** and then
killed the process; the same instant at second precision returned in **0.37s**.

### Fix

Numeric epochs are disambiguated by magnitude — seconds, milli-, micro- or
nanoseconds. The thresholds are the epoch of ~1973-03-03 expressed in each unit,
so any realistic timestamp maps to exactly one unit and the ranges never overlap.

Two details worth calling out:

- **Integer epochs are parsed with `ParseInt`, not `ParseFloat`.** Nanosecond
  epochs (~1.8e18) exceed the 53-bit mantissa of a `float64`, so a float
  round-trip silently loses sub-microsecond precision. Fractional input
  (Prometheus sends fractional seconds) still goes through `ParseFloat` +
  `math.Modf`.
- **The Tempo path already had its own `epochToTime`** in
  `reader/controller/tempo.go`, but it only handled seconds/milliseconds/ns ≥ 1e18,
  so it misread microsecond epochs as milliseconds and ns epochs below 1e18 as
  milliseconds. Both paths now share one implementation, which fixes those cases too.

The compiled regexp is also hoisted to a package-level `var` instead of being
rebuilt on every request.

### Tests

`reader/controller/utils_test.go` (new) covers each unit, fractional seconds,
sub-second milli/micro precision, exact ns round-tripping, RFC3339, the empty
default, and the previously-broken Tempo inputs.

```
$ go test ./reader/controller/ -run 'TestParseTimeSecOrRFCMagnitudes|TestEpochToTimeSharedWithTempo' -v
--- PASS: TestParseTimeSecOrRFCMagnitudes (0.00s)
--- PASS: TestEpochToTimeSharedWithTempo (0.00s)
ok  	github.com/metrico/qryn/v5/reader/controller
```

`gofmt`, `go vet ./reader/controller/` and `go build ./...` are clean.

### Verification in a real deployment

Built from `v4.3.1` + this patch and deployed to our Kubernetes cluster
(4 Gigapipe instances, ClickHouse backend). The exact request that previously
panicked now returns `200` in `0.40s` with real data, and Grafana Logs Drilldown
works end to end — `index/volume`, `detected_labels`, `detected_fields`,
`patterns` and `query_range` all answer with ns-epoch parameters, no restarts.
