### PR TITLE
fix(logql): two planner panics behind Grafana Logs Drilldown 500s

### DIFF
--- a/reader/logql/logql_transpiler/clickhouse_planner/analyze.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/analyze.go
@@ -111,7 +111,7 @@ func AnalyzeMetrics15sShortcut(script *logql_parser.LogQLScript) bool {
 	if duration.Seconds() < 15 {
 		return false
 	}
-	if lraOrUnwrap.StrSel.Pipelines != nil &&
+	if len(lraOrUnwrap.StrSel.Pipelines) > 0 &&
 		lraOrUnwrap.StrSel.Pipelines[len(lraOrUnwrap.StrSel.Pipelines)-1].Unwrap != nil {
 		return false
 	}

--- a/reader/logql/logql_transpiler/clickhouse_planner/analyze_empty_pipeline_test.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/analyze_empty_pipeline_test.go
@@ -1,0 +1,32 @@
+package clickhouse_planner
+
+import (
+	"testing"
+
+	"github.com/metrico/qryn/v5/reader/logql/logql_parser"
+)
+
+// Grafana Logs Drilldown emits `sum(count_over_time({...} | json | logfmt [1m]))`
+// (its LOG_STREAM_SELECTOR_EXPR has no `| drop __error__`). The planner cancels the
+// json+logfmt pair, leaving an empty-but-non-nil Pipelines slice; the old
+// `Pipelines != nil` guard then indexed [-1] and panicked.
+func TestAnalyzeMetrics15sShortcutEmptyPipelines(t *testing.T) {
+	for _, q := range []string{
+		`sum(count_over_time({service_name=~".+"} | json | logfmt [1m]))`,
+		`sum(rate({service_name=~".+"} | json | logfmt [5m]))`,
+	} {
+		script, err := logql_parser.Parse(q)
+		if err != nil {
+			t.Fatalf("parse %q: %v", q, err)
+		}
+		lra := findFirst[logql_parser.LRAOrUnwrap](script)
+		if lra == nil {
+			t.Fatalf("no LRAOrUnwrap in %q", q)
+		}
+		// Emulate cancelJsonAndLogFmt: pair stripped, slice non-nil but empty.
+		lra.StrSel.Pipelines = []logql_parser.StrSelectorPipeline{}
+		if !AnalyzeMetrics15sShortcut(script) {
+			t.Errorf("%q: want shortcut eligible for empty pipeline", q)
+		}
+	}
+}

--- a/reader/logql/logql_transpiler/planner.go
+++ b/reader/logql/logql_transpiler/planner.go
@@ -124,7 +124,13 @@ func Plan(script *log_parser.LogQLScript) (shared.RequestProcessorChain, error) 
 		return planBinaryExprRAM(script)
 	}
 
+	// cancelJsonAndLogFmt mutates the pipeline list, so the plan mode decided
+	// above may no longer hold: dropping a `json | logfmt` pair can remove the
+	// only stage that forced internal (Go-side) evaluation. Re-derive it, or
+	// breakScript would hand internal/planner.Plan a nil script.
 	cancelJsonAndLogFmt(script)
+	mode = decidePlanMode(script)
+
 	for _, plugin := range plugins.GetLogQLPlannerPlugins() {
 		res, err := plugin.Plan(script)
 		if err == nil {

--- a/reader/logql/logql_transpiler/planner_test.go
+++ b/reader/logql/logql_transpiler/planner_test.go
@@ -1,0 +1,32 @@
+package logql_transpiler
+
+import (
+	"testing"
+
+	log_parser "github.com/metrico/qryn/v5/reader/logql/logql_parser"
+)
+
+// Grafana Logs Drilldown always emits a chained `| json | logfmt` pipeline.
+// cancelJsonAndLogFmt strips that pair from the AST, which can turn an
+// internally-planned script into a fully ClickHouse-planned one. The plan mode
+// must therefore be re-derived after the mutation, otherwise breakScript
+// returns a nil internal script and planning dereferences it.
+func TestPlanCancelledJsonLogfmt(t *testing.T) {
+	for _, query := range []string{
+		`{service_name="tix-webhook"} | json | logfmt | drop __error__, __error_details__`,
+		`sum(count_over_time({service_name="tix-webhook"} | json | logfmt | drop __error__, __error_details__ [5m]))`,
+		`{service_name="tix-webhook"} | json | logfmt`,
+	} {
+		script, err := log_parser.Parse(query)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", query, err)
+		}
+		chain, err := Plan(script)
+		if err != nil {
+			t.Fatalf("Plan(%q): %v", query, err)
+		}
+		if len(chain) == 0 {
+			t.Fatalf("Plan(%q): empty processor chain", query)
+		}
+	}
+}


### PR DESCRIPTION
Both panics are hit by stock Grafana Logs Drilldown queries against a qryn/gigapipe Loki datasource, and both are recovered by `tamePanic` into an opaque HTTP 500.

### 1. Stale plan mode after `cancelJsonAndLogFmt`

`Plan()` computes `mode := decidePlanMode(script)` *before* `cancelJsonAndLogFmt(script)` mutates the pipeline list. When a chained `| json | logfmt` pair is cancelled, the stale mode can still be `planModeInternal`; `breakScript()` then returns a nil internal script and `internal/planner.Plan` feeds it to `shared.GetStrSelector`:

```
panic: runtime error: invalid memory address or nil pointer dereference
  shared.GetStrSelector      shared/funcs.go:63
  internal/planner.Plan      internal/planner/planner.go:14
```

Repro: `{service_name=~".+"} | json | logfmt | drop __error__`. Drilldown always emits `| json | logfmt`, so every "show logs" click 500s.

Fix: re-derive `mode` after the AST mutation.

### 2. `index out of range [-1]` in `AnalyzeMetrics15sShortcut`

`analyze.go:114` guards with `StrSel.Pipelines != nil`, but after `cancelJsonAndLogFmt` the slice is empty and non-nil, so the index computes `[-1]`:

```
panic: runtime error: index out of range [-1]
  clickhouse_planner.AnalyzeMetrics15sShortcut  analyze.go:115
```

Repro: `sum(count_over_time({service_name=~".+"} | json | logfmt [1m]))`. Drilldown's `LOG_STREAM_SELECTOR_EXPR` omits `| drop __error__`, so its histogram panel query trips this on load.

Fix: use the `len(...) > 0` idiom already used at `analyze.go:169` and `internal/planner/planner.go:165,184`.

### Tests

Two new tests, each red before its fix and green after:
- `reader/logql/logql_transpiler/planner_test.go` → `TestPlanCancelledJsonLogfmt`
- `reader/logql/logql_transpiler/clickhouse_planner/analyze_empty_pipeline_test.go` → `TestAnalyzeMetrics15sShortcutEmptyPipelines`

`go build ./...` clean, `go test ./reader/logql/...` all pass.

Related: #885 / #886 (nanosecond epoch parsing, the third Drilldown blocker).