### PR TITLE
docs: document OTLP profiles support (v5.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 - [Configuration & Docker](docs/configuration.md) — environment variables, Docker quickstart, cross-cluster setup
 - [Profiling API](docs/profiling-api.md) — profiling endpoints, DOT format export, Graphviz visualization
+- [OTLP Profiles Ingestion](docs/otlp-profiles.md) — OpenTelemetry profiles signal ingestion via `/v1development/profiles`
 - [Contributing](docs/contributing.md) — development setup, testing, CLA requirement
 - [Full Documentation](https://gigapipe.com/docs/oss) — hosted docs at gigapipe.com
 - [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/metrico/gigapipe)
@@ -158,6 +159,18 @@ This query calculates span counts for successful HTTP requests over the last hou
 > Any Pyroscope SDK client or Pyroscope compatible agent can be used with gigapipe out of the box for **continuous profiling**
 
 <img src="https://github.com/metrico/qryn/assets/1423657/0bd11ca9-a2b4-41ee-9ea1-6f21fa4077b2" width=700>
+
+#### OTLP Profiles Ingestion
+
+⚡ **gigapipe** also ingests the **OpenTelemetry profiles signal** (`profiles/v1development`) directly from OpenTelemetry collectors:
+
+```
+POST /v1development/profiles      Content-Type: application/x-protobuf
+```
+
+> 💡 _No collector code changes required — point an `otlphttp` exporter at gigapipe and profiles flow in._
+
+OTLP profiles land in the same ClickHouse `profiles` tables as Pyroscope data and are queryable through the existing Pyroscope-compatible API (flamegraph, series, stacktraces). See [docs/otlp-profiles.md](docs/otlp-profiles.md) for details.
 
 #### DOT Graph Rendering
 

--- a/docs/profiling-api.md
+++ b/docs/profiling-api.md
@@ -2,6 +2,8 @@
 
 Gigapipe implements the Pyroscope API for continuous profiling with support for querying, rendering, and exporting profile data.
 
+Profiles ingested via the [OpenTelemetry profiles signal](otlp-profiles.md) are queryable through these same endpoints — see [OTLP Profiles](#otlp-profiles) below.
+
 ## Profile Endpoints
 
 ### Profile Types
@@ -175,6 +177,43 @@ name:sample_type:sample_unit:period_type:period_unit
 ```
 process_cpu:cpu:nanoseconds:cpu:nanoseconds{service_name="my-app", env="prod"}
 ```
+
+## OTLP Profiles
+
+Beyond Pyroscope SDK clients, gigapipe ingests the OpenTelemetry profiles signal
+(`profiles/v1development`) over HTTP protobuf at `POST /v1development/profiles`.
+See [OTLP Profiles Ingestion](otlp-profiles.md) for the ingestion path and
+collector configuration. On the query side, OTLP profiles work through the same
+Pyroscope-compatible endpoints described above.
+
+### Storage
+
+OTLP profiles land in the same ClickHouse `profiles` tables as Pyroscope
+profiles. Ingested rows carry the `otel_v1development` payload type internally so
+the reader can distinguish them from native Pyroscope payloads.
+
+### Coexistence with Pyroscope profiles
+
+Because both signals share the same tables, a single query can return data
+sourced from both Pyroscope SDKs and OTLP collectors. No separate endpoint,
+datasource, or query syntax is needed — the `SelectSeries`,
+`SelectMergeStacktraces`, and `/pyroscope/render` endpoints all operate over the
+combined data.
+
+### OTLP → pprof conversion on read
+
+OTLP profiles are stored in their native OTLP encoding and converted to pprof
+on read, at query time. This keeps ingestion cheap and lets the existing
+flamegraph / series / stacktrace code paths consume OTLP and Pyroscope profiles
+identically.
+
+### Type namespace differences
+
+The `type` label for an OTLP profile is derived from the OTLP `sample_type` type
+string (e.g. `cpu`, `samples`), whereas Pyroscope profiles use their mapped
+profile types (e.g. `process_cpu`, `memory`). When querying OTLP-sourced
+profiles, match on the OTLP-derived type in the profile type ID rather than the
+Pyroscope name.
 
 ## Use Cases
 


### PR DESCRIPTION
Implements the documentation plan tracked in #883 (v5.1.0 release), covering the OTLP profiles support added in #876.

## Changes

**README.md**
- Add an OTLP Profiles Ingestion subsection under Pyroscope + Phlare, noting the `/v1development/profiles` endpoint and that OTLP profiles are queryable through the existing Pyroscope-compatible API.
- Link `docs/otlp-profiles.md` from the documentation index.

**docs/profiling-api.md**
- Add an OTLP Profiles section covering:
  - storage (`otel_v1development` payload type)
  - coexistence with Pyroscope profiles in the same ClickHouse tables
  - seamless use of the existing query/render endpoints
  - OTLP→pprof conversion on read (`otlpToPProf`, gated in `reader/service/prof.go`)
  - type-namespace differences (OTLP `sample_type` vs Pyroscope mapped types)

Docs-only change. Claims cross-checked against `shared/otlp/const.go`, `reader/service/otlp_pprof.go`, and `reader/service/prof.go`.

Closes #883