### PR TITLE
feat(writer): OTLP/gRPC ingest for traces, logs, and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Configuration & Docker](docs/configuration.md) — environment variables, Docker quickstart, cross-cluster setup
 - [Profiling API](docs/profiling-api.md) — profiling endpoints, DOT format export, Graphviz visualization
 - [OTLP Profiles Ingestion](docs/otlp-profiles.md) — OpenTelemetry profiles signal ingestion via `/v1development/profiles`
+- [OTLP over gRPC](docs/otlp-grpc.md) — OTLP/gRPC receiver (`OTLP_GRPC_ADDR`) for traces, logs, and profiles
 - [Contributing](docs/contributing.md) — development setup, testing, CLA requirement
 - [Full Documentation](https://gigapipe.com/docs/oss) — hosted docs at gigapipe.com
 - [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/metrico/gigapipe)

--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -419,7 +419,13 @@ func httpStart(server *mux.Router, httpURL string, mode string) {
 		logger.Error("HTTP server shutdown error:", err)
 	}
 	if grpcServer != nil {
-		grpcServer.GracefulStop()
+		stopped := make(chan struct{})
+		go func() { grpcServer.GracefulStop(); close(stopped) }()
+		select {
+		case <-stopped:
+		case <-time.After(shutdownTimeout):
+			grpcServer.Stop()
+		}
 	}
 
 	// 2. Stop the ruler (cancels evaluation loops, waits for in-flight evals).

--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/metrico/qryn/v5/shared/distconfig"
 	"github.com/metrico/qryn/v5/view"
 	"github.com/metrico/qryn/v5/writer"
+	writergrpc "github.com/metrico/qryn/v5/writer/grpc"
 )
 
 var appFlags CommandLineFlags
@@ -397,6 +398,14 @@ func httpStart(server *mux.Router, httpURL string, mode string) {
 
 	logger.Info("Server is listening on", httpURL)
 
+	// Start the OTLP gRPC receiver. Returns (nil, nil) when OTLP_GRPC_ADDR is
+	// empty, leaving existing behavior unchanged (no listener opened).
+	grpcServer, err := writergrpc.Start(os.Getenv("OTLP_GRPC_ADDR"))
+	if err != nil {
+		logger.Error("Error starting OTLP gRPC receiver:", err)
+		panic(err)
+	}
+
 	// Block until SIGTERM or SIGINT.
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
@@ -408,6 +417,9 @@ func httpStart(server *mux.Router, httpURL string, mode string) {
 	defer cancel()
 	if err := httpServer.Shutdown(ctx); err != nil {
 		logger.Error("HTTP server shutdown error:", err)
+	}
+	if grpcServer != nil {
+		grpcServer.GracefulStop()
 	}
 
 	// 2. Stop the ruler (cancels evaluation loops, waits for in-flight evals).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,10 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 - **`HOST`** - HTTP server bind address (default: `0.0.0.0`)
 - **`CORS_ALLOW_ORIGIN`** - Enable CORS and set allowed origin (e.g., `https://example.com`)
 
+## OTLP Ingestion
+
+- **`OTLP_GRPC_ADDR`** - Address for the OTLP/gRPC receiver (e.g. `:4317`, the OTel-convention gRPC port). When set, gigapipe accepts OTLP over gRPC in addition to the existing OTLP/HTTP endpoints. Unset or empty disables the receiver (default: off) and leaves existing behavior unchanged. Supports traces, logs, and profiles. See [OTLP over gRPC](otlp-grpc.md).
+
 ## Write Settings
 
 - **`BULK_MAX_SIZE_BYTES`** - Maximum batch size in bytes before flushing to ClickHouse

--- a/docs/otlp-grpc.md
+++ b/docs/otlp-grpc.md
@@ -1,0 +1,66 @@
+# OTLP over gRPC
+
+gigapipe accepts OpenTelemetry (OTLP) data over **gRPC** in addition to the
+existing OTLP/HTTP endpoints. The gRPC receiver is disabled by default and is
+enabled by setting the `OTLP_GRPC_ADDR` environment variable.
+
+## Enabling the receiver
+
+Set `OTLP_GRPC_ADDR` to a listen address. `4317` is the OTel-convention gRPC
+port; OTLP/HTTP continues to be served on the existing HTTP port (`PORT`,
+default `3100`).
+
+```bash
+OTLP_GRPC_ADDR=:4317
+```
+
+When `OTLP_GRPC_ADDR` is unset or empty the receiver is not started, no listener
+is opened, and existing behavior is unchanged.
+
+## Supported signals
+
+| Signal    | OTLP/gRPC | OTLP/HTTP |
+|-----------|-----------|-----------|
+| Traces    | ✅        | ✅        |
+| Logs      | ✅        | ✅        |
+| Profiles  | ✅        | ✅ (`/v1development/profiles`) |
+
+## Multitenancy and per-request options
+
+The tenant and per-request options are selected via gRPC metadata, mirroring the
+equivalent OTLP/HTTP headers:
+
+| gRPC metadata key | HTTP header       | Purpose                                          |
+|-------------------|-------------------|--------------------------------------------------|
+| `x-ch-dsn`        | `X-CH-DSN`        | Selects the tenant (ClickHouse DSN)              |
+| `x-scope-meta`    | `X-Scope-Meta`    | Scope metadata                                   |
+| `x-ttl-days`      | `X-Ttl-Days`      | Per-request TTL in days                          |
+| `x-async-insert`  | `X-Async-Insert`  | Insert mode: `1` async, `0` sync, otherwise default |
+
+## Routing via an OpenTelemetry Collector
+
+A collector can export to the gigapipe gRPC receiver with `otlp` (gRPC) instead
+of, or alongside, `otlphttp`:
+
+```yaml
+exporters:
+  otlp:
+    endpoint: <gigapipe-writer-host>:4317
+    headers:
+      x-ch-dsn: <tenant-dsn>
+service:
+  pipelines:
+    traces:
+      receivers:  [otlp]
+      exporters:  [otlp]
+    logs:
+      receivers:  [otlp]
+      exporters:  [otlp]
+```
+
+For profiles specifically, see [OTLP Profiles Ingestion](otlp-profiles.md).
+
+## Graceful shutdown
+
+On `SIGTERM`/`SIGINT` the gRPC receiver drains in-flight requests alongside the
+HTTP server during graceful shutdown.

--- a/docs/otlp-grpc.md
+++ b/docs/otlp-grpc.md
@@ -35,7 +35,6 @@ equivalent OTLP/HTTP headers:
 | `x-ch-dsn`        | `X-CH-DSN`        | Selects the tenant (ClickHouse DSN)              |
 | `x-scope-meta`    | `X-Scope-Meta`    | Scope metadata                                   |
 | `x-ttl-days`      | `X-Ttl-Days`      | Per-request TTL in days                          |
-| `x-async-insert`  | `X-Async-Insert`  | Insert mode: `1` async, `0` sync, otherwise default |
 
 ## Routing via an OpenTelemetry Collector
 

--- a/docs/otlp-profiles.md
+++ b/docs/otlp-profiles.md
@@ -10,6 +10,10 @@ Only the protobuf encoding is supported. Requests with
 A successful request returns `200 OK`; a request that carries no profiles is a
 no-op that still returns `200 OK`.
 
+Profiles can also be ingested over **OTLP/gRPC** when the receiver is enabled via
+`OTLP_GRPC_ADDR`. See [OTLP over gRPC](otlp-grpc.md) for the gRPC transport,
+supported signals, and tenant metadata keys.
+
 ## Routing via an OpenTelemetry Collector
 
 No collector code changes are required; a profiles-capable collector

--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.11 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -546,6 +546,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.11 h1:el5LYpXissAiCKZ5/6yjlr6mh
 github.com/grafana/pyroscope-go/godeltaprof v0.1.11/go.mod h1:jl1V8M4cWsXciROCPIDDG7CtjSjT/ECbp6eLVuMxYRI=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7EAJ0BHIethd+J6LqxFNw5mSiI2bM=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/consul/api v1.34.4 h1:0U4YZ1Yp7K9WK9ex0gTJraFim26l02wCvsmf2ukalVE=
 github.com/hashicorp/consul/api v1.34.4/go.mod h1:vz5gBNeycefpAAVNVbLBFObUu3isju6EK8UVZjXSTWc=
 github.com/hashicorp/cronexpr v1.1.3 h1:rl5IkxXN2m681EfivTlccqIryzYJSXRGRNa0xeG7NA4=

--- a/writer/controller/builder.go
+++ b/writer/controller/builder.go
@@ -198,19 +198,13 @@ func doLogsPattern(s *model.TimeSamplesData) {
 	controller.ClusterLines(s.MMessage, s.MFingerprint, s.MTimestampNS)
 }
 
-func doParse(r *http.Request, parser Parser) error {
-	reader := getBodyStream(r)
-	tsService := getService(r, utils.ContextKeyTsService)
-	splService := getService(r, utils.ContextKeySplService)
-	spanAttrsService := getService(r, utils.ContextKeySpanAttrsService)
-	spansService := getService(r, utils.ContextKeySpansService)
-	profileService := getService(r, utils.ContextKeyProfileService)
-	node := r.Context().Value(utils.ContextKeyNode).(string)
-
-	//var promises []chan error
+// IngestParsed runs parser and pushes each ParserResponse to the given
+// per-tenant insert services. It is the transport-agnostic core shared by the
+// HTTP handlers and the gRPC receiver.
+func IngestParsed(ctx context.Context, parser Parser, svcs InsertServices) error {
+	fpNode := FPCache.DB(svcs.Node)
 	var promises []*promise.Promise[uint32]
-	var err error = nil
-	res := parser(r.Context(), reader, FPCache.DB(node))
+	res := parser(ctx, nil, fpNode)
 	for response := range res {
 		if response.Error != nil {
 			go func() {
@@ -219,23 +213,37 @@ func doParse(r *http.Request, parser Parser) error {
 			}()
 			return response.Error
 		}
-
 		promises = append(promises,
-			doPush(response.TimeSeriesRequest, service.INSERT_MODE_SYNC, tsService),
-			doPush(response.SamplesRequest, service.INSERT_MODE_SYNC, splService),
-			doPush(response.SpansAttrsRequest, service.INSERT_MODE_SYNC, spanAttrsService),
-			doPush(response.SpansRequest, service.INSERT_MODE_SYNC, spansService),
-			doPush(response.ProfileRequest, service.INSERT_MODE_SYNC, profileService),
+			doPush(response.TimeSeriesRequest, service.INSERT_MODE_SYNC, svcs.Ts),
+			doPush(response.SamplesRequest, service.INSERT_MODE_SYNC, svcs.Spl),
+			doPush(response.SpansAttrsRequest, service.INSERT_MODE_SYNC, svcs.SpanAttrs),
+			doPush(response.SpansRequest, service.INSERT_MODE_SYNC, svcs.Spans),
+			doPush(response.ProfileRequest, service.INSERT_MODE_SYNC, svcs.Profile),
 		)
 		if response.SamplesRequest != nil {
 			doLogsPattern(response.SamplesRequest.(*model.TimeSamplesData))
 		}
 	}
 	for _, p := range promises {
-		_, err = p.Get()
-		if err != nil {
+		if _, err := p.Get(); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func doParse(r *http.Request, parser Parser) error {
+	svcs := InsertServices{
+		Ts:        getService(r, utils.ContextKeyTsService),
+		Spl:       getService(r, utils.ContextKeySplService),
+		SpanAttrs: getService(r, utils.ContextKeySpanAttrsService),
+		Spans:     getService(r, utils.ContextKeySpansService),
+		Profile:   getService(r, utils.ContextKeyProfileService),
+		Node:      r.Context().Value(utils.ContextKeyNode).(string),
+	}
+	reader := getBodyStream(r)
+	bound := func(ctx context.Context, _ io.Reader, fp numbercache.ICache[uint64]) chan *model.ParserResponse {
+		return parser(ctx, reader, fp)
+	}
+	return IngestParsed(r.Context(), bound, svcs)
 }

--- a/writer/controller/ingest_test.go
+++ b/writer/controller/ingest_test.go
@@ -2,27 +2,81 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
 
+	clconfig "github.com/metrico/cloki-config"
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/writer/config"
 	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/helpers"
 	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+	"github.com/metrico/qryn/v5/writer/utils/promise"
 )
 
-func TestIngestParsed_EmptyParserReturnsNil(t *testing.T) {
-	// IngestParsed resolves a per-node fingerprint cache via FPCache.DB(node)
-	// before running the parser, so the test needs a real (if trivial) cache
-	// registered for the node under test.
+// installConfig sets a minimal global config so doPush can read retry settings
+// (config.Cloki.Setting.SYSTEM_SETTINGS) without a nil-pointer panic. One retry
+// attempt with no delay keeps the push path fast and deterministic.
+func installConfig(t *testing.T) {
+	t.Helper()
+	old := config.Cloki
+	setting := &clokiconfig.ClokiBaseSettingServer{}
+	setting.SYSTEM_SETTINGS.RetryAttempts = 1
+	setting.SYSTEM_SETTINGS.RetryTimeoutS = 0
+	config.Cloki = &clconfig.ClokiConfig{Setting: setting}
+	t.Cleanup(func() { config.Cloki = old })
+}
+
+// installFPCache registers a trivial per-node fingerprint cache for the node
+// under test and restores the previous global on cleanup. IngestParsed resolves
+// FPCache.DB(node) before running the parser, so a real (if trivial) cache must
+// exist for the node.
+func installFPCache(t *testing.T, node string) {
+	t.Helper()
 	old := FPCache
 	FPCache = numbercache.NewCache(time.Minute, func(val uint64) []byte {
 		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
-	}, map[string]*model.DataDatabasesMap{"n": {}})
-	defer func() {
+	}, map[string]*model.DataDatabasesMap{node: {}})
+	t.Cleanup(func() {
 		FPCache.Stop()
 		FPCache = old
-	}()
+	})
+}
+
+// recorderSvc is a minimal IInsertServiceV2 that records every request routed
+// to it and returns an already-fulfilled promise so doPush completes at once.
+type recorderSvc struct {
+	mu       sync.Mutex
+	received []helpers.SizeGetter
+}
+
+func (r *recorderSvc) Request(req helpers.SizeGetter, insertMode int) *promise.Promise[uint32] {
+	r.mu.Lock()
+	r.received = append(r.received, req)
+	r.mu.Unlock()
+	return promise.Fulfilled[uint32](nil, 0)
+}
+
+func (r *recorderSvc) reqs() []helpers.SizeGetter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]helpers.SizeGetter(nil), r.received...)
+}
+
+func (r *recorderSvc) Run()                        {}
+func (r *recorderSvc) Stop()                       {}
+func (r *recorderSvc) Ping() (time.Time, error)    { return time.Time{}, nil }
+func (r *recorderSvc) GetState(insertMode int) int { return 0 }
+func (r *recorderSvc) GetNodeName() string         { return "n" }
+func (r *recorderSvc) Init()                       {}
+func (r *recorderSvc) PlanFlush()                  {}
+
+func TestIngestParsed_EmptyParserReturnsNil(t *testing.T) {
+	installFPCache(t, "n")
 
 	// A parser that emits no responses must complete without error and
 	// without touching any (nil) service.
@@ -34,5 +88,117 @@ func TestIngestParsed_EmptyParserReturnsNil(t *testing.T) {
 	err := IngestParsed(context.Background(), parser, InsertServices{Node: "n"})
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestIngestParsed_PushRouting proves the field->service mapping: each
+// ParserResponse sub-request is pushed to its matching service and ONLY that
+// service, for ALL FIVE slots:
+//
+//	TimeSeriesRequest -> Ts
+//	SamplesRequest    -> Spl
+//	SpansAttrsRequest -> SpanAttrs
+//	SpansRequest      -> Spans
+//	ProfileRequest    -> Profile
+//
+// Every slot carries a distinct recognizable value and each recorder must see
+// exactly its own request and no other. This guards against any cross-wiring
+// (e.g. a Ts<->Spl or SpanAttrs<->Spans swap) in any slot.
+func TestIngestParsed_PushRouting(t *testing.T) {
+	installFPCache(t, "n")
+	installConfig(t)
+
+	// SamplesRequest MUST be a *model.TimeSamplesData: IngestParsed casts it in
+	// doLogsPattern. The other four only need to be SizeGetters; distinct
+	// *model.TimeSamplesData pointers give recognizable identities to assert on.
+	tsReq := &model.TimeSamplesData{Size: 10}
+	samplesReq := &model.TimeSamplesData{Size: 20}
+	spanAttrsReq := &model.TimeSamplesData{Size: 30}
+	spansReq := &model.TimeSamplesData{Size: 40}
+	profileReq := &model.TimeSamplesData{Size: 50}
+
+	parser := func(_ context.Context, _ io.Reader, _ numbercache.ICache[uint64]) chan *model.ParserResponse {
+		ch := make(chan *model.ParserResponse, 1)
+		ch <- &model.ParserResponse{
+			TimeSeriesRequest: tsReq,
+			SamplesRequest:    samplesReq,
+			SpansAttrsRequest: spanAttrsReq,
+			SpansRequest:      spansReq,
+			ProfileRequest:    profileReq,
+		}
+		close(ch)
+		return ch
+	}
+
+	ts := &recorderSvc{}
+	spl := &recorderSvc{}
+	spanAttrs := &recorderSvc{}
+	spans := &recorderSvc{}
+	profile := &recorderSvc{}
+
+	err := IngestParsed(context.Background(), parser, InsertServices{
+		Ts:        ts,
+		Spl:       spl,
+		SpanAttrs: spanAttrs,
+		Spans:     spans,
+		Profile:   profile,
+		Node:      "n",
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// Each recorder must have received exactly its own request and only that.
+	cases := []struct {
+		name string
+		svc  *recorderSvc
+		want helpers.SizeGetter
+	}{
+		{"Ts", ts, tsReq},
+		{"Spl", spl, samplesReq},
+		{"SpanAttrs", spanAttrs, spanAttrsReq},
+		{"Spans", spans, spansReq},
+		{"Profile", profile, profileReq},
+	}
+	for _, c := range cases {
+		got := c.svc.reqs()
+		if len(got) != 1 || got[0] != c.want {
+			t.Fatalf("%s: expected exactly [%p], got %v", c.name, c.want, got)
+		}
+	}
+}
+
+// TestIngestParsed_ErrorPath proves that a ParserResponse carrying an Error is
+// returned verbatim, and that trailing responses on the channel are drained so
+// the parser goroutine cannot deadlock. The overall test timeout guards against
+// a hang.
+func TestIngestParsed_ErrorPath(t *testing.T) {
+	installFPCache(t, "n")
+
+	wantErr := errors.New("boom")
+
+	parser := func(_ context.Context, _ io.Reader, _ numbercache.ICache[uint64]) chan *model.ParserResponse {
+		// Buffered + trailing responses: IngestParsed returns on the first
+		// error but must drain the rest without blocking the sender.
+		ch := make(chan *model.ParserResponse, 3)
+		ch <- &model.ParserResponse{Error: wantErr}
+		ch <- &model.ParserResponse{SamplesRequest: &model.TimeSamplesData{Size: 1}}
+		ch <- &model.ParserResponse{SpansRequest: &model.TimeSamplesData{Size: 2}}
+		close(ch)
+		return ch
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- IngestParsed(context.Background(), parser, InsertServices{Node: "n"})
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected %v, got %v", wantErr, err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("IngestParsed did not return within timeout (possible deadlock)")
 	}
 }

--- a/writer/controller/ingest_test.go
+++ b/writer/controller/ingest_test.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+)
+
+func TestIngestParsed_EmptyParserReturnsNil(t *testing.T) {
+	// IngestParsed resolves a per-node fingerprint cache via FPCache.DB(node)
+	// before running the parser, so the test needs a real (if trivial) cache
+	// registered for the node under test.
+	old := FPCache
+	FPCache = numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, map[string]*model.DataDatabasesMap{"n": {}})
+	defer func() {
+		FPCache.Stop()
+		FPCache = old
+	}()
+
+	// A parser that emits no responses must complete without error and
+	// without touching any (nil) service.
+	parser := func(_ context.Context, _ io.Reader, _ numbercache.ICache[uint64]) chan *model.ParserResponse {
+		ch := make(chan *model.ParserResponse)
+		close(ch)
+		return ch
+	}
+	err := IngestParsed(context.Background(), parser, InsertServices{Node: "n"})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}

--- a/writer/controller/middleware.go
+++ b/writer/controller/middleware.go
@@ -215,16 +215,27 @@ var withTSAndSampleService = WithPreRequest(func(w http.ResponseWriter, r *http.
 
 	ctx := r.Context()
 	dsn := ctx.Value(utils.ContextKeyDSN)
-
-	svcs, err := ResolveInsertServices(dsn.(string))
+	//// Assuming Registry functions are available and compatible with net/http
+	svc, err := Registry.GetSamplesService(dsn.(string))
 	if err != nil {
 		return err
 	}
+	ctx = context.WithValue(r.Context(), utils.ContextKeySplService, svc)
 
-	ctx = context.WithValue(ctx, utils.ContextKeySplService, svcs.Spl)
-	ctx = context.WithValue(ctx, utils.ContextKeyTsService, svcs.Ts)
-	ctx = context.WithValue(ctx, utils.ContextKeyProfileService, svcs.Profile)
-	ctx = context.WithValue(ctx, utils.ContextKeyNode, svcs.Profile.GetNodeName())
+	svc, err = Registry.GetTimeSeriesService(dsn.(string))
+	if err != nil {
+		return err
+	}
+	ctx = context.WithValue(ctx, utils.ContextKeyTsService, svc)
+
+	svc, err = Registry.GetProfileInsertService(dsn.(string))
+	if err != nil {
+		return err
+	}
+	ctx = context.WithValue(ctx, utils.ContextKeyProfileService, svc)
+
+	nodeName := svc.GetNodeName()
+	ctx = context.WithValue(ctx, utils.ContextKeyNode, nodeName)
 	*r = *r.WithContext(ctx)
 	return nil
 })
@@ -232,16 +243,23 @@ var withTSAndSampleService = WithPreRequest(func(w http.ResponseWriter, r *http.
 var withTracesService = WithPreRequest(func(w http.ResponseWriter, r *http.Request) error {
 	dsn := r.Context().Value(utils.ContextKeyDSN)
 
-	svcs, err := ResolveInsertServices(dsn.(string))
+	// Get spans attributes service
+	spanAttrsSvc, err := Registry.GetSpansSeriesService(dsn.(string))
 	if err != nil {
-		return fmt.Errorf("failed to resolve insert services: %v", err)
+		return fmt.Errorf("failed to get spans attributes service: %v", err)
+	}
+
+	// Get spans service
+	spansSvc, err := Registry.GetSpansService(dsn.(string))
+	if err != nil {
+		return fmt.Errorf("failed to get spans service: %v", err)
 	}
 
 	// Update context with both services
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, utils.ContextKeySpanAttrsService, svcs.SpanAttrs)
-	ctx = context.WithValue(ctx, utils.ContextKeySpansService, svcs.Spans)
-	ctx = context.WithValue(ctx, utils.ContextKeyNode, svcs.Spans.GetNodeName())
+	ctx = context.WithValue(ctx, utils.ContextKeySpanAttrsService, spanAttrsSvc)
+	ctx = context.WithValue(ctx, utils.ContextKeySpansService, spansSvc)
+	ctx = context.WithValue(ctx, utils.ContextKeyNode, spansSvc.GetNodeName())
 
 	// Update request context
 	*r = *r.WithContext(ctx)

--- a/writer/controller/middleware.go
+++ b/writer/controller/middleware.go
@@ -215,27 +215,16 @@ var withTSAndSampleService = WithPreRequest(func(w http.ResponseWriter, r *http.
 
 	ctx := r.Context()
 	dsn := ctx.Value(utils.ContextKeyDSN)
-	//// Assuming Registry functions are available and compatible with net/http
-	svc, err := Registry.GetSamplesService(dsn.(string))
+
+	svcs, err := ResolveInsertServices(dsn.(string))
 	if err != nil {
 		return err
 	}
-	ctx = context.WithValue(r.Context(), utils.ContextKeySplService, svc)
 
-	svc, err = Registry.GetTimeSeriesService(dsn.(string))
-	if err != nil {
-		return err
-	}
-	ctx = context.WithValue(ctx, utils.ContextKeyTsService, svc)
-
-	svc, err = Registry.GetProfileInsertService(dsn.(string))
-	if err != nil {
-		return err
-	}
-	ctx = context.WithValue(ctx, utils.ContextKeyProfileService, svc)
-
-	nodeName := svc.GetNodeName()
-	ctx = context.WithValue(ctx, utils.ContextKeyNode, nodeName)
+	ctx = context.WithValue(ctx, utils.ContextKeySplService, svcs.Spl)
+	ctx = context.WithValue(ctx, utils.ContextKeyTsService, svcs.Ts)
+	ctx = context.WithValue(ctx, utils.ContextKeyProfileService, svcs.Profile)
+	ctx = context.WithValue(ctx, utils.ContextKeyNode, svcs.Profile.GetNodeName())
 	*r = *r.WithContext(ctx)
 	return nil
 })
@@ -243,23 +232,16 @@ var withTSAndSampleService = WithPreRequest(func(w http.ResponseWriter, r *http.
 var withTracesService = WithPreRequest(func(w http.ResponseWriter, r *http.Request) error {
 	dsn := r.Context().Value(utils.ContextKeyDSN)
 
-	// Get spans attributes service
-	spanAttrsSvc, err := Registry.GetSpansSeriesService(dsn.(string))
+	svcs, err := ResolveInsertServices(dsn.(string))
 	if err != nil {
-		return fmt.Errorf("failed to get spans attributes service: %v", err)
-	}
-
-	// Get spans service
-	spansSvc, err := Registry.GetSpansService(dsn.(string))
-	if err != nil {
-		return fmt.Errorf("failed to get spans service: %v", err)
+		return fmt.Errorf("failed to resolve insert services: %v", err)
 	}
 
 	// Update context with both services
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, utils.ContextKeySpanAttrsService, spanAttrsSvc)
-	ctx = context.WithValue(ctx, utils.ContextKeySpansService, spansSvc)
-	ctx = context.WithValue(ctx, utils.ContextKeyNode, spansSvc.GetNodeName())
+	ctx = context.WithValue(ctx, utils.ContextKeySpanAttrsService, svcs.SpanAttrs)
+	ctx = context.WithValue(ctx, utils.ContextKeySpansService, svcs.Spans)
+	ctx = context.WithValue(ctx, utils.ContextKeyNode, svcs.Spans.GetNodeName())
 
 	// Update request context
 	*r = *r.WithContext(ctx)

--- a/writer/controller/services.go
+++ b/writer/controller/services.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/metrico/qryn/v5/writer/service"
+)
+
+// InsertServices bundles the per-tenant insert services the OTLP write path
+// needs. It is the single source of these lookups for both the HTTP
+// middleware and the gRPC receiver.
+type InsertServices struct {
+	Ts        service.IInsertServiceV2
+	Spl       service.IInsertServiceV2
+	SpanAttrs service.IInsertServiceV2
+	Spans     service.IInsertServiceV2
+	Profile   service.IInsertServiceV2
+	Node      string
+}
+
+// ResolveInsertServices looks up all insert services for a tenant DSN.
+func ResolveInsertServices(dsn string) (InsertServices, error) {
+	var s InsertServices
+	if Registry == nil {
+		return s, fmt.Errorf("service registry not initialized")
+	}
+	var err error
+	if s.Spl, err = Registry.GetSamplesService(dsn); err != nil {
+		return s, err
+	}
+	if s.Ts, err = Registry.GetTimeSeriesService(dsn); err != nil {
+		return s, err
+	}
+	if s.Profile, err = Registry.GetProfileInsertService(dsn); err != nil {
+		return s, err
+	}
+	if s.SpanAttrs, err = Registry.GetSpansSeriesService(dsn); err != nil {
+		return s, err
+	}
+	if s.Spans, err = Registry.GetSpansService(dsn); err != nil {
+		return s, err
+	}
+	s.Node = s.Spans.GetNodeName()
+	return s, nil
+}

--- a/writer/controller/services.go
+++ b/writer/controller/services.go
@@ -6,9 +6,10 @@ import (
 	"github.com/metrico/qryn/v5/writer/service"
 )
 
-// InsertServices bundles the per-tenant insert services the OTLP write path
-// needs. It is the single source of these lookups for both the HTTP
-// middleware and the gRPC receiver.
+// InsertServices bundles per-tenant insert services. Only the fields a given
+// signal needs are populated; the rest stay nil (IngestParsed/doPush are
+// nil-safe). SIGNAL ISOLATION: each signal resolves ONLY its own services —
+// logs never resolve spans services, traces never resolve samples, etc.
 type InsertServices struct {
 	Ts        service.IInsertServiceV2
 	Spl       service.IInsertServiceV2
@@ -18,8 +19,25 @@ type InsertServices struct {
 	Node      string
 }
 
-// ResolveInsertServices looks up all insert services for a tenant DSN.
-func ResolveInsertServices(dsn string) (InsertServices, error) {
+// ResolveTraceServices resolves only the trace insert services for a tenant.
+func ResolveTraceServices(dsn string) (InsertServices, error) {
+	var s InsertServices
+	if Registry == nil {
+		return s, fmt.Errorf("service registry not initialized")
+	}
+	var err error
+	if s.SpanAttrs, err = Registry.GetSpansSeriesService(dsn); err != nil {
+		return s, err
+	}
+	if s.Spans, err = Registry.GetSpansService(dsn); err != nil {
+		return s, err
+	}
+	s.Node = s.Spans.GetNodeName()
+	return s, nil
+}
+
+// ResolveLogServices resolves only the log insert services for a tenant.
+func ResolveLogServices(dsn string) (InsertServices, error) {
 	var s InsertServices
 	if Registry == nil {
 		return s, fmt.Errorf("service registry not initialized")
@@ -31,15 +49,20 @@ func ResolveInsertServices(dsn string) (InsertServices, error) {
 	if s.Ts, err = Registry.GetTimeSeriesService(dsn); err != nil {
 		return s, err
 	}
+	s.Node = s.Spl.GetNodeName()
+	return s, nil
+}
+
+// ResolveProfileServices resolves only the profile insert service for a tenant.
+func ResolveProfileServices(dsn string) (InsertServices, error) {
+	var s InsertServices
+	if Registry == nil {
+		return s, fmt.Errorf("service registry not initialized")
+	}
+	var err error
 	if s.Profile, err = Registry.GetProfileInsertService(dsn); err != nil {
 		return s, err
 	}
-	if s.SpanAttrs, err = Registry.GetSpansSeriesService(dsn); err != nil {
-		return s, err
-	}
-	if s.Spans, err = Registry.GetSpansService(dsn); err != nil {
-		return s, err
-	}
-	s.Node = s.Spans.GetNodeName()
+	s.Node = s.Profile.GetNodeName()
 	return s, nil
 }

--- a/writer/controller/services_test.go
+++ b/writer/controller/services_test.go
@@ -2,13 +2,16 @@ package controller
 
 import "testing"
 
-func TestResolveInsertServices_RequiresRegistry(t *testing.T) {
-	// With a nil Registry the resolver must return an error, not panic.
+func TestResolveServices_RequireRegistry(t *testing.T) {
+	// With a nil Registry each resolver must return an error, not panic.
 	old := Registry
 	Registry = nil
 	defer func() { Registry = old; _ = recover() }()
-	_, err := ResolveInsertServices("dsn")
-	if err == nil {
-		t.Fatal("expected error when Registry is nil")
+	for _, fn := range []func(string) (InsertServices, error){
+		ResolveTraceServices, ResolveLogServices, ResolveProfileServices,
+	} {
+		if _, err := fn("dsn"); err == nil {
+			t.Fatal("expected error when Registry is nil")
+		}
 	}
 }

--- a/writer/controller/services_test.go
+++ b/writer/controller/services_test.go
@@ -6,7 +6,7 @@ func TestResolveServices_RequireRegistry(t *testing.T) {
 	// With a nil Registry each resolver must return an error, not panic.
 	old := Registry
 	Registry = nil
-	defer func() { Registry = old; _ = recover() }()
+	defer func() { Registry = old }()
 	for _, fn := range []func(string) (InsertServices, error){
 		ResolveTraceServices, ResolveLogServices, ResolveProfileServices,
 	} {

--- a/writer/controller/services_test.go
+++ b/writer/controller/services_test.go
@@ -1,0 +1,14 @@
+package controller
+
+import "testing"
+
+func TestResolveInsertServices_RequiresRegistry(t *testing.T) {
+	// With a nil Registry the resolver must return an error, not panic.
+	old := Registry
+	Registry = nil
+	defer func() { Registry = old; _ = recover() }()
+	_, err := ResolveInsertServices("dsn")
+	if err == nil {
+		t.Fatal("expected error when Registry is nil")
+	}
+}

--- a/writer/grpc/integration_test.go
+++ b/writer/grpc/integration_test.go
@@ -1,0 +1,213 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	clconfig "github.com/metrico/cloki-config"
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/writer/config"
+	"github.com/metrico/qryn/v5/writer/controller"
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/service"
+	"github.com/metrico/qryn/v5/writer/utils/helpers"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+	"github.com/metrico/qryn/v5/writer/utils/promise"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// recorderSvc is a minimal IInsertServiceV2 that records every request routed to
+// it and returns an already-fulfilled promise so doPush completes at once. It
+// mirrors the recorder in writer/controller/ingest_test.go (that file is package
+// controller and cannot be imported here).
+type recorderSvc struct {
+	node     string
+	mu       sync.Mutex
+	received []helpers.SizeGetter
+}
+
+func (r *recorderSvc) Request(req helpers.SizeGetter, insertMode int) *promise.Promise[uint32] {
+	r.mu.Lock()
+	r.received = append(r.received, req)
+	r.mu.Unlock()
+	return promise.Fulfilled[uint32](nil, 0)
+}
+
+func (r *recorderSvc) reqs() []helpers.SizeGetter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]helpers.SizeGetter(nil), r.received...)
+}
+
+func (r *recorderSvc) Run()                     {}
+func (r *recorderSvc) Stop()                    {}
+func (r *recorderSvc) Ping() (time.Time, error) { return time.Time{}, nil }
+func (r *recorderSvc) GetState(insertMode int) int {
+	return service.INSERT_STATE_IDLE
+}
+func (r *recorderSvc) GetNodeName() string {
+	if r.node != "" {
+		return r.node
+	}
+	return "n"
+}
+func (r *recorderSvc) Init()      {}
+func (r *recorderSvc) PlanFlush() {}
+
+// fakeRegistry is an in-memory registry.ServiceRegistry test double. For traces,
+// ResolveTraceServices reads GetSpansSeriesService (SpanAttrs slot) and
+// GetSpansService (Spans slot); every other method exists only to satisfy the
+// interface and returns nil.
+type fakeRegistry struct {
+	spans     *recorderSvc
+	spanAttrs *recorderSvc
+}
+
+func (f *fakeRegistry) GetTimeSeriesService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *fakeRegistry) GetSamplesService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *fakeRegistry) GetMetricsService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *fakeRegistry) GetSpansService(id string) (service.IInsertServiceV2, error) {
+	return f.spans, nil
+}
+func (f *fakeRegistry) GetSpansSeriesService(id string) (service.IInsertServiceV2, error) {
+	return f.spanAttrs, nil
+}
+func (f *fakeRegistry) GetProfileInsertService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *fakeRegistry) GetPatternInsertService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *fakeRegistry) Run()  {}
+func (f *fakeRegistry) Stop() {}
+
+// installFakeRegistry installs a fakeRegistry (save/restore) whose trace insert
+// services record pushed rows, and returns the spans recorder to assert on.
+func installFakeRegistry(t *testing.T) *recorderSvc {
+	t.Helper()
+	spans := &recorderSvc{node: "n"}
+	fr := &fakeRegistry{spans: spans, spanAttrs: &recorderSvc{node: "n"}}
+	old := controller.Registry
+	controller.Registry = fr
+	t.Cleanup(func() { controller.Registry = old })
+	return spans
+}
+
+// installFPCache registers a trivial per-node fingerprint cache for node "n" and
+// restores the previous global on cleanup. IngestParsed resolves FPCache.DB(node)
+// before running the parser, so a real (if trivial) cache must exist.
+func installFPCache(t *testing.T, node string) {
+	t.Helper()
+	old := controller.FPCache
+	controller.FPCache = numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, map[string]*model.DataDatabasesMap{node: {}})
+	t.Cleanup(func() {
+		controller.FPCache.Stop()
+		controller.FPCache = old
+	})
+}
+
+// installConfig sets a minimal global config so doPush can read retry settings
+// without a nil-pointer panic. One retry attempt with no delay keeps the push
+// path fast and deterministic.
+func installConfig(t *testing.T) {
+	t.Helper()
+	old := config.Cloki
+	setting := &clokiconfig.ClokiBaseSettingServer{}
+	setting.SYSTEM_SETTINGS.RetryAttempts = 1
+	setting.SYSTEM_SETTINGS.RetryTimeoutS = 0
+	config.Cloki = &clconfig.ClokiConfig{Setting: setting}
+	t.Cleanup(func() { config.Cloki = old })
+}
+
+// sampleTraceRequest builds an ExportTraceServiceRequest carrying one span under
+// one resource (service.name=svc) and one scope. TraceId is 16 bytes, SpanId 8.
+func sampleTraceRequest() *coltracepb.ExportTraceServiceRequest {
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{
+			Resource: &resourcev1.Resource{Attributes: []*commonv1.KeyValue{{
+				Key:   "service.name",
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "svc"}},
+			}}},
+			ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{{
+				Name:    "op",
+				TraceId: []byte("0123456789abcdef"),
+				SpanId:  []byte("01234567"),
+			}}}},
+		}},
+	}
+}
+
+// TestGRPCTraces_EndToEnd drives the OTLP gRPC TraceService over an in-memory
+// bufconn connection and asserts a span row reaches the insert layer (the Spans
+// recorder receives at least one pushed request).
+func TestGRPCTraces_EndToEnd(t *testing.T) {
+	spans := installFakeRegistry(t)
+	installFPCache(t, "n")
+	installConfig(t)
+
+	lis := bufconn.Listen(1 << 20)
+	srv := NewServer()
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-ch-dsn", "test-dsn")
+	client := coltracepb.NewTraceServiceClient(conn)
+	if _, err := client.Export(ctx, sampleTraceRequest()); err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+
+	// IngestParsed pushes synchronously within Export, so the recorder should
+	// already hold the request; a short bounded wait guards against any async.
+	deadline := time.Now().Add(2 * time.Second)
+	for len(spans.reqs()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := spans.reqs()
+	if len(got) == 0 {
+		t.Fatalf("spans insert service received no requests; expected at least one span row")
+	}
+
+	// Count alone is vacuous: doParseSpans always emits a ParserResponse whose
+	// SpansRequest is a non-nil &model.TempoSamples{} even for an empty span
+	// list, so an empty span input would still record a request. Inspect the
+	// payload to prove an actual span row — with THIS span's identity — reached
+	// the insert layer. (Negative guard: an empty ScopeSpans.Spans slice would
+	// leave MTraceId/MName empty and fail here.)
+	ts, ok := got[0].(*model.TempoSamples)
+	if !ok {
+		t.Fatalf("spans request had unexpected type %T", got[0])
+	}
+	if len(ts.MTraceId) == 0 || len(ts.MName) == 0 {
+		t.Fatalf("spans request carried no span rows: %#v", ts)
+	}
+	if ts.MName[0] != "op" {
+		t.Fatalf("span name did not flow through: got %q, want %q", ts.MName[0], "op")
+	}
+}

--- a/writer/grpc/logs.go
+++ b/writer/grpc/logs.go
@@ -1,0 +1,41 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	"github.com/metrico/qryn/v5/writer/utils/unmarshal"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// logsServer implements the OTLP LogsService gRPC handler, converting the
+// already-decoded ExportLogsServiceRequest into the shared parse/ingest path.
+type logsServer struct {
+	collogspb.UnimplementedLogsServiceServer
+}
+
+// Export resolves the tenant's log insert services from the request metadata
+// and ingests the pre-decoded log records through the transport-agnostic core.
+func (s *logsServer) Export(ctx context.Context, req *collogspb.ExportLogsServiceRequest) (*collogspb.ExportLogsServiceResponse, error) {
+	dsn, ctx := dsnCtx(ctx)
+	svcs, err := controller.ResolveLogServices(dsn)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	ld := &logsv1.LogsData{ResourceLogs: req.ResourceLogs}
+	parser := controller.Parser(unmarshal.OTLPLogsFromData(ld))
+	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &collogspb.ExportLogsServiceResponse{}, nil
+}
+
+// registerLogs wires the logs handler onto a gRPC server. Task 9 calls this
+// from registerServices; NewServer stays untouched here.
+func registerLogs(g *grpc.Server) {
+	collogspb.RegisterLogsServiceServer(g, &logsServer{})
+}

--- a/writer/grpc/logs_test.go
+++ b/writer/grpc/logs_test.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestLogsExport_NoTenantErrors asserts that with no service registry
+// configured, Export returns an InvalidArgument status rather than panicking.
+func TestLogsExport_NoTenantErrors(t *testing.T) {
+	saved := controller.Registry
+	controller.Registry = nil
+	defer func() { controller.Registry = saved }()
+
+	srv := &logsServer{}
+	_, err := srv.Export(context.Background(), &collogspb.ExportLogsServiceRequest{})
+	if err == nil {
+		t.Fatal("expected error without registry")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", status.Code(err))
+	}
+}

--- a/writer/grpc/profiles.go
+++ b/writer/grpc/profiles.go
@@ -1,0 +1,39 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	"github.com/metrico/qryn/v5/writer/utils/unmarshal"
+	pprofileotlp "go.opentelemetry.io/collector/pdata/pprofile/pprofileotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// profilesServer implements the OTLP ProfilesService gRPC handler, converting the
+// already-decoded ExportRequest into the shared parse/ingest path.
+type profilesServer struct {
+	pprofileotlp.UnimplementedGRPCServer
+}
+
+// Export resolves the tenant's profile insert services from the request metadata
+// and ingests the pre-decoded profiles through the transport-agnostic core.
+func (s *profilesServer) Export(ctx context.Context, req pprofileotlp.ExportRequest) (pprofileotlp.ExportResponse, error) {
+	dsn, ctx := dsnCtx(ctx)
+	svcs, err := controller.ResolveProfileServices(dsn)
+	if err != nil {
+		return pprofileotlp.NewExportResponse(), status.Error(codes.InvalidArgument, err.Error())
+	}
+	parser := controller.Parser(unmarshal.OTLPProfilesFromProfiles(req.Profiles()))
+	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
+		return pprofileotlp.NewExportResponse(), status.Error(codes.Internal, err.Error())
+	}
+	return pprofileotlp.NewExportResponse(), nil
+}
+
+// registerProfiles wires the profiles handler onto a gRPC server. It is called
+// from registerServices, which NewServer invokes.
+func registerProfiles(g *grpc.Server) {
+	pprofileotlp.RegisterGRPCServer(g, &profilesServer{})
+}

--- a/writer/grpc/profiles_test.go
+++ b/writer/grpc/profiles_test.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	pprofileotlp "go.opentelemetry.io/collector/pdata/pprofile/pprofileotlp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestProfilesExport_NoTenantErrors verifies that with no tenant registry the
+// profiles handler surfaces an InvalidArgument gRPC error rather than panicking.
+func TestProfilesExport_NoTenantErrors(t *testing.T) {
+	saved := controller.Registry
+	controller.Registry = nil
+	defer func() { controller.Registry = saved }()
+
+	srv := &profilesServer{}
+	_, err := srv.Export(context.Background(), pprofileotlp.NewExportRequest())
+	if err == nil {
+		t.Fatal("expected error without registry")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", status.Code(err))
+	}
+}

--- a/writer/grpc/register.go
+++ b/writer/grpc/register.go
@@ -1,0 +1,10 @@
+package grpc
+
+import "google.golang.org/grpc"
+
+// registerServices wires all three OTLP signal handlers onto the gRPC server.
+func registerServices(s *grpc.Server) {
+	registerTrace(s)
+	registerLogs(s)
+	registerProfiles(s)
+}

--- a/writer/grpc/server.go
+++ b/writer/grpc/server.go
@@ -7,10 +7,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-// NewServer builds a gRPC server. In this task it registers no services yet;
-// Task 9 will add registerServices(s) here once all three OTLP handlers exist.
+// NewServer builds a gRPC server with all three OTLP signal handlers
+// (traces, logs, profiles) registered.
 func NewServer() *grpc.Server {
 	s := grpc.NewServer()
+	registerServices(s)
 	return s
 }
 

--- a/writer/grpc/server.go
+++ b/writer/grpc/server.go
@@ -1,0 +1,36 @@
+package grpc
+
+import (
+	"net"
+
+	"github.com/metrico/qryn/v5/writer/utils/logger"
+	"google.golang.org/grpc"
+)
+
+// NewServer builds a gRPC server. In this task it registers no services yet;
+// Task 9 will add registerServices(s) here once all three OTLP handlers exist.
+func NewServer() *grpc.Server {
+	s := grpc.NewServer()
+	return s
+}
+
+// Start listens on addr and serves in a goroutine, returning the server for
+// shutdown. An empty addr disables the receiver and returns (nil, nil). A
+// listen error is returned to the caller.
+func Start(addr string) (*grpc.Server, error) {
+	if addr == "" {
+		return nil, nil
+	}
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	s := NewServer()
+	go func() {
+		logger.Info("OTLP gRPC receiver listening on", addr)
+		if err := s.Serve(lis); err != nil {
+			logger.Error("OTLP gRPC serve error:", err)
+		}
+	}()
+	return s, nil
+}

--- a/writer/grpc/server.go
+++ b/writer/grpc/server.go
@@ -1,16 +1,33 @@
 package grpc
 
 import (
+	"context"
 	"net"
 
 	"github.com/metrico/qryn/v5/writer/utils/logger"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// recoveryInterceptor recovers from panics in unary handlers, logs them, and
+// returns codes.Internal — mirroring the HTTP ErrorHandler so a panicking
+// handler cannot crash the receiver.
+func recoveryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("OTLP gRPC handler panic:", r)
+			err = status.Errorf(codes.Internal, "panic: %v", r)
+			resp = nil
+		}
+	}()
+	return handler(ctx, req)
+}
 
 // NewServer builds a gRPC server with all three OTLP signal handlers
 // (traces, logs, profiles) registered.
 func NewServer() *grpc.Server {
-	s := grpc.NewServer()
+	s := grpc.NewServer(grpc.ChainUnaryInterceptor(recoveryInterceptor))
 	registerServices(s)
 	return s
 }

--- a/writer/grpc/server_test.go
+++ b/writer/grpc/server_test.go
@@ -1,0 +1,47 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestRecoveryInterceptor_PanicBecomesInternal asserts a panicking handler is
+// recovered and surfaced as codes.Internal, mirroring the HTTP ErrorHandler.
+func TestRecoveryInterceptor_PanicBecomesInternal(t *testing.T) {
+	resp, err := recoveryInterceptor(
+		context.Background(), nil, nil,
+		func(ctx context.Context, req any) (any, error) {
+			panic("boom")
+		},
+	)
+	if err == nil {
+		t.Fatal("expected non-nil error from recovered panic")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil resp, got %v", resp)
+	}
+	if got := status.Code(err); got != codes.Internal {
+		t.Fatalf("expected codes.Internal, got %v (err=%v)", got, err)
+	}
+}
+
+// TestRecoveryInterceptor_PassThrough confirms a non-panicking handler's result
+// flows through unchanged.
+func TestRecoveryInterceptor_PassThrough(t *testing.T) {
+	want := "ok"
+	resp, err := recoveryInterceptor(
+		context.Background(), nil, nil,
+		func(ctx context.Context, req any) (any, error) {
+			return want, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != want {
+		t.Fatalf("expected %q, got %v", want, resp)
+	}
+}

--- a/writer/grpc/tenant.go
+++ b/writer/grpc/tenant.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/metrico/qryn/v5/writer/service"
+	"github.com/metrico/qryn/v5/writer/utils"
+	"google.golang.org/grpc/metadata"
+)
+
+// asyncMode maps the x-async-insert metadata value to the int insert-mode,
+// mirroring getAsyncMode in the HTTP middleware.
+func asyncMode(v string) int {
+	switch v {
+	case "0":
+		return service.INSERT_MODE_SYNC
+	case "1":
+		return service.INSERT_MODE_ASYNC
+	default:
+		return service.INSERT_MODE_DEFAULT
+	}
+}
+
+// mdFirst returns the first value for key in md, or "" if absent.
+func mdFirst(md metadata.MD, key string) string {
+	if vs := md.Get(key); len(vs) > 0 {
+		return vs[0]
+	}
+	return ""
+}
+
+// dsnCtx extracts the tenant DSN from the incoming gRPC metadata (x-ch-dsn) and
+// propagates the parity metadata keys into context under the same ContextKey*
+// keys the HTTP middleware uses, returning the DSN and the enriched context.
+//
+// Handlers (Tasks 7-9) call dsnCtx(ctx) and then the signal-scoped resolver
+// directly, e.g. controller.ResolveTraceServices(dsn); there is deliberately no
+// shared all-signals resolver here (signal isolation).
+func dsnCtx(ctx context.Context) (string, context.Context) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	dsn := mdFirst(md, "x-ch-dsn")
+	ctx = context.WithValue(ctx, utils.ContextKeyDSN, dsn)
+	ctx = context.WithValue(ctx, utils.ContextKeyMeta, mdFirst(md, "x-scope-meta"))
+	// Mirror getAsyncMode: store the int insert-mode (not the raw string), so a
+	// downstream reader type-asserting .(int) does not panic.
+	ctx = context.WithValue(ctx, utils.ContextKeyAsync, asyncMode(mdFirst(md, "x-async-insert")))
+
+	// Mirror WithOverallContextMiddleware: parse x-ttl-days to uint16, default
+	// 0 on empty/parse error. Stored as uint16 (not string) because the write
+	// path type-asserts it: builder.go does p.ttlDays = ttlDays.(uint16).
+	ttlDays := uint16(0)
+	if strTTLDays := mdFirst(md, "x-ttl-days"); strTTLDays != "" {
+		if iTTLDays, err := strconv.ParseUint(strTTLDays, 10, 16); err == nil {
+			ttlDays = uint16(iTTLDays)
+		}
+	}
+	ctx = context.WithValue(ctx, utils.ContextKeyTTLDays, ttlDays)
+
+	return dsn, ctx
+}

--- a/writer/grpc/tenant_test.go
+++ b/writer/grpc/tenant_test.go
@@ -1,0 +1,73 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/metrico/qryn/v5/writer/service"
+	"github.com/metrico/qryn/v5/writer/utils"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestDSNCtx_ReadsMetadata(t *testing.T) {
+	md := metadata.New(map[string]string{"x-ch-dsn": "clickhouse://x"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	dsn, _ := dsnCtx(ctx)
+	if dsn != "clickhouse://x" {
+		t.Fatalf("got %q", dsn)
+	}
+}
+
+func TestDSNCtx_EmptyWhenAbsent(t *testing.T) {
+	dsn, _ := dsnCtx(context.Background())
+	if dsn != "" {
+		t.Fatalf("expected empty dsn, got %q", dsn)
+	}
+}
+
+func TestDSNCtx_ParsesTTLDays(t *testing.T) {
+	// Valid value parses to uint16.
+	md := metadata.New(map[string]string{"x-ttl-days": "7"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, enriched := dsnCtx(ctx)
+	if got := enriched.Value(utils.ContextKeyTTLDays); got != uint16(7) {
+		t.Fatalf("x-ttl-days=7: got %#v, want uint16(7)", got)
+	}
+
+	// Absent metadata defaults to uint16(0).
+	_, enriched = dsnCtx(context.Background())
+	if got := enriched.Value(utils.ContextKeyTTLDays); got != uint16(0) {
+		t.Fatalf("absent x-ttl-days: got %#v, want uint16(0)", got)
+	}
+
+	// Invalid value defaults to uint16(0).
+	md = metadata.New(map[string]string{"x-ttl-days": "notanumber"})
+	ctx = metadata.NewIncomingContext(context.Background(), md)
+	_, enriched = dsnCtx(ctx)
+	if got := enriched.Value(utils.ContextKeyTTLDays); got != uint16(0) {
+		t.Fatalf("invalid x-ttl-days: got %#v, want uint16(0)", got)
+	}
+}
+
+func TestDSNCtx_ParsesAsyncMode(t *testing.T) {
+	cases := []struct {
+		val  string // "" means metadata absent
+		want int
+	}{
+		{"1", service.INSERT_MODE_ASYNC},
+		{"0", service.INSERT_MODE_SYNC},
+		{"", service.INSERT_MODE_DEFAULT},
+	}
+	for _, c := range cases {
+		ctx := context.Background()
+		if c.val != "" {
+			md := metadata.New(map[string]string{"x-async-insert": c.val})
+			ctx = metadata.NewIncomingContext(ctx, md)
+		}
+		_, enriched := dsnCtx(ctx)
+		got := enriched.Value(utils.ContextKeyAsync)
+		if gi, ok := got.(int); !ok || gi != c.want {
+			t.Fatalf("x-async-insert=%q: got %#v, want int(%d)", c.val, got, c.want)
+		}
+	}
+}

--- a/writer/grpc/trace.go
+++ b/writer/grpc/trace.go
@@ -1,0 +1,41 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	"github.com/metrico/qryn/v5/writer/utils/unmarshal"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// traceServer implements the OTLP TraceService gRPC handler, converting the
+// already-decoded ExportTraceServiceRequest into the shared parse/ingest path.
+type traceServer struct {
+	coltracepb.UnimplementedTraceServiceServer
+}
+
+// Export resolves the tenant's trace insert services from the request metadata
+// and ingests the pre-decoded spans through the transport-agnostic core.
+func (s *traceServer) Export(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) (*coltracepb.ExportTraceServiceResponse, error) {
+	dsn, ctx := dsnCtx(ctx)
+	svcs, err := controller.ResolveTraceServices(dsn)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	td := &tracev1.TracesData{ResourceSpans: req.ResourceSpans}
+	parser := controller.Parser(unmarshal.OTLPTracesFromData(td))
+	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &coltracepb.ExportTraceServiceResponse{}, nil
+}
+
+// registerTrace wires the trace handler onto a gRPC server. Task 9 calls this
+// from registerServices; NewServer stays untouched here.
+func registerTrace(g *grpc.Server) {
+	coltracepb.RegisterTraceServiceServer(g, &traceServer{})
+}

--- a/writer/grpc/trace_test.go
+++ b/writer/grpc/trace_test.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestTraceExport_NoTenantErrors asserts that with no service registry
+// configured, Export returns an InvalidArgument status rather than panicking.
+func TestTraceExport_NoTenantErrors(t *testing.T) {
+	saved := controller.Registry
+	controller.Registry = nil
+	defer func() { controller.Registry = saved }()
+
+	srv := &traceServer{}
+	_, err := srv.Export(context.Background(), &coltracepb.ExportTraceServiceRequest{})
+	if err == nil {
+		t.Fatal("expected error without registry")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", status.Code(err))
+	}
+}

--- a/writer/utils/unmarshal/builder.go
+++ b/writer/utils/unmarshal/builder.go
@@ -57,6 +57,20 @@ type ParserCtx struct {
 
 type parserFn func(ctx *ParserCtx) error
 
+// Decode (on the three parser interfaces below) drives one parser: it takes
+// whatever the ParserCtx holds and emits gigapipe insert-model rows through the
+// registered on* handler. The name is historical and slightly overloaded — what
+// it does depends on how the ParserCtx was populated:
+//
+//   - Body-parsing decoders (zipkin, datadog, influx, and the HTTP OTLP path)
+//     read raw bytes from the ctx (bodyReader/bodyBuffer) and DO parse the wire
+//     format before converting to rows.
+//   - Pre-decoded decoders (the gRPC OTLP path, via withPreParsedBody) receive
+//     an ALREADY-decoded object in ctx.bodyObject and do NOT re-parse any wire
+//     bytes — Decode here is purely the OTLP-structure -> insert-row transform.
+//
+// So "Decode" over an already-decoded proto is not redundant: it is the
+// structure-to-storage-model conversion, which must run regardless of transport.
 type iLogsParser interface {
 	Decode() error
 	SetOnEntries(h onEntriesHandler)

--- a/writer/utils/unmarshal/builder.go
+++ b/writer/utils/unmarshal/builder.go
@@ -514,6 +514,19 @@ func withParsedBody(fn func() proto.Message) buildOption {
 	}
 }
 
+// withPreParsedBody injects an already-decoded proto object as the body,
+// bypassing body buffering and proto.Unmarshal. Used by the gRPC receiver,
+// where the framework has already decoded the wire bytes.
+func withPreParsedBody(obj any) buildOption {
+	return func(builder *parserBuilder) *parserBuilder {
+		builder.PreParse = append(builder.PreParse, func(ctx *ParserCtx) error {
+			ctx.bodyObject = obj
+			return nil
+		})
+		return builder
+	}
+}
+
 func withPayloadType(tp int8) buildOption {
 	return func(builder *parserBuilder) *parserBuilder {
 		builder.payloadType = tp

--- a/writer/utils/unmarshal/otlp.go
+++ b/writer/utils/unmarshal/otlp.go
@@ -164,3 +164,14 @@ var UnmarshalOTLPV2 = Build(
 	withBufferedBody,
 	withParsedBody(func() proto.Message { return &tracev1.TracesData{} }),
 	withSpansParser(func(ctx *ParserCtx) iSpansParser { return &OTLPDecoder{ctx: ctx} }))
+
+// OTLPTracesFromData builds a parser over an already-decoded TracesData,
+// reusing the OTLP span decoder without re-marshaling. Body read and
+// proto.Unmarshal are skipped; the supplied object is injected directly.
+func OTLPTracesFromData(td *tracev1.TracesData) ParsingFunction {
+	return Build(
+		withPayloadType(2),
+		withPreParsedBody(td),
+		withSpansParser(func(ctx *ParserCtx) iSpansParser { return &OTLPDecoder{ctx: ctx} }),
+	)
+}

--- a/writer/utils/unmarshal/otlp_grpc_test.go
+++ b/writer/utils/unmarshal/otlp_grpc_test.go
@@ -2,6 +2,7 @@ package unmarshal
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -29,15 +30,34 @@ func TestOTLPTracesFromData_EmitsSpans(t *testing.T) {
 	defer cache.Stop()
 	ch := OTLPTracesFromData(td)(context.Background(), nil, cache)
 	var spans int
+	var sawName, sawTraceID bool
 	for resp := range ch {
 		if resp.Error != nil {
 			t.Fatalf("unexpected error: %v", resp.Error)
 		}
-		if resp.SpansRequest != nil {
-			spans++
+		ts, ok := resp.SpansRequest.(*model.TempoSamples)
+		if !ok || ts == nil {
+			continue
 		}
+		for _, name := range ts.MName {
+			if strings.Contains(name, "op") {
+				sawName = true
+			}
+		}
+		for _, tid := range ts.MTraceId {
+			if len(tid) > 0 {
+				sawTraceID = true
+			}
+		}
+		spans += len(ts.MName)
 	}
 	if spans == 0 {
-		t.Fatal("expected at least one spans request")
+		t.Fatal("expected at least one span in the emitted TempoSamples")
+	}
+	if !sawName {
+		t.Fatal("expected an emitted span with Name containing \"op\"")
+	}
+	if !sawTraceID {
+		t.Fatal("expected an emitted span with a non-empty TraceId")
 	}
 }

--- a/writer/utils/unmarshal/otlp_grpc_test.go
+++ b/writer/utils/unmarshal/otlp_grpc_test.go
@@ -1,0 +1,43 @@
+package unmarshal
+
+import (
+	"context"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func TestOTLPTracesFromData_EmitsSpans(t *testing.T) {
+	td := &tracev1.TracesData{ResourceSpans: []*tracev1.ResourceSpans{{
+		Resource: &resourcev1.Resource{Attributes: []*commonv1.KeyValue{{
+			Key:   "service.name",
+			Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "svc"}},
+		}}},
+		ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{{
+			Name: "op", TraceId: []byte("0123456789abcdef"), SpanId: []byte("01234567"),
+		}}}},
+	}}}
+	cache := numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, map[string]*model.DataDatabasesMap{})
+	defer cache.Stop()
+	ch := OTLPTracesFromData(td)(context.Background(), nil, cache)
+	var spans int
+	for resp := range ch {
+		if resp.Error != nil {
+			t.Fatalf("unexpected error: %v", resp.Error)
+		}
+		if resp.SpansRequest != nil {
+			spans++
+		}
+	}
+	if spans == 0 {
+		t.Fatal("expected at least one spans request")
+	}
+}

--- a/writer/utils/unmarshal/otlp_profile.go
+++ b/writer/utils/unmarshal/otlp_profile.go
@@ -418,7 +418,14 @@ func (d *otlpProfilesDec) Decode() error {
 	if err := req.UnmarshalProto(data); err != nil {
 		return fmt.Errorf("failed to unmarshal OTLP profiles: %w", err)
 	}
-	profs := req.Profiles()
+	return d.decodeProfiles(req.Profiles())
+}
+
+// decodeProfiles walks the resource/scope/profile tree of an already-decoded
+// pprofile.Profiles value and emits one onProfiles call per profile. It is the
+// shared core of both the HTTP body path (otlpProfilesDec.Decode) and the
+// pre-decoded gRPC path (otlpProfilesPreDec.Decode).
+func (d *otlpProfilesDec) decodeProfiles(profs pprofile.Profiles) error {
 	dict := profs.Dictionary()
 
 	rps := profs.ResourceProfiles()
@@ -452,7 +459,42 @@ func (d *otlpProfilesDec) Decode() error {
 	return nil
 }
 
+// otlpProfilesPreDec decodes an already-decoded pprofile.Profiles value injected
+// via withPreParsedBody (used by the gRPC receiver, where the collector framework
+// has already unmarshalled the wire bytes). It reuses the exact same walk loop as
+// the HTTP path via the shared decodeProfiles method.
+type otlpProfilesPreDec struct {
+	ctx        *ParserCtx
+	onProfiles onProfileHandler
+}
+
+func (d *otlpProfilesPreDec) SetOnProfile(h onProfileHandler) { d.onProfiles = h }
+
+// Decode does NO wire decoding: bodyObject was already unmarshalled by the gRPC
+// collector framework. It only runs the shared OTLP-structure -> insert-row
+// transform (decodeProfiles), the same conversion the HTTP path performs after
+// its UnmarshalProto step.
+func (d *otlpProfilesPreDec) Decode() error {
+	profs, ok := d.ctx.bodyObject.(pprofile.Profiles)
+	if !ok {
+		return fmt.Errorf("expected pprofile.Profiles body object, got %T", d.ctx.bodyObject)
+	}
+	shared := &otlpProfilesDec{ctx: d.ctx, onProfiles: d.onProfiles}
+	return shared.decodeProfiles(profs)
+}
+
 var UnmarshalOTLPProfilesProtoV2 = Build(
 	withProfileParser(func(ctx *ParserCtx) iProfilesParser {
 		return &otlpProfilesDec{ctx: ctx}
 	}))
+
+// OTLPProfilesFromProfiles builds a ParsingFunction that decodes an already-decoded
+// pprofile.Profiles value (from the gRPC receiver) over the shared profiles loop,
+// without re-marshalling.
+func OTLPProfilesFromProfiles(profs pprofile.Profiles) ParsingFunction {
+	return Build(
+		withPreParsedBody(profs),
+		withProfileParser(func(ctx *ParserCtx) iProfilesParser {
+			return &otlpProfilesPreDec{ctx: ctx}
+		}))
+}

--- a/writer/utils/unmarshal/otlp_profile_grpc_test.go
+++ b/writer/utils/unmarshal/otlp_profile_grpc_test.go
@@ -1,0 +1,113 @@
+package unmarshal
+
+import (
+	"context"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+)
+
+func newProfilesGRPCCache() numbercache.ICache[uint64] {
+	return numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, map[string]*model.DataDatabasesMap{})
+}
+
+// TestOTLPProfilesFromProfiles_NoPanicOnEmpty verifies the pre-decoded gRPC path
+// runs the shared decode loop over an empty pprofile.Profiles without panicking
+// or surfacing an error.
+func TestOTLPProfilesFromProfiles_NoPanicOnEmpty(t *testing.T) {
+	profs := pprofile.NewProfiles()
+	cache := newProfilesGRPCCache()
+	defer cache.Stop()
+
+	ch := OTLPProfilesFromProfiles(profs)(context.Background(), nil, cache)
+	for resp := range ch {
+		if resp.Error != nil {
+			t.Fatalf("unexpected error: %v", resp.Error)
+		}
+	}
+}
+
+// TestOTLPProfilesFromProfiles_EmitsProfile proves a real, populated
+// pprofile.Profiles flows through the pre-decoded gRPC path
+// (OTLPProfilesFromProfiles) into an emitted *model.ProfileData carrying the
+// fixture's content. The fixture is identical to the HTTP path's
+// TestOTLPProfilesDecEmitsProfile so the two paths are proven equivalent.
+func TestOTLPProfilesFromProfiles_EmitsProfile(t *testing.T) {
+	// Same one-symbolized-profile fixture as the HTTP TestOTLPProfilesDecEmitsProfile.
+	profs := pprofile.NewProfiles()
+	dict := profs.Dictionary()
+	dict.StringTable().Append("", "cpu", "nanoseconds", "main")
+	f0 := dict.FunctionTable().AppendEmpty()
+	f0.SetNameStrindex(3)
+	l0 := dict.LocationTable().AppendEmpty()
+	l0.Lines().AppendEmpty().SetFunctionIndex(0)
+	stk := dict.StackTable().AppendEmpty()
+	stk.LocationIndices().Append(0)
+	rp := profs.ResourceProfiles().AppendEmpty()
+	rp.Resource().Attributes().PutStr("service.name", "svc")
+	sp := rp.ScopeProfiles().AppendEmpty()
+	p := sp.Profiles().AppendEmpty()
+	p.SetTime(pcommon.Timestamp(1_700_000_000_000_000_000))
+	p.SetDurationNano(1_000_000_000)
+	p.SampleType().SetTypeStrindex(1)
+	p.SampleType().SetUnitStrindex(2)
+	p.PeriodType().SetTypeStrindex(1)
+	p.PeriodType().SetUnitStrindex(2)
+	s := p.Samples().AppendEmpty()
+	s.SetStackIndex(0)
+	s.Values().Append(42)
+
+	cache := newProfilesGRPCCache()
+	defer cache.Stop()
+
+	ch := OTLPProfilesFromProfiles(profs)(context.Background(), nil, cache)
+
+	var got []*model.ProfileData
+	for resp := range ch {
+		if resp.Error != nil {
+			t.Fatalf("unexpected error: %v", resp.Error)
+		}
+		if resp.ProfileRequest == nil {
+			continue
+		}
+		pd, ok := resp.ProfileRequest.(*model.ProfileData)
+		if !ok {
+			t.Fatalf("ProfileRequest is %T, want *model.ProfileData", resp.ProfileRequest)
+		}
+		got = append(got, pd)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 profile response, got %d", len(got))
+	}
+	pd := got[0]
+
+	if len(pd.ServiceName) != 1 || pd.ServiceName[0] != "svc" {
+		t.Fatalf("ServiceName = %v, want [svc]", pd.ServiceName)
+	}
+	if len(pd.Ptype) != 1 || pd.Ptype[0] != "cpu" {
+		t.Fatalf("Ptype = %v, want [cpu]", pd.Ptype)
+	}
+	if len(pd.TimestampNs) != 1 || pd.TimestampNs[0] != 1_700_000_000_000_000_000 {
+		t.Fatalf("TimestampNs = %v, want [1700000000000000000]", pd.TimestampNs)
+	}
+	if len(pd.DurationNs) != 1 || pd.DurationNs[0] != 1_000_000_000 {
+		t.Fatalf("DurationNs = %v, want [1000000000]", pd.DurationNs)
+	}
+	if len(pd.PayloadType) != 1 || pd.PayloadType[0] != otlpProfilePayloadType {
+		t.Fatalf("PayloadType = %v, want [%s]", pd.PayloadType, otlpProfilePayloadType)
+	}
+	if len(pd.Payload) != 1 || len(pd.Payload[0]) == 0 {
+		t.Fatalf("Payload not carried through: %v", pd.Payload)
+	}
+	if len(pd.ValuesAgg) != 1 || pd.ValuesAgg[0].ValueInt64 != 42 {
+		t.Fatalf("ValuesAgg = %+v, want single entry ValueInt64=42", pd.ValuesAgg)
+	}
+}

--- a/writer/utils/unmarshal/otlplogs.go
+++ b/writer/utils/unmarshal/otlplogs.go
@@ -163,3 +163,13 @@ var UnmarshalOTLPLogsV2 = Build(
 	withLogsParser(func(ctx *ParserCtx) iLogsParser {
 		return &otlpLogDec{ctx: ctx}
 	}))
+
+// OTLPLogsFromData builds a parser over an already-decoded LogsData, reusing
+// the OTLP logs decoder without re-marshaling. Used by the gRPC receiver,
+// where the framework has already decoded the wire bytes.
+func OTLPLogsFromData(ld *otlplogs.LogsData) ParsingFunction {
+	return Build(
+		withPreParsedBody(ld),
+		withLogsParser(func(ctx *ParserCtx) iLogsParser { return &otlpLogDec{ctx: ctx} }),
+	)
+}

--- a/writer/utils/unmarshal/otlplogs_grpc_test.go
+++ b/writer/utils/unmarshal/otlplogs_grpc_test.go
@@ -1,0 +1,80 @@
+package unmarshal
+
+import (
+	"context"
+	"testing"
+	"time"
+	"unsafe"
+
+	clconfig "github.com/metrico/cloki-config"
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/writer/config"
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	logsv1 "go.opentelemetry.io/proto/otlp/logs/v1"
+)
+
+func TestOTLPLogsFromData_EmitsSamples(t *testing.T) {
+	// The full ParsingFunction path runs the logs decoder through onEntries ->
+	// fingerprintLabels, which reads config.Cloki.Setting.FingerPrintType. Install
+	// a minimal global config so that read does not nil-pointer panic.
+	old := config.Cloki
+	config.Cloki = &clconfig.ClokiConfig{Setting: &clokiconfig.ClokiBaseSettingServer{}}
+	t.Cleanup(func() { config.Cloki = old })
+
+	ld := &logsv1.LogsData{ResourceLogs: []*logsv1.ResourceLogs{{
+		ScopeLogs: []*logsv1.ScopeLogs{{LogRecords: []*logsv1.LogRecord{{
+			TimeUnixNano: 1,
+			Body:         &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "hello"}},
+		}}}},
+	}}}
+
+	// The record's message must actually flow through the decoder into the
+	// flushed SamplesRequest. Asserting only SamplesRequest != nil is vacuous:
+	// doParseLogs always flushes a non-nil (possibly empty) TimeSamplesData.
+	if got := collectMessages(t, ld); !containsMessage(got, "hello") {
+		t.Fatalf("expected flushed SamplesRequest to contain %q; got messages %v", "hello", got)
+	}
+
+	// Negative sanity check: an empty LogsData must not produce the message,
+	// proving the positive assertion above is not vacuous.
+	if got := collectMessages(t, &logsv1.LogsData{}); containsMessage(got, "hello") {
+		t.Fatalf("empty LogsData unexpectedly produced %q; got messages %v", "hello", got)
+	}
+}
+
+// collectMessages runs the pre-decoded logs parser over ld and returns every
+// message that reaches the flushed SamplesRequest (*model.TimeSamplesData).
+func collectMessages(t *testing.T, ld *logsv1.LogsData) []string {
+	t.Helper()
+	cache := numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, map[string]*model.DataDatabasesMap{})
+	defer cache.Stop()
+
+	var messages []string
+	for resp := range OTLPLogsFromData(ld)(context.Background(), nil, cache) {
+		if resp.Error != nil {
+			t.Fatalf("unexpected error: %v", resp.Error)
+		}
+		if resp.SamplesRequest == nil {
+			continue
+		}
+		spl, ok := resp.SamplesRequest.(*model.TimeSamplesData)
+		if !ok {
+			t.Fatalf("SamplesRequest is %T, want *model.TimeSamplesData", resp.SamplesRequest)
+		}
+		messages = append(messages, spl.MMessage...)
+	}
+	return messages
+}
+
+func containsMessage(messages []string, want string) bool {
+	for _, m := range messages {
+		if m == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds an OTLP **gRPC** receiver alongside the existing OTLP/HTTP endpoints. gRPC is the OTel-standard transport; until now gigapipe only accepted OTLP over HTTP. Supports **traces, logs, and profiles**.

The receiver is **disabled by default** — it starts only when `OTLP_GRPC_ADDR` is set (e.g. `:4317`, the OTel-convention port). Unset/empty opens no listener and leaves existing behavior byte-for-byte unchanged.

## Approach

Reuses the existing insert pipeline rather than building a parallel one. gRPC handlers hand the **already-decoded** proto (`ResourceSpans`/`ResourceLogs`/profiles) straight to the existing signal decoders — **single decode, no re-marshal**.

- Extracted the insert core (`IngestParsed`) out of the HTTP `doParse` so both transports share one push path. The HTTP path is **byte-identical** to before (verified — `middleware.go` diff empty).
- **Signal isolation:** each signal resolves only its own insert services (`ResolveTrace/Log/ProfileServices`) — logs never depend on span services, etc.
- Tenant + per-request options come from gRPC metadata (`x-ch-dsn`, `x-scope-meta`, `x-ttl-days`), mirroring the equivalent HTTP headers with matching context types.
- **Panic recovery:** a unary interceptor recovers handler panics → logs → `codes.Internal`, mirroring the HTTP `ErrorHandler`.
- **Graceful shutdown:** the gRPC server drains in-flight RPCs on SIGTERM/SIGINT, bounded by the same `shutdownTimeout` as the HTTP server.

## Testing

- gRPC handler unit tests (tenant resolution, nil-registry errors, panic→Internal).
- End-to-end bufconn integration test: real gRPC trace client → handler → insert layer, asserting the span's identity reaches the insert row.
- `IngestParsed` push-routing + error-path unit tests; `OTLP*FromData` decoder unit tests for all three signals.
- Full suite green (`go test ./...` → exit 0).

## Config

| Env | Effect |
|-----|--------|
| `OTLP_GRPC_ADDR` | Listen address for the gRPC receiver (e.g. `:4317`). Unset = off. |
