### PR TITLE
fix(promql): project the empty label set for an empty grouping set

### DIFF
--- a/reader/promql/promql_transpiler/planner/sum.go
+++ b/reader/promql/promql_transpiler/planner/sum.go
@@ -100,6 +100,15 @@ func (s *AggPlanner) patchLabels() sql.SQLObject {
 		// explicitly, since it is never in the user's label list.
 		labels = append(append([]string{}, s.Labels...), "__name__")
 	}
+	if len(labels) == 0 {
+		// An empty grouping set keeps no labels at all, so the projection is the
+		// constant empty label set -- which is also what prometheus produces for
+		// `sum(x)` and `sum by () (x)`. Building the filter here would render
+		// `x.1 IN ()`, which ClickHouse rejects. `without` never lands here: it
+		// always carries __name__ to drop.
+		return sql.NewRawObject("'{}'")
+	}
+
 	sqlLabels := make([]sql.SQLObject, len(labels))
 	for i, label := range labels {
 		sqlLabels[i] = sql.NewStringVal(label)

--- a/reader/promql/promql_transpiler/vector_agg_test.go
+++ b/reader/promql/promql_transpiler/vector_agg_test.go
@@ -53,6 +53,29 @@ func TestAggByKeepsOnlyListedLabels(t *testing.T) {
 	}
 }
 
+// TestAggEmptyGroupingKeepsNoLabels guards the empty grouping set: a bare
+// aggregation and `by ()` keep no labels, so the projection must be the constant
+// empty label set. Rendering the filter instead would emit `x.1 IN ()`, which
+// ClickHouse rejects with UNSUPPORTED_METHOD on every version.
+func TestAggEmptyGroupingKeepsNoLabels(t *testing.T) {
+	for _, q := range []string{
+		`sum(http_requests_total{job="myjob"})`,
+		`sum by () (http_requests_total{job="myjob"})`,
+		`count(http_requests_total{job="myjob"})`,
+		`sum(rate(http_requests_total{job="myjob"}[5m]))`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			got := transpileRange(t, q)
+			if strings.Contains(got, "IN ()") {
+				t.Errorf("empty IN list is not valid ClickHouse:\n%s", got)
+			}
+			if !strings.Contains(got, "'{}' as new_labels") {
+				t.Errorf("an empty grouping set must project the empty label set:\n%s", got)
+			}
+		})
+	}
+}
+
 // TestAggWithoutDropsNameLabel guards the __name__ fix: `without` must drop the
 // listed labels and __name__, which prometheus removes from every aggregation.
 func TestAggWithoutDropsNameLabel(t *testing.T) {


### PR DESCRIPTION
A bare `sum(x)` parses as `by` with no grouping labels, so the label projection in AggPlanner rendered `x.1 IN ()`. ClickHouse rejects that on every version -- UNSUPPORTED_METHOD on 24.9 and 25.4, NUMBER_OF_ARGUMENTS_ DOESNT_MATCH on 23.8 -- so every aggregation without a by/without clause returned a 500. `by ()` hit it too; `without ()` did not, since it always carries __name__ to drop and so never renders an empty list.

An empty grouping set keeps no labels, which is exactly the constant empty label set prometheus produces for `sum(x)`. Short-circuit to it rather than building a membership test, which also skips a per-series JSON parse in the labels CTE.

Fixes #901