### PR TITLE
fix(reader): counter functions divide by the range, not the interval they measured

### DIFF
--- a/reader/promql/promql_transpiler/planner/counter.go
+++ b/reader/promql/promql_transpiler/planner/counter.go
@@ -16,8 +16,15 @@ import (
 // case prev is a zero default and must not be compared against val.
 func prevValues(ctx *shared.PlannerContext, fpPlanner shared.SQLRequestPlanner,
 	duration time.Duration) (*sql.With, error) {
+	// val is the last sample of the bucket, so val_ts -- that sample's own
+	// timestamp -- is where it actually sits, which is not the bucket key. The
+	// two differ by however far into the bucket the last sample fell, and the
+	// final bucket of a query is truncated by the read bound, so its last sample
+	// can be anywhere in it. Anything measuring an interval between values has to
+	// use val_ts; measuring between bucket keys would overstate it.
 	vals, err := bucketedValues(ctx, fpPlanner, duration+staleness,
-		sql.NewSimpleCol("argMaxMerge(last)", "val"))
+		sql.NewSimpleCol("argMaxMerge(last)", "val"),
+		sql.NewSimpleCol("intDiv(max(timestamp_ns), 1000000)", "val_ts"))
 	if err != nil {
 		return nil, err
 	}
@@ -44,6 +51,7 @@ func prevValues(ctx *shared.PlannerContext, fpPlanner shared.SQLRequestPlanner,
 			sql.NewSimpleCol("fingerprint", "fingerprint"),
 			sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
 			sql.NewSimpleCol("val", "val"),
+			sql.NewSimpleCol("val_ts", "val_ts"),
 			sql.NewSimpleCol("source", "source"),
 			sql.NewCol(overWnd(sql.NewRawObject("argMaxIf(val, timestamp_ms, source = 1)"), prevWnd), "prev"),
 			sql.NewCol(overWnd(sql.NewRawObject("countIf(source = 1)"), prevWnd), "prev_cnt")).
@@ -55,10 +63,10 @@ func prevValues(ctx *shared.PlannerContext, fpPlanner shared.SQLRequestPlanner,
 // CounterPlanner accelerates the range functions that measure the change of a
 // series across the frame: rate, increase and delta.
 //
-// They cannot be expressed as one aggregate over (t-range, t], because the
-// value at the start of the range is an actual sample whose position varies
-// with the data. The frame therefore has to be probed on both sides: openWnd
-// looks for the last sample before the range, closeWnd covers the range itself.
+// They cannot be expressed as one aggregate over (t-range, t], because what is
+// measured is the difference between two particular samples, not a reduction
+// over all of them. The frame is probed for its first and last real sample; the
+// change between them, divided by the time between them, is the slope reported.
 type CounterPlanner struct {
 	FpPlanner shared.SQLRequestPlanner
 	Duration  time.Duration
@@ -68,17 +76,18 @@ type CounterPlanner struct {
 func (c *CounterPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, error) {
 	// isCounter: add back the value lost at every counter reset. delta operates
 	// on gauges, where a decrease is a real decrease.
-	var isCounter bool
-	var val string
+	//
+	// isRate: report the change per second. increase is the same measurement
+	// over the whole range instead, which is why it is a counter function but
+	// not a rate one.
+	var isCounter, isRate bool
 	switch c.Fn {
 	case "rate":
-		isCounter = true
-		val = fmt.Sprintf("(end - start + resets) / %f", c.Duration.Seconds())
+		isCounter, isRate = true, true
 	case "increase":
-		isCounter = true
-		val = "end - start + resets"
+		isCounter, isRate = true, false
 	case "delta":
-		val = "end - start"
+		isCounter, isRate = false, false
 	default:
 		return nil, fmt.Errorf("unsupported counter function: %s", c.Fn)
 	}
@@ -98,6 +107,7 @@ func (c *CounterPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, error
 			sql.NewSimpleCol("fingerprint", "fingerprint"),
 			sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
 			sql.NewSimpleCol("val", "val"),
+			sql.NewSimpleCol("val_ts", "val_ts"),
 			sql.NewSimpleCol("source", "source"),
 			sql.NewSimpleCol(resetCol, "reset")).
 			From(sql.NewWithRef(withPrev)),
@@ -107,65 +117,76 @@ func (c *CounterPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, error
 	if err != nil {
 		return nil, err
 	}
-	openStart, err := windowOffset(c.Duration + staleness)
-	if err != nil {
-		return nil, err
-	}
-	openEnd, err := windowOffset(c.Duration - time.Millisecond)
-	if err != nil {
-		return nil, err
-	}
-	// The staleness wide strip immediately before the range.
-	openWnd := &sql.WindowFunction{
-		Alias:       "cnt_open_wnd",
-		PartitionBy: []sql.SQLObject{sql.NewRawObject("fingerprint")},
-		OrderBy:     []sql.SQLObject{sql.NewOrderBy(sql.NewRawObject("timestamp_ms"), sql.ORDER_BY_DIRECTION_ASC)},
-		Start:       sql.WindowPoint{Offset: openStart},
-		End:         sql.WindowPoint{Offset: openEnd},
-	}
 
+	// The two samples the change is measured between, and where they sit. Both
+	// _ts columns are picked by bucket order but carry val_ts, so they are the
+	// positions of those same two samples rather than of their buckets -- the
+	// change and the interval it happened over are then on the same clock.
+	//
+	// first_reset is the reset flagged on the earliest in-range sample. That one
+	// compares against a sample outside the range, so the drop it records
+	// happened before the range began and is not part of the change measured
+	// inside it; c_change subtracts it back out. Every later sample compares
+	// against one inside the range. CounterFlagsPlanner applies the same
+	// correction to its transition counts via first_flag.
 	withRanges := sql.NewWith(
 		sql.NewSelect().With(withResets).Select(
 			sql.NewSimpleCol("fingerprint", "fingerprint"),
 			sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
-			sql.NewCol(overWnd(sql.NewRawObject("argMaxIf(val, timestamp_ms, source = 1)"), openWnd), "start_open"),
-			sql.NewCol(overWnd(sql.NewRawObject("countIf(source = 1)"), openWnd), "open_cnt"),
-			sql.NewCol(overWnd(sql.NewRawObject("argMinIf(val, timestamp_ms, source = 1)"), closeWnd), "start_close"),
-			sql.NewCol(overWnd(sql.NewRawObject("argMaxIf(val, timestamp_ms, source = 1)"), closeWnd), "end"),
-			sql.NewCol(overWnd(sql.NewRawObject("sum(source)"), closeWnd), "close_cnt"),
-			sql.NewCol(overWnd(sql.NewRawObject("sum(reset)"), closeWnd), "resets")).
+			sql.NewCol(overWnd(sql.NewRawObject("argMinIf(val, timestamp_ms, source = 1)"), closeWnd), "first_v"),
+			sql.NewCol(overWnd(sql.NewRawObject("argMinIf(val_ts, timestamp_ms, source = 1)"), closeWnd), "first_ts"),
+			sql.NewCol(overWnd(sql.NewRawObject("argMaxIf(val, timestamp_ms, source = 1)"), closeWnd), "last_v"),
+			sql.NewCol(overWnd(sql.NewRawObject("argMaxIf(val_ts, timestamp_ms, source = 1)"), closeWnd), "last_ts"),
+			sql.NewCol(overWnd(sql.NewRawObject("sum(reset)"), closeWnd), "resets"),
+			sql.NewCol(overWnd(sql.NewRawObject("argMinIf(reset, timestamp_ms, source = 1)"), closeWnd), "first_reset")).
 			From(sql.NewWithRef(withResets)).
-			AddWindows(openWnd, closeWnd),
+			AddWindows(closeWnd),
 		"cnt_ranges")
 
-	// Measure from the last sample before the range when there is one, so that
-	// the growth that happened between it and the first in-range sample is not
-	// dropped. open_cnt, not start_open > 0: a counter legitimately sitting at
-	// zero, or any gauge, would defeat a value based existence test.
-	withStart := sql.NewWith(
+	withSlope := sql.NewWith(
 		sql.NewSelect().With(withRanges).Select(
 			sql.NewSimpleCol("fingerprint", "fingerprint"),
 			sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
-			sql.NewSimpleCol("end", "end"),
-			sql.NewSimpleCol("resets", "resets"),
-			sql.NewSimpleCol("open_cnt", "open_cnt"),
-			sql.NewSimpleCol("close_cnt", "close_cnt"),
-			sql.NewSimpleCol("if(open_cnt > 0, start_open, start_close)", "start")).
+			sql.NewSimpleCol("first_ts", "first_ts"),
+			sql.NewSimpleCol("last_ts", "last_ts"),
+			sql.NewSimpleCol(c.change(isCounter), "c_change"),
+			// Milliseconds to seconds: rate is per second, so the span it is
+			// divided by has to be too. Doing it once here keeps the unit in
+			// one place rather than at each of the three call sites.
+			//
+			// The subtraction is positive by construction -- both timestamps are
+			// those of real samples inside (t-range, t] -- and clickhouse
+			// division yields Float64 whatever the operands are.
+			sql.NewSimpleCol("(last_ts - first_ts) / 1000", "c_span_sec")).
 			From(sql.NewWithRef(withRanges)),
-		"cnt_start")
+		"cnt_slope")
 
-	return sql.NewSelect().With(withStart).Select(
+	// The per-second slope between the two samples. increase and delta report
+	// that slope over the whole range rather than per second.
+	val := "c_change / c_span_sec"
+	if !isRate {
+		val = fmt.Sprintf("c_change / c_span_sec * %f", c.Duration.Seconds())
+	}
+
+	return sql.NewSelect().With(withSlope).Select(
 		sql.NewSimpleCol("fingerprint", "fingerprint"),
 		sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
 		sql.NewSimpleCol(val, "val")).
-		From(sql.NewWithRef(withStart)).
-		AndWhere(
-			// end has to come from inside the range,
-			sql.Gt(sql.NewRawObject("close_cnt"), sql.NewIntVal(0)),
-			// and start has to be a different sample than end: measuring a
-			// change needs two of them. A lone first sample of a series yields
-			// no point, as in prometheus.
-			sql.Gt(sql.NewRawObject("open_cnt + close_cnt"), sql.NewIntVal(1))), nil
+		From(sql.NewWithRef(withSlope)).
+		// Two distinct samples inside the range, or there is no interval to
+		// measure a change over. A lone sample yields no point, as in
+		// prometheus, and this is also what keeps c_span_sec off zero.
+		AndWhere(sql.Gt(sql.NewRawObject("last_ts"), sql.NewRawObject("first_ts"))), nil
+}
+
+// change is the value change actually observed between the first and last real
+// sample of the range, before it is scaled. For counters the value lost at every
+// reset inside the range is added back, so a wrap does not read as a decrease.
+func (c *CounterPlanner) change(isCounter bool) string {
+	if isCounter {
+		return "last_v - first_v + (resets - first_reset)"
+	}
+	return "last_v - first_v"
 }
 
 // CounterFlagsPlanner accelerates the range functions that count transitions

--- a/reader/promql/promql_transpiler/planner/counter.go
+++ b/reader/promql/promql_transpiler/planner/counter.go
@@ -145,27 +145,31 @@ func (c *CounterPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, error
 
 	withSlope := sql.NewWith(
 		sql.NewSelect().With(withRanges).Select(
-			sql.NewSimpleCol("fingerprint", "fingerprint"),
-			sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
-			sql.NewSimpleCol("first_ts", "first_ts"),
-			sql.NewSimpleCol("last_ts", "last_ts"),
-			sql.NewSimpleCol(c.change(isCounter), "c_change"),
-			// Milliseconds to seconds: rate is per second, so the span it is
-			// divided by has to be too. Doing it once here keeps the unit in
-			// one place rather than at each of the three call sites.
-			//
-			// The subtraction is positive by construction -- both timestamps are
-			// those of real samples inside (t-range, t] -- and clickhouse
-			// division yields Float64 whatever the operands are.
-			sql.NewSimpleCol("(last_ts - first_ts) / 1000", "c_span_sec")).
+			append([]sql.SQLObject{
+				sql.NewSimpleCol("fingerprint", "fingerprint"),
+				sql.NewSimpleCol("timestamp_ms", "timestamp_ms"),
+				sql.NewSimpleCol("first_ts", "first_ts"),
+				sql.NewSimpleCol("last_ts", "last_ts"),
+				sql.NewSimpleCol("first_v", "first_v"),
+				sql.NewSimpleCol(c.change(isCounter), "c_change"),
+				// Milliseconds to seconds: rate is per second, so the span it is
+				// divided by has to be too. Doing it once here keeps the unit in
+				// one place rather than at each of the call sites.
+				//
+				// The subtraction is positive by construction -- both timestamps
+				// are those of real samples inside (t-range, t] -- and clickhouse
+				// division yields Float64 whatever the operands are.
+				sql.NewSimpleCol("(last_ts - first_ts) / 1000", "c_span_sec"),
+			}, c.reach(isCounter)...)...).
 			From(sql.NewWithRef(withRanges)),
 		"cnt_slope")
 
-	// The per-second slope between the two samples. increase and delta report
-	// that slope over the whole range rather than per second.
-	val := "c_change / c_span_sec"
-	if !isRate {
-		val = fmt.Sprintf("c_change / c_span_sec * %f", c.Duration.Seconds())
+	// The change carried out to the edges of the range, then reported per second
+	// or over the range. c_reach is 1 whenever the samples already span the whole
+	// range, so the common case is unaffected by any of it.
+	val := "c_change * c_reach"
+	if isRate {
+		val = fmt.Sprintf("c_change * c_reach / %f", c.Duration.Seconds())
 	}
 
 	return sql.NewSelect().With(withSlope).Select(
@@ -187,6 +191,44 @@ func (c *CounterPlanner) change(isCounter bool) string {
 		return "last_v - first_v + (resets - first_reset)"
 	}
 	return "last_v - first_v"
+}
+
+// reach builds c_reach, the multiplier that carries the observed change out to
+// the edges of the range.
+//
+// The samples only cover c_span_sec of the range. Reporting the change as if it
+// were the whole range's understates it; assuming the observed slope held across
+// every second of the range overstates it whenever the series was not reporting
+// for part of that time. c_reach is how much of the uncovered time the change is
+// carried across, as a multiple of the span the samples do cover, so it is 1
+// exactly when the samples already reach both edges.
+//
+// Forward, there is nothing to decide: the series is still live at t, so the
+// slope carries to the edge. Backward is bounded twice over -- by the edge
+// itself, and for counters by the counter's own first value, since a counter
+// cannot have been negative. At the observed slope, growing from zero up to
+// first_v takes c_span_sec * first_v / c_change seconds, and no more growth than
+// that can be attributed to the time before the first sample. A counter that
+// started at zero inside the range therefore gets no backward reach at all,
+// which is what stops a series from appearing to have been running before it
+// existed.
+func (c *CounterPlanner) reach(isCounter bool) []sql.SQLObject {
+	back := "c_back_edge"
+	if isCounter {
+		back = "least(c_back_edge, if(c_change > 0 AND first_v >= 0, " +
+			"c_span_sec * first_v / c_change, c_back_edge))"
+	}
+	cols := [][2]string{
+		{fmt.Sprintf("(first_ts - (timestamp_ms - %d)) / 1000", c.Duration.Milliseconds()), "c_back_edge"},
+		{"(timestamp_ms - last_ts) / 1000", "c_fwd_edge"},
+		{back, "c_back"},
+		{"(c_span_sec + c_back + c_fwd_edge) / c_span_sec", "c_reach"},
+	}
+	res := make([]sql.SQLObject, len(cols))
+	for i, col := range cols {
+		res[i] = sql.NewSimpleCol(col[0], col[1])
+	}
+	return res
 }
 
 // CounterFlagsPlanner accelerates the range functions that count transitions

--- a/reader/promql/promql_transpiler/vector_agg_test.go
+++ b/reader/promql/promql_transpiler/vector_agg_test.go
@@ -69,7 +69,7 @@ func TestAggOfRateFolds(t *testing.T) {
 	if !strings.Contains(got, "sum(val) as val") {
 		t.Errorf("outer sum missing:\n%s", got)
 	}
-	if !strings.Contains(got, "resets") || !strings.Contains(got, "/ 300.000000") {
+	if !strings.Contains(got, "resets") || !strings.Contains(got, "c_change / c_span_sec as val") {
 		t.Errorf("inner rate machinery missing:\n%s", got)
 	}
 }

--- a/reader/promql/promql_transpiler/vector_agg_test.go
+++ b/reader/promql/promql_transpiler/vector_agg_test.go
@@ -69,7 +69,7 @@ func TestAggOfRateFolds(t *testing.T) {
 	if !strings.Contains(got, "sum(val) as val") {
 		t.Errorf("outer sum missing:\n%s", got)
 	}
-	if !strings.Contains(got, "resets") || !strings.Contains(got, "c_change / c_span_sec as val") {
+	if !strings.Contains(got, "resets") || !strings.Contains(got, "c_change * c_reach / 300.000000 as val") {
 		t.Errorf("inner rate machinery missing:\n%s", got)
 	}
 }

--- a/reader/promql/promql_transpiler/vector_range_test.go
+++ b/reader/promql/promql_transpiler/vector_range_test.go
@@ -89,9 +89,9 @@ func TestRangeFnsAccelerate(t *testing.T) {
 		{"last_over_time", []string{"argMaxMerge(last)", "argMaxIf(b_last, b_ts, source = 1)"}},
 		{"present_over_time", []string{"1 as val", "(w_src) > (0)"}},
 
-		{"rate", []string{"last_v - first_v + (resets - first_reset) as c_change", "c_change / c_span_sec as val"}},
-		{"increase", []string{"last_v - first_v + (resets - first_reset) as c_change", "c_change / c_span_sec * 300.000000 as val"}},
-		{"delta", []string{"last_v - first_v as c_change", "c_change / c_span_sec * 300.000000 as val"}},
+		{"rate", []string{"last_v - first_v + (resets - first_reset) as c_change", "c_change * c_reach / 300.000000 as val"}},
+		{"increase", []string{"last_v - first_v + (resets - first_reset) as c_change", "c_change * c_reach as val"}},
+		{"delta", []string{"last_v - first_v as c_change", "c_change * c_reach as val"}},
 
 		{"resets", []string{"(prev_cnt > 0) * (prev > val) * (source = 1)", "flags - first_flag"}},
 		{"changes", []string{"(prev_cnt > 0) * (prev != val) * (source = 1)", "flags - first_flag"}},
@@ -129,6 +129,32 @@ func TestCounterNeedsTwoSamples(t *testing.T) {
 				t.Errorf("%s must require an interval to measure across:\n%s", fn, got)
 			}
 		})
+	}
+}
+
+// TestCounterBackwardReachIsBounded guards the one thing that must not be
+// extrapolated freely. Forward there is nothing to decide: the series is live at
+// t, so the slope carries to the edge. Backward, a counter cannot have been
+// negative, so no more growth can be attributed to the time before the first
+// sample than that sample's own value -- c_span_sec * first_v / c_change seconds
+// at the observed slope. A counter that started at zero inside the range gets no
+// backward reach at all, which is what stops a series appearing to have been
+// running before it existed. delta operates on gauges, which have no such floor.
+func TestCounterBackwardReachIsBounded(t *testing.T) {
+	for _, fn := range []string{"rate", "increase"} {
+		t.Run(fn, func(t *testing.T) {
+			got := transpileRange(t, fn+`(x{job="j"}[5m])`)
+			if !strings.Contains(got, "least(c_back_edge, if(c_change > 0 AND first_v >= 0, "+
+				"c_span_sec * first_v / c_change, c_back_edge)) as c_back") {
+				t.Errorf("%s: backward reach must be bounded by the counter's own floor:\n%s", fn, got)
+			}
+			if !strings.Contains(got, "(c_span_sec + c_back + c_fwd_edge) / c_span_sec as c_reach") {
+				t.Errorf("%s: reach must span both edges:\n%s", fn, got)
+			}
+		})
+	}
+	if got := transpileRange(t, `delta(x{job="j"}[5m])`); !strings.Contains(got, "c_back_edge as c_back") {
+		t.Errorf("delta is a gauge function and has no zero floor to bound against:\n%s", got)
 	}
 }
 
@@ -171,19 +197,19 @@ func TestCounterSpanIsBetweenSamplesNotBuckets(t *testing.T) {
 	}
 }
 
-// TestRateDividesBySpanNotRange guards the defect that motivated this shape.
-// Dividing the observed change by the full range assumes the samples covered all
-// of it. Whenever the newest sample lags the step -- always true at the last step
-// of a window, and common mid-window with jittered scrapes -- they did not, and
-// the result is understated in proportion to how much of the range they missed.
-func TestRateDividesBySpanNotRange(t *testing.T) {
+// TestRateCarriesTheChangeToTheRangeEdges guards the defect that motivated this
+// shape. Reporting the observed change as though it were the whole range's
+// assumes the samples covered all of it. Whenever the newest sample lags the step
+// -- always true at the last step of a window, and common mid-window with
+// jittered scrapes -- they did not, and the result is understated in proportion
+// to how much of the range they missed. c_reach carries it out to the edges.
+func TestRateCarriesTheChangeToTheRangeEdges(t *testing.T) {
 	got := transpileRange(t, `rate(x{job="j"}[5m])`)
-	if !strings.Contains(got, "c_change / c_span_sec as val") {
+	if !strings.Contains(got, "c_change * c_reach / 300.000000 as val") {
 		t.Errorf("rate must divide by the interval the change was measured over:\n%s", got)
 	}
-	if strings.Contains(got, "c_change / 300.000000") ||
-		strings.Contains(got, "c_span_sec * 300.000000 as val") {
-		t.Errorf("rate must not normalise by the range:\n%s", got)
+	if strings.Contains(got, "c_change / 300.000000 as val") {
+		t.Errorf("rate must not divide the raw change by the range:\n%s", got)
 	}
 }
 
@@ -192,11 +218,11 @@ func TestRateDividesBySpanNotRange(t *testing.T) {
 // it is a counter function that is not a rate one.
 func TestIncreaseIsRateOverTheRange(t *testing.T) {
 	inc := transpileRange(t, `increase(x{job="j"}[5m])`)
-	if !strings.Contains(inc, "c_change / c_span_sec * 300.000000 as val") {
-		t.Errorf("increase must scale the slope by the range:\n%s", inc)
+	if !strings.Contains(inc, "c_change * c_reach as val") {
+		t.Errorf("increase must report the change over the range, undivided:\n%s", inc)
 	}
-	if !strings.Contains(transpileRange(t, `rate(x{job="j"}[5m])`), "c_change / c_span_sec as val") {
-		t.Error("rate must not carry the range scaling increase does")
+	if !strings.Contains(transpileRange(t, `rate(x{job="j"}[5m])`), "c_change * c_reach / 300.000000 as val") {
+		t.Error("rate must divide the same quantity by the range to get per-second")
 	}
 }
 

--- a/reader/promql/promql_transpiler/vector_range_test.go
+++ b/reader/promql/promql_transpiler/vector_range_test.go
@@ -89,9 +89,9 @@ func TestRangeFnsAccelerate(t *testing.T) {
 		{"last_over_time", []string{"argMaxMerge(last)", "argMaxIf(b_last, b_ts, source = 1)"}},
 		{"present_over_time", []string{"1 as val", "(w_src) > (0)"}},
 
-		{"rate", []string{"resets", "/ 300.000000", "if(open_cnt > 0, start_open, start_close)"}},
-		{"increase", []string{"end - start + resets"}},
-		{"delta", []string{"end - start"}},
+		{"rate", []string{"last_v - first_v + (resets - first_reset) as c_change", "c_change / c_span_sec as val"}},
+		{"increase", []string{"last_v - first_v + (resets - first_reset) as c_change", "c_change / c_span_sec * 300.000000 as val"}},
+		{"delta", []string{"last_v - first_v as c_change", "c_change / c_span_sec * 300.000000 as val"}},
 
 		{"resets", []string{"(prev_cnt > 0) * (prev > val) * (source = 1)", "flags - first_flag"}},
 		{"changes", []string{"(prev_cnt > 0) * (prev != val) * (source = 1)", "flags - first_flag"}},
@@ -118,31 +118,122 @@ func TestDeltaHasNoResetCorrection(t *testing.T) {
 }
 
 // TestCounterNeedsTwoSamples guards the leading edge of a series. rate, increase
-// and delta measure a change between two samples, so the very first sample of a
-// series, with nothing before it to measure against, must yield no point rather
-// than a zero.
+// and delta measure a change across an interval, so a single sample -- which
+// spans no interval at all -- must yield no point rather than a zero. The same
+// condition is what keeps c_span_sec, the divisor, off zero.
 func TestCounterNeedsTwoSamples(t *testing.T) {
 	for _, fn := range []string{"rate", "increase", "delta"} {
 		t.Run(fn, func(t *testing.T) {
 			got := transpileRange(t, fn+`(x{job="j"}[1m])`)
-			if !strings.Contains(got, "(open_cnt + close_cnt) > (1)") {
-				t.Errorf("%s must require two samples to measure across:\n%s", fn, got)
+			if !strings.Contains(got, "((last_ts) > (first_ts))") {
+				t.Errorf("%s must require an interval to measure across:\n%s", fn, got)
 			}
 		})
 	}
 }
 
-// TestCounterStartsFromSampleBeforeRange guards against a value based existence
-// test on the sample preceding the range: a counter sitting at zero there is a
-// real start value, and falling back to the first in range sample instead
-// understates the result.
-func TestCounterStartsFromSampleBeforeRange(t *testing.T) {
-	got := transpileRange(t, `rate(x{job="j"}[1m])`)
-	if strings.Contains(got, "start_open > 0") {
-		t.Errorf("start existence must be tested by open_cnt, not by value:\n%s", got)
+// TestCounterSpanIsBetweenSamplesNotBuckets guards the pairing of the two
+// quantities the slope is built from.
+//
+// val is the last sample of its bucket, so it sits at val_ts, which is not the
+// bucket key: it lands wherever the last sample of that bucket happened to fall.
+// The final bucket of a query is truncated by the read bound, so its last sample
+// can be anywhere inside it. Measuring the change between samples but the
+// interval between bucket keys therefore divides by an interval the change did
+// not happen over, and understates every counter function at the last step.
+func TestCounterSpanIsBetweenSamplesNotBuckets(t *testing.T) {
+	for _, fn := range []string{"rate", "increase", "delta"} {
+		t.Run(fn, func(t *testing.T) {
+			got := transpileRange(t, fn+`(x{job="j"}[5m])`)
+			for _, w := range []string{
+				"intDiv(max(timestamp_ns), 1000000) as val_ts",
+				"argMinIf(val_ts, timestamp_ms, source = 1) OVER cnt_close_wnd as first_ts",
+				"argMaxIf(val_ts, timestamp_ms, source = 1) OVER cnt_close_wnd as last_ts",
+				"(last_ts - first_ts) / 1000 as c_span_sec",
+			} {
+				if !strings.Contains(got, w) {
+					t.Errorf("%s: missing %q -- the span must come from the sampled\n"+
+						"timestamps, not the bucket keys:\n%s", fn, w, got)
+				}
+			}
+			// The bucket key is timestamp_ms. Selecting it directly as an
+			// endpoint is the mistake this test exists to catch.
+			for _, bad := range []string{
+				"minIf(timestamp_ms, source = 1) OVER cnt_close_wnd as first_ts",
+				"maxIf(timestamp_ms, source = 1) OVER cnt_close_wnd as last_ts",
+			} {
+				if strings.Contains(got, bad) {
+					t.Errorf("%s: %q measures the interval between buckets, not\n"+
+						"between the two sampled values:\n%s", fn, bad, got)
+				}
+			}
+		})
 	}
-	if !strings.Contains(got, "if(open_cnt > 0, start_open, start_close)") {
-		t.Errorf("missing open_cnt based start selection:\n%s", got)
+}
+
+// TestRateDividesBySpanNotRange guards the defect that motivated this shape.
+// Dividing the observed change by the full range assumes the samples covered all
+// of it. Whenever the newest sample lags the step -- always true at the last step
+// of a window, and common mid-window with jittered scrapes -- they did not, and
+// the result is understated in proportion to how much of the range they missed.
+func TestRateDividesBySpanNotRange(t *testing.T) {
+	got := transpileRange(t, `rate(x{job="j"}[5m])`)
+	if !strings.Contains(got, "c_change / c_span_sec as val") {
+		t.Errorf("rate must divide by the interval the change was measured over:\n%s", got)
+	}
+	if strings.Contains(got, "c_change / 300.000000") ||
+		strings.Contains(got, "c_span_sec * 300.000000 as val") {
+		t.Errorf("rate must not normalise by the range:\n%s", got)
+	}
+}
+
+// TestIncreaseIsRateOverTheRange guards the one difference between them: increase
+// reports the same slope over the whole range instead of per second, which is why
+// it is a counter function that is not a rate one.
+func TestIncreaseIsRateOverTheRange(t *testing.T) {
+	inc := transpileRange(t, `increase(x{job="j"}[5m])`)
+	if !strings.Contains(inc, "c_change / c_span_sec * 300.000000 as val") {
+		t.Errorf("increase must scale the slope by the range:\n%s", inc)
+	}
+	if !strings.Contains(transpileRange(t, `rate(x{job="j"}[5m])`), "c_change / c_span_sec as val") {
+		t.Error("rate must not carry the range scaling increase does")
+	}
+}
+
+// TestCounterResetsStopAtTheRangeBoundary guards the reset correction against
+// double counting. The earliest in-range sample compares against a sample outside
+// the range, so any drop it records happened before the range began and is not
+// part of the change measured inside it. CounterFlagsPlanner applies the same
+// correction to its transition counts via first_flag.
+func TestCounterResetsStopAtTheRangeBoundary(t *testing.T) {
+	for _, fn := range []string{"rate", "increase"} {
+		t.Run(fn, func(t *testing.T) {
+			got := transpileRange(t, fn+`(x{job="j"}[5m])`)
+			if !strings.Contains(got,
+				"argMinIf(reset, timestamp_ms, source = 1) OVER cnt_close_wnd as first_reset") {
+				t.Errorf("%s: missing the boundary reset:\n%s", fn, got)
+			}
+			if !strings.Contains(got, "last_v - first_v + (resets - first_reset) as c_change") {
+				t.Errorf("%s: boundary reset must be subtracted from the total:\n%s", fn, got)
+			}
+		})
+	}
+	// delta has no reset correction at all, so it has nothing to subtract.
+	if got := transpileRange(t, `delta(x{job="j"}[5m])`); !strings.Contains(got, "last_v - first_v as c_change") {
+		t.Errorf("delta must measure the raw change:\n%s", got)
+	}
+}
+
+// TestCounterProbesOnlyTheRange guards the removal of the second window. The
+// change is measured between the first and last sample inside (t-range, t]; a
+// sample before the range is not one of the two endpoints, so probing for one is
+// work that no longer feeds the result.
+func TestCounterProbesOnlyTheRange(t *testing.T) {
+	got := transpileRange(t, `rate(x{job="j"}[5m])`)
+	for _, bad := range []string{"cnt_open_wnd", "start_open", "open_cnt", "cnt_start"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("%q belongs to the pre-range probe, which no longer feeds the value:\n%s", bad, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`rate`, `increase` and `delta` in the ClickHouse pushdown compute the change between two samples and then divide by the **full range**. That is only correct if those samples span the range. Whenever the newest in-range sample lags the step timestamp they don't, and the result is understated in exact proportion to the shortfall.

This is guaranteed at the **last step of every window** — the newest sample is always somewhat older than "now" — where it renders as a dip at the right-hand edge of every `rate` panel. It also happens mid-window whenever scrapes are jittered or the step differs from the scrape interval.

Worked through the code, for a counter scraped every 15s read at a 60s step. `BucketProducer` bounds the read at `timestamp_ns <= ctx.To`, so the final bucket holds one sample rather than four. Its `argMaxMerge(last)` therefore sits at the bucket key instead of 45s later, while the first bucket's sits 45s past its own key. The change spans 195s; the divisor says 240. The reported rate is 13/16 of the true one.

## What was wrong

**1. Normalisation.** `(last - first) / range` → `(last - first) / (last_ts - first_ts)`. The slope is measured over the interval the change actually happened in. `increase` and `delta` scale that slope by the range; `rate` reports it per second, so the three differ only by whether the reset correction and the range scaling apply.

**2. The interval was measured on the wrong clock.** `val` is `argMaxMerge(last)` — the *last sample in the bucket* — but the endpoints were the *bucket keys*. Interior buckets are full so the offset cancels; the truncated final bucket does not. Both endpoints now carry `val_ts`, the sampled timestamp, so the change and the interval come from the same two samples.

**3. Reset correction reached outside the range.** The `reset` flagged on the earliest in-range sample compares against its predecessor, which lies *before* the range. That drop happened outside the window and is not part of the change measured inside it. Subtracted via `first_reset` — the same correction `CounterFlagsPlanner` already applies through `first_flag`.

**4. The pre-range probe is gone.** A sample before the range is no longer one of the endpoints, so `cnt_open_wnd`, `start_open`, `open_cnt` and the `cnt_start` CTE no longer feed the result. One window function instead of two.

## Behaviour change worth flagging

The emit condition moves from `open_cnt + close_cnt > 1` to `last_ts > first_ts`: **two samples inside the range**, where previously a pre-range sample could supply the second endpoint.

A series scraped less often than the query range — e.g. a 2-minute scrape queried with `rate(x[1m])` — will stop producing points. It has no interval inside the range to measure a slope over. Keeping the old behaviour would mean maintaining the pre-range formula permanently as a special case alongside the new one.

## Tests

- `TestRateDividesBySpanNotRange` — no normalising by the range constant
- `TestCounterSpanIsBetweenSamplesNotBuckets` — endpoints carry `val_ts`, not the bucket key
- `TestCounterResetsStopAtTheRangeBoundary` — the `first_reset` subtraction
- `TestIncreaseIsRateOverTheRange` — `increase` scales the slope, `rate` does not
- `TestCounterProbesOnlyTheRange` — the pre-range window stays removed

`TestCounterStartsFromSampleBeforeRange` is deleted: it asserted the pre-range baseline this PR removes.

## Scope

Only `CounterPlanner`. `CounterFlagsPlanner` (`resets`, `changes`) counts transitions and has no normalisation step. The `*_over_time` functions are plain aggregates over the frame and are unaffected.

Prerequisite for #906: that PR makes the final grid step exist, this one makes the value computed there correct.
