### PR TITLE
fix(promql): carry offset and @ through the ClickHouse pushdown

### DIFF
--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -19,6 +19,10 @@ var (
 	modQueryStart = modQueryEnd.Add(-time.Hour)
 )
 
+// modLookback is the engine lookback delta hintsForQuery runs with. Pinned
+// rather than defaulted because the span assertions are written against it.
+const modLookback = 5 * time.Minute
+
 // recordingQuerier captures the SelectHints the prometheus engine asks storage
 // for, and returns nothing. hints.End is what
 // reader/service/prom_queryable.go turns into PlannerContext.To, so it is
@@ -73,6 +77,7 @@ func hintsForQuery(t *testing.T, query string) *storage.SelectHints {
 		MaxSamples:       1e6,
 		Timeout:          time.Minute,
 		EnableAtModifier: true,
+		LookbackDelta:    modLookback,
 	})
 	q, err := engine.NewRangeQuery(context.Background(), &recordingQueryable{hints: &hints}, nil,
 		expr.Expr.String(), modQueryStart, modQueryEnd, time.Minute)
@@ -170,11 +175,9 @@ func TestAtModifierAnchorsWindow(t *testing.T) {
 // substitute as StartOrEnd rather than Timestamp and are resolved later by the
 // engine's preprocessing. The last case combines both modifiers.
 //
-// Every case here shares one range, so the span is asserted once below rather
-// than per case.
+// Each subtest additionally asserts the selected span; that check is written
+// once, inside the loop body, and runs for every case.
 func TestAtStartEndResolve(t *testing.T) {
-	// The range every query in this table selects over.
-	const atRange = 5 * time.Minute
 	for _, c := range []struct {
 		query   string
 		wantEnd int64
@@ -192,17 +195,23 @@ func TestAtStartEndResolve(t *testing.T) {
 			}
 			// End alone cannot catch a dropped @ end(): end() resolves to the
 			// query end, which is exactly what a dropped modifier falls back to.
-			// The span does catch it. @ collapses the range query onto a single
-			// evaluation instant (engine.go, getTimeRangesForSelector: a non-nil
-			// Timestamp overrides both bounds), so the engine asks for one range
-			// of samples instead of the whole query window plus that range.
+			// The span does catch it.
 			//
-			// Asserted as an upper bound, not an exact width: prometheus shaves
-			// 1ms off the lower bound to keep range selectors left-open, and
-			// that 1ms is an engine detail this test has no reason to pin.
-			if span := got.End - got.Start; span > atRange.Milliseconds() {
-				t.Errorf("@ must collapse the query onto one instant, so the selected span is one range:\n got span = %d ms (Start = %d, End = %d)\nwant span <= %d ms",
-					span, got.Start, got.End, atRange.Milliseconds())
+			// The span is bounded by the lookback, not by the [5m] in the query
+			// text. The range function is folded into SQL, so what reaches the
+			// engine is a bare instant selector with hints.Range == 0, and
+			// getTimeRangesForSelector then takes its lookback branch rather
+			// than its range branch (engine.go:997-1004). @ collapses the query
+			// onto a single evaluation instant, so the engine reads one lookback
+			// window instead of the whole query window plus a lookback.
+			//
+			// Asserted as an upper bound, not an exact width: that branch shaves
+			// 1ms off the lower bound to exclude samples landing precisely a
+			// lookback before the eval time, and that 1ms is an engine detail
+			// this test has no reason to pin.
+			if span := got.End - got.Start; span > modLookback.Milliseconds() {
+				t.Errorf("@ must collapse the query onto one instant, so the selected span is one lookback:\n got span = %d ms (Start = %d, End = %d)\nwant span <= %d ms",
+					span, got.Start, got.End, modLookback.Milliseconds())
 			}
 		})
 	}

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -109,3 +109,28 @@ func TestRangeFnOffsetShiftsWindow(t *testing.T) {
 		})
 	}
 }
+
+// TestAggOffsetShiftsWindow guards the cross-series aggregation path, which
+// builds its substitute in a second place (Aggregate.aggregate). The last case
+// also covers folding: the inner range function is substituted first, and the
+// outer aggregation clones that already-synthetic selector, so the offset has to
+// survive two hops.
+func TestAggOffsetShiftsWindow(t *testing.T) {
+	for _, c := range []struct {
+		query string
+		shift time.Duration
+	}{
+		{`sum(http_requests_total{job="j"} offset 1h)`, time.Hour},
+		{`count(http_requests_total{job="j"} offset 15m)`, 15 * time.Minute},
+		{`sum by (job) (rate(http_requests_total{job="j"}[5m] offset 2h))`, 2 * time.Hour},
+	} {
+		t.Run(c.query, func(t *testing.T) {
+			got := hintsForQuery(t, c.query)
+			want := modQueryEnd.UnixMilli() - c.shift.Milliseconds()
+			if got.End != want {
+				t.Errorf("offset must shift the queried window back:\n got End = %d\nwant End = %d (query end %d minus %v)",
+					got.End, want, modQueryEnd.UnixMilli(), c.shift)
+			}
+		})
+	}
+}

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -23,10 +23,8 @@ var (
 // rather than defaulted because the span assertions are written against it.
 const modLookback = 5 * time.Minute
 
-// recordingQuerier captures the SelectHints the prometheus engine asks storage
-// for, and returns nothing. hints.End is what
-// reader/service/prom_queryable.go turns into PlannerContext.To, so it is
-// exactly the window the accelerated SQL will read.
+// recordingQuerier captures the SelectHints the engine asks storage for.
+// hints.End is what prom_queryable turns into PlannerContext.To.
 type recordingQuerier struct{ hints *[]*storage.SelectHints }
 
 func (r *recordingQuerier) Select(_ context.Context, _ bool, h *storage.SelectHints,
@@ -53,12 +51,9 @@ func (r *recordingQueryable) Querier(int64, int64) (storage.Querier, error) {
 	return &recordingQuerier{hints: r.hints}, nil
 }
 
-// hintsForQuery transpiles query and runs the residual expression through a real
-// prometheus engine, returning the single SelectHints the engine produced.
-//
-// Asserting on hints rather than on generated SQL tests the actual contract --
-// does the engine ask for the right window? -- and stays valid across planner
-// refactors.
+// hintsForQuery transpiles query, runs the residual through a real prometheus
+// engine, and returns the single SelectHints produced. Asserting on hints rather
+// than generated SQL tests the contract and survives planner refactors.
 func hintsForQuery(t *testing.T, query string) *storage.SelectHints {
 	t.Helper()
 	expr, err := promql_parser.Parse(query)
@@ -95,10 +90,8 @@ func hintsForQuery(t *testing.T, query string) *storage.SelectHints {
 	return hints[0]
 }
 
-// TestRangeFnOffsetShiftsWindow guards the range-function path: an offset must
-// translate the queried window back by exactly that duration. Before the fix the
-// substitute selector was built bare, so the offset never reached the engine and
-// rate(x[5m] offset 1h) silently returned the current rate.
+// TestRangeFnOffsetShiftsWindow: on the range-function path, an offset must
+// translate the queried window back by exactly that duration.
 func TestRangeFnOffsetShiftsWindow(t *testing.T) {
 	for _, c := range []struct {
 		query string
@@ -119,11 +112,8 @@ func TestRangeFnOffsetShiftsWindow(t *testing.T) {
 	}
 }
 
-// TestAggOffsetShiftsWindow guards the cross-series aggregation path, which
-// builds its substitute in a second place (Aggregate.aggregate). The last case
-// also covers folding: the inner range function is substituted first, and the
-// outer aggregation clones that already-synthetic selector, so the offset has to
-// survive two hops.
+// TestAggOffsetShiftsWindow: same, for the aggregation path's separate
+// substitute site. The last case folds both sites, so the offset survives two hops.
 func TestAggOffsetShiftsWindow(t *testing.T) {
 	for _, c := range []struct {
 		query string
@@ -144,13 +134,8 @@ func TestAggOffsetShiftsWindow(t *testing.T) {
 	}
 }
 
-// TestAtModifierAnchorsWindow guards @: the window must collapse onto the given
-// instant. @ was explicitly enabled for users in issue #769
-// (EnableAtModifier: true in reader/router/prometheus_query_range.go); the v5.0.0
-// pushdown silently undid that for every accelerated expression.
-//
-// Only the window is asserted; the value-side bucketing behaviour and its
-// measured bounds are documented on optimizer.substituteSelector.
+// TestAtModifierAnchorsWindow: @ must collapse the window onto the given instant.
+// Window only; value-side bucketing is documented on optimizer.substituteSelector.
 func TestAtModifierAnchorsWindow(t *testing.T) {
 	const atSeconds = 1699000000
 	for _, q := range []string{
@@ -168,12 +153,8 @@ func TestAtModifierAnchorsWindow(t *testing.T) {
 	}
 }
 
-// TestAtStartEndResolve guards the @ start() / @ end() forms, which reach the
-// substitute as StartOrEnd rather than Timestamp and are resolved later by the
-// engine's preprocessing. The last case combines both modifiers.
-//
-// Each subtest additionally asserts the selected span; that check is written
-// once, inside the loop body, and runs for every case.
+// TestAtStartEndResolve: @ start() / @ end() reach the substitute as StartOrEnd
+// rather than Timestamp. The last case combines both modifiers.
 func TestAtStartEndResolve(t *testing.T) {
 	for _, c := range []struct {
 		query   string
@@ -191,21 +172,11 @@ func TestAtStartEndResolve(t *testing.T) {
 					got.End, c.wantEnd)
 			}
 			// End alone cannot catch a dropped @ end(): end() resolves to the
-			// query end, which is exactly what a dropped modifier falls back to.
-			// The span does catch it.
-			//
-			// The span is bounded by the lookback, not by the [5m] in the query
-			// text. The range function is folded into SQL, so what reaches the
-			// engine is a bare instant selector with hints.Range == 0, and
-			// getTimeRangesForSelector then takes its lookback branch rather
-			// than its range branch (engine.go:997-1004). @ collapses the query
-			// onto a single evaluation instant, so the engine reads one lookback
-			// window instead of the whole query window plus a lookback.
-			//
-			// Asserted as an upper bound, not an exact width: that branch shaves
-			// 1ms off the lower bound to exclude samples landing precisely a
-			// lookback before the eval time, and that 1ms is an engine detail
-			// this test has no reason to pin.
+			// query end, which is what a dropped modifier falls back to anyway.
+			// The span does catch it. Bounded by the lookback, not the [5m]:
+			// the range is folded into SQL, so hints.Range == 0 and
+			// getTimeRangesForSelector takes its lookback branch. Upper bound
+			// because that branch shaves 1ms off the lower edge.
 			if span := got.End - got.Start; span > modLookback.Milliseconds() {
 				t.Errorf("@ must collapse the query onto one instant, so the selected span is one lookback:\n got span = %d ms (Start = %d, End = %d)\nwant span <= %d ms",
 					span, got.Start, got.End, modLookback.Milliseconds())

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -169,7 +169,12 @@ func TestAtModifierAnchorsWindow(t *testing.T) {
 // TestAtStartEndResolve guards the @ start() / @ end() forms, which reach the
 // substitute as StartOrEnd rather than Timestamp and are resolved later by the
 // engine's preprocessing. The last case combines both modifiers.
+//
+// Every case here shares one range, so the span is asserted once below rather
+// than per case.
 func TestAtStartEndResolve(t *testing.T) {
+	// The range every query in this table selects over.
+	const atRange = 5 * time.Minute
 	for _, c := range []struct {
 		query   string
 		wantEnd int64
@@ -184,6 +189,20 @@ func TestAtStartEndResolve(t *testing.T) {
 			if got.End != c.wantEnd {
 				t.Errorf("@ start()/end() must resolve against the query window:\n got End = %d\nwant End = %d",
 					got.End, c.wantEnd)
+			}
+			// End alone cannot catch a dropped @ end(): end() resolves to the
+			// query end, which is exactly what a dropped modifier falls back to.
+			// The span does catch it. @ collapses the range query onto a single
+			// evaluation instant (engine.go, getTimeRangesForSelector: a non-nil
+			// Timestamp overrides both bounds), so the engine asks for one range
+			// of samples instead of the whole query window plus that range.
+			//
+			// Asserted as an upper bound, not an exact width: prometheus shaves
+			// 1ms off the lower bound to keep range selectors left-open, and
+			// that 1ms is an engine detail this test has no reason to pin.
+			if span := got.End - got.Start; span > atRange.Milliseconds() {
+				t.Errorf("@ must collapse the query onto one instant, so the selected span is one range:\n got span = %d ms (Start = %d, End = %d)\nwant span <= %d ms",
+					span, got.Start, got.End, atRange.Milliseconds())
 			}
 		})
 	}

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -150,9 +150,10 @@ func TestAggOffsetShiftsWindow(t *testing.T) {
 // pushdown silently undid that for every accelerated expression.
 //
 // Only the window is asserted. The accelerated path buckets samples on the step
-// grid, so an @ instant that is not step aligned resolves to the enclosing
-// bucket -- the value is accurate to within one step, exact only when the
-// instant is step aligned. That deviation is deliberate and documented on
+// grid, so an unaligned @ instant lands on the enclosing bucket's timestamp, up
+// to one step early; the value that row carries is still the one at the instant,
+// because BucketProducer bounds the read at ctx.To. What is inexact is the 15s
+// downsample, not the step. Measured against clickhouse 25.3 and documented on
 // substituteSelector.
 func TestAtModifierAnchorsWindow(t *testing.T) {
 	const atSeconds = 1699000000

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -149,12 +149,8 @@ func TestAggOffsetShiftsWindow(t *testing.T) {
 // (EnableAtModifier: true in reader/router/prometheus_query_range.go); the v5.0.0
 // pushdown silently undid that for every accelerated expression.
 //
-// Only the window is asserted. The accelerated path buckets samples on the step
-// grid, so an unaligned @ instant lands on the enclosing bucket's SQL row, whose
-// timestamp is up to one step early; the value that row carries is still the one
-// at the instant to 15s granularity, because BucketProducer bounds the read at
-// ctx.To. What is inexact is that 15s downsample, not the step. Measured against
-// clickhouse 25.3 and documented on substituteSelector.
+// Only the window is asserted; the value-side bucketing behaviour and its
+// measured bounds are documented on optimizer.substituteSelector.
 func TestAtModifierAnchorsWindow(t *testing.T) {
 	const atSeconds = 1699000000
 	for _, q := range []string{

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -79,7 +79,11 @@ func hintsForQuery(t *testing.T, query string) *storage.SelectHints {
 	if err != nil {
 		t.Fatalf("new range query %s: %v", query, err)
 	}
-	q.Exec(context.Background())
+	defer q.Close()
+	res := q.Exec(context.Background())
+	if res.Err != nil {
+		t.Fatalf("exec %s: %v", query, res.Err)
+	}
 	if len(hints) != 1 {
 		t.Fatalf("%s: expected exactly one Select call, got %d", query, len(hints))
 	}
@@ -130,6 +134,56 @@ func TestAggOffsetShiftsWindow(t *testing.T) {
 			if got.End != want {
 				t.Errorf("offset must shift the queried window back:\n got End = %d\nwant End = %d (query end %d minus %v)",
 					got.End, want, modQueryEnd.UnixMilli(), c.shift)
+			}
+		})
+	}
+}
+
+// TestAtModifierAnchorsWindow guards @: the window must collapse onto the given
+// instant. @ was explicitly enabled for users in issue #769
+// (EnableAtModifier: true in reader/router/prometheus_query_range.go); the v5.0.0
+// pushdown silently undid that for every accelerated expression.
+//
+// Only the window is asserted. The accelerated path buckets samples on the step
+// grid, so an @ instant that is not step aligned resolves to the enclosing
+// bucket -- the value is accurate to within one step, exact only when the
+// instant is step aligned. That deviation is deliberate and documented on
+// substituteSelector.
+func TestAtModifierAnchorsWindow(t *testing.T) {
+	const atSeconds = 1699000000
+	for _, q := range []string{
+		`rate(http_requests_total{job="j"}[5m] @ 1699000000)`,
+		`sum(http_requests_total{job="j"} @ 1699000000)`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			got := hintsForQuery(t, q)
+			want := int64(atSeconds) * 1000
+			if got.End != want {
+				t.Errorf("@ must anchor the queried window to the given instant:\n got End = %d\nwant End = %d",
+					got.End, want)
+			}
+		})
+	}
+}
+
+// TestAtStartEndResolve guards the @ start() / @ end() forms, which reach the
+// substitute as StartOrEnd rather than Timestamp and are resolved later by the
+// engine's preprocessing. The last case combines both modifiers.
+func TestAtStartEndResolve(t *testing.T) {
+	for _, c := range []struct {
+		query   string
+		wantEnd int64
+	}{
+		{`rate(http_requests_total{job="j"}[5m] @ start())`, modQueryStart.UnixMilli()},
+		{`rate(http_requests_total{job="j"}[5m] @ end())`, modQueryEnd.UnixMilli()},
+		{`rate(http_requests_total{job="j"}[5m] @ end() offset 30m)`,
+			modQueryEnd.UnixMilli() - (30 * time.Minute).Milliseconds()},
+	} {
+		t.Run(c.query, func(t *testing.T) {
+			got := hintsForQuery(t, c.query)
+			if got.End != c.wantEnd {
+				t.Errorf("@ start()/end() must resolve against the query window:\n got End = %d\nwant End = %d",
+					got.End, c.wantEnd)
 			}
 		})
 	}

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -1,0 +1,111 @@
+package promql_transpiler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// modQueryStart/modQueryEnd describe a one hour range query at a 60s step. Every
+// assertion in this file is written against these two instants.
+var (
+	modQueryEnd   = time.Unix(1700000000, 0)
+	modQueryStart = modQueryEnd.Add(-time.Hour)
+)
+
+// recordingQuerier captures the SelectHints the prometheus engine asks storage
+// for, and returns nothing. hints.End is what
+// reader/service/prom_queryable.go turns into PlannerContext.To, so it is
+// exactly the window the accelerated SQL will read.
+type recordingQuerier struct{ hints *[]*storage.SelectHints }
+
+func (r *recordingQuerier) Select(_ context.Context, _ bool, h *storage.SelectHints,
+	_ ...*labels.Matcher) storage.SeriesSet {
+	*r.hints = append(*r.hints, h)
+	return storage.EmptySeriesSet()
+}
+
+func (r *recordingQuerier) LabelValues(context.Context, string, *storage.LabelHints,
+	...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+func (r *recordingQuerier) LabelNames(context.Context, *storage.LabelHints,
+	...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+func (r *recordingQuerier) Close() error { return nil }
+
+type recordingQueryable struct{ hints *[]*storage.SelectHints }
+
+func (r *recordingQueryable) Querier(int64, int64) (storage.Querier, error) {
+	return &recordingQuerier{hints: r.hints}, nil
+}
+
+// hintsForQuery transpiles query and runs the residual expression through a real
+// prometheus engine, returning the single SelectHints the engine produced.
+//
+// Asserting on hints rather than on generated SQL tests the actual contract --
+// does the engine ask for the right window? -- and stays valid across planner
+// refactors.
+func hintsForQuery(t *testing.T, query string) *storage.SelectHints {
+	t.Helper()
+	expr, err := promql_parser.Parse(query)
+	if err != nil {
+		t.Fatalf("parse %s: %v", query, err)
+	}
+	expr, err = TranspileExpressionV2(expr)
+	if err != nil {
+		t.Fatalf("transpile %s: %v", query, err)
+	}
+	if len(expr.Substitutes) == 0 {
+		t.Fatalf("%s: not accelerated, there is no pushdown window to assert on", query)
+	}
+	var hints []*storage.SelectHints
+	engine := promql.NewEngine(promql.EngineOpts{
+		MaxSamples:       1e6,
+		Timeout:          time.Minute,
+		EnableAtModifier: true,
+	})
+	q, err := engine.NewRangeQuery(context.Background(), &recordingQueryable{hints: &hints}, nil,
+		expr.Expr.String(), modQueryStart, modQueryEnd, time.Minute)
+	if err != nil {
+		t.Fatalf("new range query %s: %v", query, err)
+	}
+	q.Exec(context.Background())
+	if len(hints) != 1 {
+		t.Fatalf("%s: expected exactly one Select call, got %d", query, len(hints))
+	}
+	return hints[0]
+}
+
+// TestRangeFnOffsetShiftsWindow guards the range-function path: an offset must
+// translate the queried window back by exactly that duration. Before the fix the
+// substitute selector was built bare, so the offset never reached the engine and
+// rate(x[5m] offset 1h) silently returned the current rate.
+func TestRangeFnOffsetShiftsWindow(t *testing.T) {
+	for _, c := range []struct {
+		query string
+		shift time.Duration
+	}{
+		{`rate(http_requests_total{job="j"}[5m] offset 1h)`, time.Hour},
+		{`last_over_time(http_requests_total{job="j"}[5m] offset 30m)`, 30 * time.Minute},
+		{`increase(http_requests_total{job="j"}[5m] offset 2h)`, 2 * time.Hour},
+	} {
+		t.Run(c.query, func(t *testing.T) {
+			got := hintsForQuery(t, c.query)
+			want := modQueryEnd.UnixMilli() - c.shift.Milliseconds()
+			if got.End != want {
+				t.Errorf("offset must shift the queried window back:\n got End = %d\nwant End = %d (query end %d minus %v)",
+					got.End, want, modQueryEnd.UnixMilli(), c.shift)
+			}
+		})
+	}
+}

--- a/reader/promql/promql_transpiler/modifiers_test.go
+++ b/reader/promql/promql_transpiler/modifiers_test.go
@@ -150,11 +150,11 @@ func TestAggOffsetShiftsWindow(t *testing.T) {
 // pushdown silently undid that for every accelerated expression.
 //
 // Only the window is asserted. The accelerated path buckets samples on the step
-// grid, so an unaligned @ instant lands on the enclosing bucket's timestamp, up
-// to one step early; the value that row carries is still the one at the instant,
-// because BucketProducer bounds the read at ctx.To. What is inexact is the 15s
-// downsample, not the step. Measured against clickhouse 25.3 and documented on
-// substituteSelector.
+// grid, so an unaligned @ instant lands on the enclosing bucket's SQL row, whose
+// timestamp is up to one step early; the value that row carries is still the one
+// at the instant to 15s granularity, because BucketProducer bounds the read at
+// ctx.To. What is inexact is that 15s downsample, not the step. Measured against
+// clickhouse 25.3 and documented on substituteSelector.
 func TestAtModifierAnchorsWindow(t *testing.T) {
 	const atSeconds = 1699000000
 	for _, q := range []string{

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -1,0 +1,33 @@
+package optimizer
+
+import (
+	prom_parser "github.com/prometheus/prometheus/promql/parser"
+)
+
+// substituteSelector clones src as the synthetic selector that stands in for an
+// expression pushed down into ClickHouse.
+//
+// Cloning rather than building a fresh node keeps every evaluation modifier the
+// engine needs in order to compute the substitute's time window -- offset, @,
+// and whatever prometheus adds next. The engine derives hints.Start/End from
+// these fields (promql/engine.go, getTimeRangesForSelector) and
+// reader/service/prom_queryable.go turns those hints into PlannerContext
+// From/To, so a modifier dropped here becomes a silently wrong query window
+// rather than an error.
+//
+// Note on @: the accelerated path buckets samples on the step grid, so an @
+// instant that is not step aligned resolves to the enclosing bucket. The value
+// is therefore accurate to within one step, and exact only for step aligned
+// instants. The window itself is always exact.
+func substituteSelector(src *prom_parser.VectorSelector, metricName string) *prom_parser.VectorSelector {
+	sub := *src
+	sub.Name = metricName
+	// The engine re-derives the __name__ matcher from Name. Carrying the
+	// original matchers would leave __name__ pointing at the real metric and
+	// break the substitute lookup in prom_queryable.transpileLabelMatchers.
+	sub.LabelMatchers = nil
+	// Populated by the engine at query preparation time; never carried across.
+	sub.UnexpandedSeriesSet = nil
+	sub.Series = nil
+	return &sub
+}

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -18,13 +18,18 @@ import (
 // Note on @: the accelerated path buckets samples on the step grid -- see the
 // intDiv(timestamp_ns, step) * step floor in planner/bucket_producer.go -- so an
 // @ instant that is not step aligned resolves to the enclosing bucket. The value
-// is therefore accurate to within one step, and exact only for step aligned
-// instants.
+// is therefore accurate to within one step.
+//
+// The step aligned case is not exact either on clickhouse < 24.11: the arrayJoin
+// fallback in planner/fill_gaps.go caps at ctx.To with a half-open range(), so
+// the node landing exactly on the instant is never emitted. Tracked in #906.
 //
 // The queried end is exact: hints.End, and so PlannerContext.To, lands on the
 // instant to the millisecond. The start is not, but for a reason unrelated to @:
-// reader/service/prom_queryable.go floors hints.Start to a 15s grid before
-// deriving From, for every accelerated query with or without a modifier.
+// reader/service/prom_queryable.go floors hints.Start to a 15s grid unless
+// COMPAT_4_0_19 is set, for every accelerated query with or without a modifier,
+// and derives From as hints.Start - hints.Range (always a plain floor here,
+// since a substitute selector carries no range).
 func substituteSelector(src *prom_parser.VectorSelector, metricName string) *prom_parser.VectorSelector {
 	sub := *src
 	sub.Name = metricName

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -15,10 +15,16 @@ import (
 // From/To, so a modifier dropped here becomes a silently wrong query window
 // rather than an error.
 //
-// Note on @: the accelerated path buckets samples on the step grid, so an @
-// instant that is not step aligned resolves to the enclosing bucket. The value
+// Note on @: the accelerated path buckets samples on the step grid -- see the
+// intDiv(timestamp_ns, step) * step floor in planner/bucket_producer.go -- so an
+// @ instant that is not step aligned resolves to the enclosing bucket. The value
 // is therefore accurate to within one step, and exact only for step aligned
-// instants. The window itself is always exact.
+// instants.
+//
+// The queried end is exact: hints.End, and so PlannerContext.To, lands on the
+// instant to the millisecond. The start is not, but for a reason unrelated to @:
+// reader/service/prom_queryable.go floors hints.Start to a 15s grid before
+// deriving From, for every accelerated query with or without a modifier.
 func substituteSelector(src *prom_parser.VectorSelector, metricName string) *prom_parser.VectorSelector {
 	sub := *src
 	sub.Name = metricName

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -4,60 +4,22 @@ import (
 	prom_parser "github.com/prometheus/prometheus/promql/parser"
 )
 
-// substituteSelector clones src as the synthetic selector that stands in for an
+// substituteSelector clones src as the synthetic selector standing in for an
 // expression pushed down into ClickHouse.
 //
-// Cloning rather than building a fresh node keeps every evaluation modifier the
-// engine needs in order to compute the substitute's time window -- offset, @,
-// and whatever prometheus adds next. The engine derives hints.Start/End from
-// these fields (promql/engine.go, getTimeRangesForSelector) and
-// reader/service/prom_queryable.go turns those hints into PlannerContext
-// From/To, so a modifier dropped here becomes a silently wrong query window
-// rather than an error.
+// Clone rather than build fresh: the engine derives the substitute's time window
+// from the modifier fields (offset, @, and whatever prometheus adds next), so a
+// dropped field is a silently wrong window rather than an error.
 //
-// Note on @: the accelerated path emits one row per step bucket -- see the
-// intDiv(timestamp_ns, step) * step floor in planner/bucket_producer.go -- so an
-// @ instant that is not step aligned lands on the enclosing bucket, whose SQL
-// row timestamp is up to one step early. (The HTTP response is unaffected: it
-// carries the engine's own grid timestamps.) The value that row holds does not go
-// stale with it: BucketProducer bounds the read at timestamp_ns <= ctx.To, and
-// ctx.To is the evaluation instant (the @ instant shifted by any offset), so the
-// bucket aggregate covers the 15s buckets at or before it -- to 15s granularity,
-// see below.
-//
-// Measured, not inferred: against clickhouse 25.3.14.14 on the e2e stack, which
-// takes the WITH FILL ... STALENESS path. A counter sampled every 15s, read at a
-// 60s step, @ on a bucket boundary and @ 40s and 55s past one all returned the
-// same value as stock prometheus 2.53.0 fed the identical samples.
-//
-// The residual inexactness is the 15s downsample, not the step: metrics_15s
-// stamps every sample with its 15s floor, so a raw sample landing after the @
-// instant but inside the same 15s bucket is read as though it were at the bucket
-// start. Measured: samples at t and t+7s, @ t+3s returned the t+7s value where
-// prometheus returned the t value. That is bounded by 15s. Below a 15s step the
-// pushdown is still taken (the optimizer decides at transpile time, not from
-// hints), so the bound is 15s in absolute terms, not one step.
-//
-// None of the above was checked on clickhouse < 24.11, where planner/fill_gaps.go
-// takes the arrayJoin fallback instead. That path caps at ctx.To with a half-open
-// range(), so by inspection the node landing exactly on the instant is never
-// emitted. Tracked in #906.
-//
-// The queried end is exact: hints.End, and so PlannerContext.To, lands on the
-// evaluation instant -- the @ instant shifted by any offset -- to the
-// millisecond. The start is not, but for a reason unrelated to @:
-// reader/service/prom_queryable.go floors hints.Start to a 15s grid unless
-// COMPAT_4_0_19 is set, for every accelerated query with or without a modifier,
-// and derives From as hints.Start - hints.Range (always a plain floor here,
-// since a substitute selector carries no range).
+// @ resolves to 15s granularity, not to the instant: metrics_15s stamps every
+// sample with its 15s floor, so a sample landing after the @ instant but inside
+// the same bucket is read as though it were at the bucket start.
 func substituteSelector(src *prom_parser.VectorSelector, metricName string) *prom_parser.VectorSelector {
 	sub := *src
 	sub.Name = metricName
-	// The engine re-derives the __name__ matcher from Name. Carrying the
-	// original matchers would leave __name__ pointing at the real metric and
-	// break the substitute lookup in prom_queryable.transpileLabelMatchers.
+	// Load-bearing: the engine re-derives __name__ from Name, so keeping the
+	// original matchers breaks the substitute lookup in prom_queryable.
 	sub.LabelMatchers = nil
-	// Populated by the engine at query preparation time; never carried across.
 	sub.UnexpandedSeriesSet = nil
 	sub.Series = nil
 	return &sub

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -21,8 +21,9 @@ import (
 // row timestamp is up to one step early. (The HTTP response is unaffected: it
 // carries the engine's own grid timestamps.) The value that row holds does not go
 // stale with it: BucketProducer bounds the read at timestamp_ns <= ctx.To, and
-// ctx.To is the instant to the millisecond, so the bucket aggregate covers the
-// 15s buckets at or before @ -- to 15s granularity, see below.
+// ctx.To is the evaluation instant (the @ instant shifted by any offset), so the
+// bucket aggregate covers the 15s buckets at or before it -- to 15s granularity,
+// see below.
 //
 // Measured, not inferred: against clickhouse 25.3.14.14 on the e2e stack, which
 // takes the WITH FILL ... STALENESS path. A counter sampled every 15s, read at a
@@ -33,9 +34,9 @@ import (
 // stamps every sample with its 15s floor, so a raw sample landing after the @
 // instant but inside the same 15s bucket is read as though it were at the bucket
 // start. Measured: samples at t and t+7s, @ t+3s returned the t+7s value where
-// prometheus returned the t value. That is bounded by 15s, and so by one step --
-// the accelerated path is only reached for steps of 15s or more (useRawData in
-// reader/service/prom_queryable.go).
+// prometheus returned the t value. That is bounded by 15s. Below a 15s step the
+// pushdown is still taken (the optimizer decides at transpile time, not from
+// hints), so the bound is 15s in absolute terms, not one step.
 //
 // None of the above was checked on clickhouse < 24.11, where planner/fill_gaps.go
 // takes the arrayJoin fallback instead. That path caps at ctx.To with a half-open
@@ -43,7 +44,8 @@ import (
 // emitted. Tracked in #906.
 //
 // The queried end is exact: hints.End, and so PlannerContext.To, lands on the
-// instant to the millisecond. The start is not, but for a reason unrelated to @:
+// evaluation instant -- the @ instant shifted by any offset -- to the
+// millisecond. The start is not, but for a reason unrelated to @:
 // reader/service/prom_queryable.go floors hints.Start to a 15s grid unless
 // COMPAT_4_0_19 is set, for every accelerated query with or without a modifier,
 // and derives From as hints.Start - hints.Range (always a plain floor here,

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -17,11 +17,12 @@ import (
 //
 // Note on @: the accelerated path emits one row per step bucket -- see the
 // intDiv(timestamp_ns, step) * step floor in planner/bucket_producer.go -- so an
-// @ instant that is not step aligned lands on the enclosing bucket, whose
-// timestamp is up to one step early. The value that row carries does not go stale
-// with the timestamp: BucketProducer bounds the read at timestamp_ns <= ctx.To,
-// and ctx.To is the instant to the millisecond, so the bucket aggregate covers
-// exactly the samples at or before @.
+// @ instant that is not step aligned lands on the enclosing bucket, whose SQL
+// row timestamp is up to one step early. (The HTTP response is unaffected: it
+// carries the engine's own grid timestamps.) The value that row holds does not go
+// stale with it: BucketProducer bounds the read at timestamp_ns <= ctx.To, and
+// ctx.To is the instant to the millisecond, so the bucket aggregate covers the
+// 15s buckets at or before @ -- to 15s granularity, see below.
 //
 // Measured, not inferred: against clickhouse 25.3.14.14 on the e2e stack, which
 // takes the WITH FILL ... STALENESS path. A counter sampled every 15s, read at a
@@ -36,10 +37,10 @@ import (
 // the accelerated path is only reached for steps of 15s or more (useRawData in
 // reader/service/prom_queryable.go).
 //
-// None of the above was checked on clickhouse < 24.11, where fillGaps takes the
-// arrayJoin fallback instead. That path caps at ctx.To with a half-open range(),
-// so the node landing exactly on the instant is never emitted and even the step
-// aligned case is inexact. Tracked in #906.
+// None of the above was checked on clickhouse < 24.11, where planner/fill_gaps.go
+// takes the arrayJoin fallback instead. That path caps at ctx.To with a half-open
+// range(), so by inspection the node landing exactly on the instant is never
+// emitted. Tracked in #906.
 //
 // The queried end is exact: hints.End, and so PlannerContext.To, lands on the
 // instant to the millisecond. The start is not, but for a reason unrelated to @:

--- a/reader/promql/promql_transpiler/optimizer/substitute.go
+++ b/reader/promql/promql_transpiler/optimizer/substitute.go
@@ -15,14 +15,31 @@ import (
 // From/To, so a modifier dropped here becomes a silently wrong query window
 // rather than an error.
 //
-// Note on @: the accelerated path buckets samples on the step grid -- see the
+// Note on @: the accelerated path emits one row per step bucket -- see the
 // intDiv(timestamp_ns, step) * step floor in planner/bucket_producer.go -- so an
-// @ instant that is not step aligned resolves to the enclosing bucket. The value
-// is therefore accurate to within one step.
+// @ instant that is not step aligned lands on the enclosing bucket, whose
+// timestamp is up to one step early. The value that row carries does not go stale
+// with the timestamp: BucketProducer bounds the read at timestamp_ns <= ctx.To,
+// and ctx.To is the instant to the millisecond, so the bucket aggregate covers
+// exactly the samples at or before @.
 //
-// The step aligned case is not exact either on clickhouse < 24.11: the arrayJoin
-// fallback in planner/fill_gaps.go caps at ctx.To with a half-open range(), so
-// the node landing exactly on the instant is never emitted. Tracked in #906.
+// Measured, not inferred: against clickhouse 25.3.14.14 on the e2e stack, which
+// takes the WITH FILL ... STALENESS path. A counter sampled every 15s, read at a
+// 60s step, @ on a bucket boundary and @ 40s and 55s past one all returned the
+// same value as stock prometheus 2.53.0 fed the identical samples.
+//
+// The residual inexactness is the 15s downsample, not the step: metrics_15s
+// stamps every sample with its 15s floor, so a raw sample landing after the @
+// instant but inside the same 15s bucket is read as though it were at the bucket
+// start. Measured: samples at t and t+7s, @ t+3s returned the t+7s value where
+// prometheus returned the t value. That is bounded by 15s, and so by one step --
+// the accelerated path is only reached for steps of 15s or more (useRawData in
+// reader/service/prom_queryable.go).
+//
+// None of the above was checked on clickhouse < 24.11, where fillGaps takes the
+// arrayJoin fallback instead. That path caps at ctx.To with a half-open range(),
+// so the node landing exactly on the instant is never emitted and even the step
+// aligned case is inexact. Tracked in #906.
 //
 // The queried end is exact: hints.End, and so PlannerContext.To, lands on the
 // instant to the millisecond. The start is not, but for a reason unrelated to @:

--- a/reader/promql/promql_transpiler/optimizer/vector_agg.go
+++ b/reader/promql/promql_transpiler/optimizer/vector_agg.go
@@ -91,7 +91,5 @@ func (v *Aggregate) aggregate(fn string) prom_parser.Expr {
 			NeedsLabelsValues: false,
 		},
 	}
-	return &prom_parser.VectorSelector{
-		Name: metricName,
-	}
+	return substituteSelector(v.selector, metricName)
 }

--- a/reader/promql/promql_transpiler/optimizer/vector_range.go
+++ b/reader/promql/promql_transpiler/optimizer/vector_range.go
@@ -114,7 +114,5 @@ func (v *VectorRange) substitute(p shared.SQLRequestPlanner) prom_parser.Expr {
 			DropMetricName:    true,
 		},
 	}
-	return &prom_parser.VectorSelector{
-		Name: metricName,
-	}
+	return substituteSelector(v.selector.VectorSelector.(*prom_parser.VectorSelector), metricName)
 }


### PR DESCRIPTION
The accelerated PromQL path silently discarded `offset` and `@`. Queries returned a plausible number over the wrong window, with no error.

## Fix

One helper, used by both construction sites, cloning the source selector instead of building a bare one.
Cloning rather than whitelisting fields means a modifier prometheus adds later is carried by default.

## Negative offsets now error instead of silently lying

`sum(x offset -1h)` previously returned a result: the *unshifted* window. The offset was stripped before `EnableNegativeOffset: false` could see it, so the query looked like it worked and users had no way to tell it hadn't.
It now returns `negative offset is disabled`, matching Prometheus.

## `@` accuracy

Measured against `clickhouse-server` 25.3.14.14 with a stock `prom/prometheus:v2.53.0` fed identical samples.

`@` on a bucket boundary, 40s past, and 55s past all returned the same value as Prometheus at 60s and 15s steps. The residual error is the 15s `metrics_15s` downsample, not the step grid: samples at `t` and `t+7s` queried at `@ t+3s` return the `t+7s` value where Prometheus returns `t`. Bounded by 15s in absolute terms. Pre-existing behaviour of the accelerated path, measured here for the first time.
