### PR TITLE
ci: derive Go toolchain from go.mod

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
       - name: build static
         run: |
           go mod tidy
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
       - name: build static
         run: |
           go mod tidy

--- a/.github/workflows/go-version-sync.yml
+++ b/.github/workflows/go-version-sync.yml
@@ -26,16 +26,13 @@ jobs:
             exit 1
           fi
           echo "version=${LATEST}" >> $GITHUB_OUTPUT
-          echo "version_mm=${LATEST_MM}" >> $GITHUB_OUTPUT
           echo "Latest stable Go version: ${LATEST}"
 
       - name: Get current Go version from go.mod
         id: go-current
         run: |
           CURRENT=$(grep '^go ' go.mod | awk '{print $2}')
-          CURRENT_MM=$(echo "${CURRENT}" | grep -oE '^[0-9]+\.[0-9]+')
           echo "version=${CURRENT}" >> $GITHUB_OUTPUT
-          echo "version_mm=${CURRENT_MM}" >> $GITHUB_OUTPUT
           echo "Current Go version: ${CURRENT}"
 
       - name: Check if update is needed
@@ -111,7 +108,8 @@ jobs:
             - `scripts/deploy/docker/Dockerfile` — updated `golang` builder image
             - `go.sum` — regenerated via `go mod tidy`
 
-            > **Manual step required:** Update `go-version` in `.github/workflows/go.yml` and `.github/workflows/build_release.yml` to `${{ steps.go-latest.outputs.version_mm }}` — these cannot be updated automatically due to GitHub token restrictions on workflow files.
+            CI workflows read their toolchain from `go.mod` via `setup-go`'s
+            `go-version-file`, so no workflow file needs a manual bump.
 
             ---
             *Keeping the project up-to-date with Go releases ensures compatibility and security enhancements.*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.26'
+        go-version-file: go.mod
 
     - name: Build Gigapipe
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
 
       - name: Build gigapipe
         run: go build -o gigapipe cmd/gigapipe/main.go


### PR DESCRIPTION
## Problem

The [Go Version Sync](.github/workflows/go-version-sync.yml) job can update `go.mod`, `go.sum`, and both Dockerfiles — but not `.github/workflows/*`. The default `GITHUB_TOKEN` has no `workflows` scope, so `peter-evans/create-pull-request` refuses to push changes to workflow files.

So every sync PR (e.g. #932) ended with a *"Manual step required"* note asking a human to bump `go-version` by hand. That step gets skipped: `k6_test.yml` sat at `1.25` while everything else was on `1.26`.

## Fix

Drop the hardcoded pins and let `actions/setup-go` read `go.mod` directly:

```yaml
- name: Set up Go
  uses: actions/setup-go@v5
  with:
    go-version-file: go.mod
```

`go.mod` becomes the single source of truth. The sync job already updates it, so nothing is left over for a human — the manual step disappears rather than being automated around.
