### PR TITLE
fix(auth): constant-time Basic auth comparison and RFC 7235 challenge semantics

### DIFF
--- a/reader/utils/middleware/basic_auth.go
+++ b/reader/utils/middleware/basic_auth.go
@@ -1,32 +1,38 @@
 package middleware
 
 import (
-	"encoding/base64"
+	"crypto/sha256"
+	"crypto/subtle"
 	"net/http"
-	"strings"
 )
 
 func BasicAuthMiddleware(login, pass string) func(next http.Handler) http.Handler {
+	// Hash the configured credentials once, not per request. Comparing
+	// SHA-256 digests rather than the raw strings keeps both operands a
+	// fixed 32 bytes, so the comparison below cannot leak credential length
+	// (subtle.ConstantTimeCompare returns early when lengths differ).
+	expectedLogin := sha256.Sum256([]byte(login))
+	expectedPass := sha256.Sum256([]byte(pass))
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			auth := r.Header.Get("Authorization")
-			if auth == "" {
+			// r.BasicAuth matches the "Basic" scheme case-insensitively, as
+			// RFC 7235 §2.1 requires, and reports a missing or malformed
+			// header as !ok.
+			username, password, ok := r.BasicAuth()
+
+			// Both comparisons are evaluated before branching: folding them
+			// into one short-circuiting condition would leak, by timing,
+			// whether the login alone was correct.
+			gotLogin := sha256.Sum256([]byte(username))
+			gotPass := sha256.Sum256([]byte(password))
+			loginOK := subtle.ConstantTimeCompare(gotLogin[:], expectedLogin[:]) == 1
+			passOK := subtle.ConstantTimeCompare(gotPass[:], expectedPass[:]) == 1
+			if !ok || !loginOK || !passOK {
+				// RFC 7235 §4.1: every 401 response MUST carry a
+				// WWW-Authenticate challenge; user agents rely on it to
+				// (re)prompt for credentials.
 				w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			authParts := strings.SplitN(auth, " ", 2)
-			if len(authParts) != 2 || authParts[0] != "Basic" {
-				http.Error(w, "Invalid authorization header", http.StatusBadRequest)
-				return
-			}
-
-			payload, _ := base64.StdEncoding.DecodeString(authParts[1])
-			pair := strings.SplitN(string(payload), ":", 2)
-
-			if len(pair) != 2 || pair[0] != login ||
-				pair[1] != pass {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}

--- a/reader/utils/middleware/basic_auth_test.go
+++ b/reader/utils/middleware/basic_auth_test.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	testLogin = "user"
+	testPass  = "s3cret"
+)
+
+// serveWithAuth runs one request carrying the given Authorization header
+// (omitted entirely when authHeader is "") through BasicAuthMiddleware, and
+// reports the response plus whether the wrapped handler was reached.
+func serveWithAuth(t *testing.T, authHeader string) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	nextCalled := false
+	h := BasicAuthMiddleware(testLogin, testPass)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec, nextCalled
+}
+
+func basicHeader(login, pass string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(login+":"+pass))
+}
+
+// TestBasicAuth_Rejects covers every rejection path. Each case asserts the
+// status code, that a WWW-Authenticate challenge was sent (RFC 7235 §4.1
+// requires one on every 401), AND that the wrapped handler never ran -- a
+// status assertion alone would not prove the request was actually blocked.
+func TestBasicAuth_Rejects(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		authHeader string
+	}{
+		{"MissingHeader", ""},
+		{"NoScheme", "abc"},
+		{"BearerScheme", "Bearer " + base64.StdEncoding.EncodeToString([]byte("user:s3cret"))},
+		{"NonBase64Payload", "Basic !!!!"},
+		{"NoColonInPayload", "Basic " + base64.StdEncoding.EncodeToString([]byte("usernopass"))},
+		{"WrongLogin", basicHeader("wrong", testPass)},
+		{"WrongPass", basicHeader(testLogin, "wrong")},
+		{"EmptyCredentials", basicHeader("", "")},
+		// A prefix of the real password must not be accepted.
+		{"PassPrefix", basicHeader(testLogin, "s3cre")},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rec, nextCalled := serveWithAuth(t, c.authHeader)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status: got %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+			if got := rec.Header().Get("WWW-Authenticate"); got == "" {
+				t.Fatal("401 response is missing the WWW-Authenticate challenge")
+			}
+			if nextCalled {
+				t.Fatal("wrapped handler ran for a rejected request")
+			}
+		})
+	}
+}
+
+// TestBasicAuth_Accepts confirms valid headers reach the wrapped handler,
+// including a lowercase scheme: RFC 7235 §2.1 makes the auth-scheme token
+// case-insensitive.
+func TestBasicAuth_Accepts(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		authHeader string
+	}{
+		{"CanonicalScheme", basicHeader(testLogin, testPass)},
+		{"LowercaseScheme", "basic " + base64.StdEncoding.EncodeToString([]byte(testLogin+":"+testPass))},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rec, nextCalled := serveWithAuth(t, c.authHeader)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want %d", rec.Code, http.StatusOK)
+			}
+			if !nextCalled {
+				t.Fatal("wrapped handler did not run for valid credentials")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Squashed final state of the Basic auth hardening (split out of the OTLP/gRPC working branch):

- Credential comparison uses `subtle.ConstantTimeCompare` over SHA-256 digests of both operands, closing the timing side channels of short-circuiting string compares: digests keep both inputs a fixed 32 bytes (so length cannot leak) and both login and password are checked before branching (so a correct login alone is not observable).
- Header parsing goes through `r.BasicAuth`, which matches the Basic scheme case-insensitively per RFC 7235 §2.1; missing, malformed, and wrong credentials all get the same 401.
- Every 401 carries the WWW-Authenticate challenge RFC 7235 §4.1 requires, not just the missing-header case.

Independent of the other PRs from this split. The gRPC-side counterpart of this hardening lives in the OTLP/gRPC receiver PR, since `writer/grpc` is introduced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)