### PR TITLE
feat(writer): OTLP metrics ingestion on /v1/metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Configuration & Docker](docs/configuration.md) — environment variables, Docker quickstart, cross-cluster setup
 - [Profiling API](docs/profiling-api.md) — profiling endpoints, DOT format export, Graphviz visualization
 - [OTLP Profiles Ingestion](docs/otlp-profiles.md) — OpenTelemetry profiles signal ingestion via `/v1development/profiles`
+- [OTLP Metrics Ingestion](docs/otlp-metrics.md) — OpenTelemetry metrics signal ingestion via `/v1/metrics` (protobuf + JSON)
 - [OTLP over gRPC](docs/otlp-grpc.md) — OTLP/gRPC receiver (`OTLP_GRPC_ADDR`) for traces, logs, and profiles
 - [Contributing](docs/contributing.md) — development setup, testing, CLA requirement
 - [Full Documentation](https://gigapipe.com/docs/oss) — hosted docs at gigapipe.com

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,7 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 
 - **`BULK_MAX_SIZE_BYTES`** - Maximum batch size in bytes before flushing to ClickHouse
 - **`BULK_MAX_AGE_MS`** - Maximum age in milliseconds before flushing batch (default: `100`)
+- **`QRYN_SYSTEM_SETTINGS_OTLP_MAX_MESSAGE_SIZE`** - Maximum decompressed size in bytes of a single OTLP export request, applied to both the OTLP/HTTP body limit and the OTLP/gRPC max receive message size (default: `67108864`, i.e. 64 MiB). Also settable in the config file as `system_settings.otlp_max_message_size`.
 
 ## Advanced Settings
 

--- a/docs/otlp-metrics.md
+++ b/docs/otlp-metrics.md
@@ -70,16 +70,3 @@ gigapipe's query engine derives staleness from its own fill window.
 The first exemplar carrying a valid trace ID is stored alongside the sample
 (on plain series and `_bucket` series), enabling metric-to-trace
 correlation queries over the stored trace IDs.
-
-## Baseline test suite
-
-`scripts/test/e2e/otlp-metrics/` contains a comparison harness that ingests
-an identical payload matrix into gigapipe (HTTP protobuf, HTTP JSON, gRPC),
-VictoriaMetrics and Prometheus, then compares PromQL results across all
-three systems and asserts the protocol-conformance behavior above:
-
-```sh
-make docker
-docker compose -f scripts/test/e2e/otlp-metrics/docker-compose.yml up -d
-go run ./scripts/test/e2e/otlp-metrics
-```

--- a/docs/otlp-metrics.md
+++ b/docs/otlp-metrics.md
@@ -1,0 +1,85 @@
+# OTLP Metrics
+
+gigapipe accepts OpenTelemetry (OTLP) metrics on both transports:
+
+- **OTLP/HTTP**: `POST /v1/metrics` with `Content-Type: application/x-protobuf`
+  or `application/json`. Gzip request bodies are supported
+  (`Content-Encoding: gzip`); the decompressed body is limited to 64 MiB
+  (HTTP 413 beyond that). The response is an `ExportMetricsServiceResponse`
+  encoded to match the request's content type; non-200 responses carry a
+  `google.rpc.Status`.
+- **OTLP/gRPC**: `opentelemetry.proto.collector.metrics.v1.MetricsService/Export`,
+  multiplexed on the same port as HTTP (see [otlp-grpc.md](otlp-grpc.md)).
+
+## Translation to Prometheus-style series
+
+Incoming metrics are translated per the OpenTelemetry Prometheus
+compatibility spec, matching what the Prometheus OTLP receiver does by
+default:
+
+- Metric names are mapped to the Prometheus charset (dots become
+  underscores), UCUM units become word suffixes (`s` → `_seconds`,
+  `By` → `_bytes`, `By/s` → `_bytes_per_second`), and monotonic sums get a
+  `_total` suffix. `{annotation}` units and the dimensionless unit `1` add no
+  suffix.
+- `service.namespace`/`service.name` become the `job` label
+  (`<namespace>/<name>`), `service.instance.id` becomes `instance`.
+- Remaining resource attributes go to a `target_info` gauge (constant value
+  1, one sample per resource per export, at the latest accepted data-point
+  timestamp), not onto every series.
+- Instrumentation scope becomes `otel_scope_name` / `otel_scope_version` /
+  `otel_scope_schema_url` labels plus `otel_scope_`-prefixed scope
+  attributes. A scope attribute whose sanitized name would collide with one
+  of those three identity labels is dropped, per the OTel↔Prometheus
+  compatibility spec.
+- Metric `description` and unit are stored as time-series metadata, not as
+  labels.
+
+Per-type mapping:
+
+| OTLP type             | Stored series |
+|-----------------------|---------------|
+| Gauge                 | one series per attribute set |
+| Sum (cumulative)      | counter (`_total`) when monotonic, gauge otherwise |
+| Histogram (cumulative)| `_bucket` (cumulative counts, `le` labels, `+Inf`), `_sum`, `_count` |
+| ExponentialHistogram (cumulative) | converted to classic `_bucket`/`_sum`/`_count` series with exact boundaries (bucket `k`'s upper bound is `2^((k+1)·2^-scale)`, computed so power-of-two bounds are exact) |
+| Summary               | quantile-labeled series plus `_sum`/`_count` |
+
+## Rejected and dropped data
+
+Per-data-point problems never fail the request: the response reports them in
+`partial_success.rejected_data_points` with a human-readable
+`error_message`, per the OTLP spec. Rejected (counted):
+
+- Sum / Histogram / ExponentialHistogram data points with **delta** or
+  unspecified aggregation temporality. gigapipe stores cumulative series
+  only; storing raw delta values would silently break `rate()` and
+  `increase()`. Use the OTel SDK default (cumulative) or the collector's
+  `deltatocumulative` processor.
+- Exponential histogram data points with negative buckets.
+- Histogram data points whose `bucket_counts` length does not match
+  `explicit_bounds` + 1.
+- Data points with a zero `time_unix_nano` or no value.
+
+Dropped silently (not counted): data points carrying the
+`NO_RECORDED_VALUE` staleness flag — they have no value by definition and
+gigapipe's query engine derives staleness from its own fill window.
+
+## Exemplars
+
+The first exemplar carrying a valid trace ID is stored alongside the sample
+(on plain series and `_bucket` series), enabling metric-to-trace
+correlation queries over the stored trace IDs.
+
+## Baseline test suite
+
+`scripts/test/e2e/otlp-metrics/` contains a comparison harness that ingests
+an identical payload matrix into gigapipe (HTTP protobuf, HTTP JSON, gRPC),
+VictoriaMetrics and Prometheus, then compares PromQL results across all
+three systems and asserts the protocol-conformance behavior above:
+
+```sh
+make docker
+docker compose -f scripts/test/e2e/otlp-metrics/docker-compose.yml up -d
+go run ./scripts/test/e2e/otlp-metrics
+```

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/kr/logfmt v0.0.0-20210122060352-19f9bcb100e6
 	github.com/labstack/gommon v0.5.0
 	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
-	github.com/metrico/cloki-config v0.0.95
+	github.com/metrico/cloki-config v0.0.96
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
@@ -51,6 +51,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.11.0
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597
 	golang.org/x/sync v0.22.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260724162435-b2f20204f0df
 	google.golang.org/grpc v1.85.0-dev
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/go-playground/validator.v9 v9.31.0
@@ -250,7 +251,6 @@ require (
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/api v0.291.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260724162435-b2f20204f0df // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260724162435-b2f20204f0df // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.3 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -707,8 +707,8 @@ github.com/mdlayher/socket v0.6.0 h1:ScZPaAGyO1icQnbFrhPM8mnXyMu9qukC1K4ZoM2IQKU
 github.com/mdlayher/socket v0.6.0/go.mod h1:q7vozUAnxSqnjHc12Fik5yUKIzfZ8ITCfMkhOtE9z18=
 github.com/mdlayher/vsock v1.3.0 h1:bqQfZ1OznI03y6YiXp2sze05RVdzLn/zsfjnjd4+ivI=
 github.com/mdlayher/vsock v1.3.0/go.mod h1:WsuksavOvwCnV5UqGHUkvAvCy+Dqy81y4goKQTzxxNY=
-github.com/metrico/cloki-config v0.0.95 h1:FNkb5z6gF78/DgZFtqUygCQk3fr+BX8iGHXui/8P2Ww=
-github.com/metrico/cloki-config v0.0.95/go.mod h1:zjxnDFtbyI08jMKjy12sleeQZjbJM2Vpngf+8gwm/4I=
+github.com/metrico/cloki-config v0.0.96 h1:txP0ybMUmhZR0Rs3rqBQeho/9DGGzmau+O+9jySoS6M=
+github.com/metrico/cloki-config v0.0.96/go.mod h1:zjxnDFtbyI08jMKjy12sleeQZjbJM2Vpngf+8gwm/4I=
 github.com/microsoft/go-mssqldb v1.10.0 h1:pHEt+Qz6YFPWqREq10mqSE524QQo+/QremwTCQht7TY=
 github.com/microsoft/go-mssqldb v1.10.0/go.mod h1:mnG7lGa9iYJbzJqGCXyuQCegStKMr3kogDLD6+bmggg=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=

--- a/writer/controller/otlp_metrics.go
+++ b/writer/controller/otlp_metrics.go
@@ -1,0 +1,128 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/metrico/qryn/v5/writer/config"
+	"github.com/metrico/qryn/v5/writer/utils/logger"
+	"github.com/metrico/qryn/v5/writer/utils/unmarshal"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	otlpContentTypeProto = "application/x-protobuf"
+	otlpContentTypeJSON  = "application/json"
+)
+
+// defaultOTLPMaxMessageSize is 64 MiB, the OTLP/HTTP spec's recommended
+// request-size bound.
+const defaultOTLPMaxMessageSize = 64 << 20
+
+// OTLPMaxMessageSize returns the maximum decompressed OTLP payload size in
+// bytes, shared by both transports: the OTLP/HTTP request body limit
+// (oversize requests get HTTP 413) and the gRPC server's MaxRecvMsgSize. One
+// value for both, so a batch accepted on one transport is never rejected on
+// the other. Configured via system_settings.otlp_max_message_size (env:
+// QRYN_SYSTEM_SETTINGS_OTLP_MAX_MESSAGE_SIZE); non-positive values and a
+// missing config both fall back to the 64 MiB default.
+func OTLPMaxMessageSize() int {
+	if config.Cloki != nil && config.Cloki.Setting != nil {
+		if v := config.Cloki.Setting.SYSTEM_SETTINGS.OTLPMaxMessageSize; v > 0 {
+			return v
+		}
+	}
+	return defaultOTLPMaxMessageSize
+}
+
+// OTLPMetricsV2 handles OTLP/HTTP metrics export on /v1/metrics. It accepts
+// binary protobuf and JSON payloads, dispatched on Content-Type, and responds
+// per the OTLP/HTTP spec: 200 with an ExportMetricsServiceResponse in the
+// request's encoding (partial_success set when data points were rejected),
+// 400 with a google.rpc.Status for undecodable payloads, 413 for oversize
+// bodies, and 503 with a google.rpc.Status for transient ingest failures.
+func OTLPMetricsV2(cfg MiddlewareConfig) func(w http.ResponseWriter, r *http.Request) {
+	return Build(
+		append(cfg.ExtraMiddleware,
+			withTSAndSampleService,
+			withOTLPMetricsParser(otlpContentTypeProto, func(body []byte, md *metricsv1.MetricsData) error {
+				return proto.Unmarshal(body, md)
+			}),
+			withOTLPMetricsParser(otlpContentTypeJSON, func(body []byte, md *metricsv1.MetricsData) error {
+				return protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(body, md)
+			}),
+		)...,
+	)
+}
+
+func withOTLPMetricsParser(contentType string, decode func([]byte, *metricsv1.MetricsData) error) BuildOption {
+	return func(ctx *PusherCtx) *PusherCtx {
+		ctx.Parser[contentType] = func(w http.ResponseWriter, r *http.Request) error {
+			return serveOTLPMetrics(w, r, contentType, decode)
+		}
+		return ctx
+	}
+}
+
+func serveOTLPMetrics(w http.ResponseWriter, r *http.Request, contentType string,
+	decode func([]byte, *metricsv1.MetricsData) error) error {
+	maxSize := OTLPMaxMessageSize()
+	body, err := io.ReadAll(io.LimitReader(getBodyStream(r), int64(maxSize)+1))
+	if err != nil {
+		return writeOTLPStatus(w, contentType, http.StatusBadRequest,
+			fmt.Sprintf("failed to read request body: %v", err))
+	}
+	if len(body) > maxSize {
+		return writeOTLPStatus(w, contentType, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("request body exceeds the %d byte limit", maxSize))
+	}
+
+	md := &metricsv1.MetricsData{}
+	if err := decode(body, md); err != nil {
+		return writeOTLPStatus(w, contentType, http.StatusBadRequest,
+			fmt.Sprintf("failed to decode metrics payload: %v", err))
+	}
+
+	stats := &unmarshal.OTLPMetricsStats{}
+	if err := doParse(r, Parser(unmarshal.OTLPMetricsFromData(md, stats))); err != nil {
+		logger.Error("OTLP metrics ingest failed: ", err)
+		return writeOTLPStatus(w, contentType, http.StatusServiceUnavailable, "temporary ingestion failure")
+	}
+
+	resp := &colmetricspb.ExportMetricsServiceResponse{}
+	if rejected := stats.RejectedDataPoints(); rejected > 0 {
+		resp.PartialSuccess = &colmetricspb.ExportMetricsPartialSuccess{
+			RejectedDataPoints: rejected,
+			ErrorMessage:       stats.ErrorMessage(),
+		}
+	}
+	return writeOTLPMessage(w, contentType, http.StatusOK, resp)
+}
+
+// writeOTLPStatus responds with a google.rpc.Status encoded in the request's
+// content type, as the OTLP/HTTP spec requires for all non-200 responses.
+func writeOTLPStatus(w http.ResponseWriter, contentType string, httpCode int, message string) error {
+	return writeOTLPMessage(w, contentType, httpCode, &spb.Status{Message: message})
+}
+
+func writeOTLPMessage(w http.ResponseWriter, contentType string, httpCode int, msg proto.Message) error {
+	var payload []byte
+	var err error
+	if contentType == otlpContentTypeJSON {
+		payload, err = protojson.Marshal(msg)
+	} else {
+		payload, err = proto.Marshal(msg)
+	}
+	if err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(httpCode)
+	_, _ = w.Write(payload)
+	return nil
+}

--- a/writer/controller/otlp_metrics_test.go
+++ b/writer/controller/otlp_metrics_test.go
@@ -1,0 +1,286 @@
+package controller
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	clconfig "github.com/metrico/cloki-config"
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/writer/config"
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/service"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// metricsFakeRegistry satisfies registry.ServiceRegistry with recorder-backed
+// samples, time-series and profile services, which is the set
+// withTSAndSampleService resolves.
+type metricsFakeRegistry struct {
+	samples    *recorderSvc
+	timeSeries *recorderSvc
+	profile    *recorderSvc
+}
+
+func (f *metricsFakeRegistry) GetTimeSeriesService(id string) (service.IInsertServiceV2, error) {
+	return f.timeSeries, nil
+}
+func (f *metricsFakeRegistry) GetSamplesService(id string) (service.IInsertServiceV2, error) {
+	return f.samples, nil
+}
+func (f *metricsFakeRegistry) GetMetricsService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *metricsFakeRegistry) GetSpansService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *metricsFakeRegistry) GetSpansSeriesService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *metricsFakeRegistry) GetProfileInsertService(id string) (service.IInsertServiceV2, error) {
+	return f.profile, nil
+}
+func (f *metricsFakeRegistry) GetPatternInsertService(id string) (service.IInsertServiceV2, error) {
+	return nil, nil
+}
+func (f *metricsFakeRegistry) Run()  {}
+func (f *metricsFakeRegistry) Stop() {}
+
+// newMetricsHandler wires OTLPMetricsV2 with the production middleware chain
+// (WithOverallContextMiddleware for DSN/gzip handling) against fake insert
+// services, returning the handler plus the samples recorder to assert on.
+func newMetricsHandler(t *testing.T) (http.HandlerFunc, *recorderSvc) {
+	t.Helper()
+	installConfig(t)
+	installFPCache(t, "n")
+	samples := &recorderSvc{}
+	old := Registry
+	Registry = &metricsFakeRegistry{samples: samples, timeSeries: &recorderSvc{}, profile: &recorderSvc{}}
+	t.Cleanup(func() { Registry = old })
+	return OTLPMetricsV2(NewMiddlewareConfig(WithOverallContextMiddleware)), samples
+}
+
+func sampleMetricsRequest() *metricsv1.MetricsData {
+	return &metricsv1.MetricsData{ResourceMetrics: []*metricsv1.ResourceMetrics{{
+		Resource: &resourcev1.Resource{Attributes: []*commonv1.KeyValue{{
+			Key:   "service.name",
+			Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "svc"}},
+		}}},
+		ScopeMetrics: []*metricsv1.ScopeMetrics{{Metrics: []*metricsv1.Metric{{
+			Name: "cpu.usage",
+			Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+				TimeUnixNano: 1700000000_000000000,
+				Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 42.5},
+			}}}},
+		}}}},
+	}}}
+}
+
+func TestOTLPMetricsHTTP_ProtoHappyPath(t *testing.T) {
+	handler, samples := newMetricsHandler(t)
+
+	body, err := proto.Marshal(sampleMetricsRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("POST", "/v1/metrics", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/x-protobuf" {
+		t.Fatalf("expected protobuf response content type, got %q", ct)
+	}
+	resp := &colmetricspb.ExportMetricsServiceResponse{}
+	if err := proto.Unmarshal(w.Body.Bytes(), resp); err != nil {
+		t.Fatalf("response is not an ExportMetricsServiceResponse: %v", err)
+	}
+	if resp.PartialSuccess != nil {
+		t.Fatalf("expected unset partial_success on full success, got %+v", resp.PartialSuccess)
+	}
+
+	got := samples.reqs()
+	if len(got) == 0 {
+		t.Fatal("samples insert service received no requests")
+	}
+	spl := got[0].(*model.TimeSamplesData)
+	if len(spl.MValue) != 1 || spl.MValue[0] != 42.5 {
+		t.Fatalf("expected one sample with value 42.5, got %#v", spl.MValue)
+	}
+}
+
+func TestOTLPMetricsHTTP_JSONWithPartialSuccess(t *testing.T) {
+	handler, samples := newMetricsHandler(t)
+
+	// One cumulative gauge (stored) plus one delta sum (rejected by policy).
+	// Temporality 1 = DELTA, encoded as an integer per the OTLP JSON mapping.
+	body := `{"resourceMetrics":[{"scopeMetrics":[{"metrics":[
+		{"name":"ok.gauge","gauge":{"dataPoints":[
+			{"timeUnixNano":"1700000000000000000","asDouble":1.5}]}},
+		{"name":"bad.delta","sum":{"aggregationTemporality":1,"isMonotonic":true,"dataPoints":[
+			{"timeUnixNano":"1700000000000000000","asInt":"3"}]}}
+	]}]}]}`
+	req := httptest.NewRequest("POST", "/v1/metrics", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected json response content type, got %q", ct)
+	}
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, `"rejectedDataPoints":"1"`) {
+		t.Fatalf("expected partial success with 1 rejected point, got %s", respBody)
+	}
+	if !strings.Contains(respBody, "temporality") {
+		t.Fatalf("expected temporality in error message, got %s", respBody)
+	}
+
+	got := samples.reqs()
+	if len(got) == 0 {
+		t.Fatal("samples insert service received no requests")
+	}
+	spl := got[0].(*model.TimeSamplesData)
+	if len(spl.MValue) != 1 || spl.MValue[0] != 1.5 {
+		t.Fatalf("expected only the gauge sample, got %#v", spl.MValue)
+	}
+}
+
+func TestOTLPMetricsHTTP_BadPayloadReturns400Status(t *testing.T) {
+	handler, _ := newMetricsHandler(t)
+
+	req := httptest.NewRequest("POST", "/v1/metrics", strings.NewReader("\x01\x02 not a proto"))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	st := &spb.Status{}
+	if err := proto.Unmarshal(w.Body.Bytes(), st); err != nil {
+		t.Fatalf("error body is not a google.rpc.Status: %v", err)
+	}
+	if st.Message == "" {
+		t.Fatal("expected a non-empty status message")
+	}
+}
+
+func TestOTLPMetricsHTTP_UnsupportedContentType(t *testing.T) {
+	handler, _ := newMetricsHandler(t)
+
+	req := httptest.NewRequest("POST", "/v1/metrics", strings.NewReader("a,b,c"))
+	req.Header.Set("Content-Type", "text/csv")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported content type, got %d", w.Code)
+	}
+}
+
+func TestOTLPMetricsHTTP_GzipRequest(t *testing.T) {
+	handler, samples := newMetricsHandler(t)
+
+	raw, err := proto.Marshal(sampleMetricsRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/metrics", &buf)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(samples.reqs()) == 0 {
+		t.Fatal("gzip request did not reach the insert layer")
+	}
+}
+
+func TestOTLPMetricsHTTP_OversizeBodyReturns413(t *testing.T) {
+	handler, _ := newMetricsHandler(t)
+
+	// A gzip body that decompresses beyond the 64 MiB limit proves the limit
+	// applies to the decompressed stream, not the wire bytes.
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := io.CopyN(zw, zeroReader{}, int64(OTLPMaxMessageSize())+2); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/metrics", &buf)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	req.Header.Set("Content-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", w.Code)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// TestOTLPMaxMessageSize covers resolution of the shared OTLP payload bound:
+// a configured system_settings.otlp_max_message_size wins when positive, and
+// both a missing config and a non-positive value fall back to the OTLP/HTTP
+// spec's recommended 64 MiB. Both transports read this one value (the HTTP
+// body limit and the gRPC MaxRecvMsgSize), so a batch accepted on one
+// transport is never rejected on the other.
+func TestOTLPMaxMessageSize(t *testing.T) {
+	old := config.Cloki
+	t.Cleanup(func() { config.Cloki = old })
+
+	config.Cloki = nil
+	if got := OTLPMaxMessageSize(); got != 64<<20 {
+		t.Errorf("no config: got %d, want %d (64 MiB)", got, 64<<20)
+	}
+
+	setting := &clokiconfig.ClokiBaseSettingServer{}
+	config.Cloki = &clconfig.ClokiConfig{Setting: setting}
+	if got := OTLPMaxMessageSize(); got != 64<<20 {
+		t.Errorf("non-positive setting: got %d, want %d (64 MiB)", got, 64<<20)
+	}
+
+	setting.SYSTEM_SETTINGS.OTLPMaxMessageSize = 10 << 20
+	if got := OTLPMaxMessageSize(); got != 10<<20 {
+		t.Errorf("configured setting: got %d, want %d", got, 10<<20)
+	}
+}

--- a/writer/router/insert.go
+++ b/writer/router/insert.go
@@ -12,6 +12,7 @@ func RouteInsertDataApis(router *mux.Router, cfg controllerv1.MiddlewareConfig) 
 	router.HandleFunc("/api/v2/series", controllerv1.PushDatadogMetricsV2(cfg)).Methods("POST")
 	router.HandleFunc("/api/v2/logs", controllerv1.PushDatadogV2(cfg)).Methods("POST")
 	router.HandleFunc("/v1/logs", controllerv1.OTLPLogsV2(cfg)).Methods("POST")
+	router.HandleFunc("/v1/metrics", controllerv1.OTLPMetricsV2(cfg)).Methods("POST")
 
 	router.HandleFunc("/influx/api/v2/write/health", controllerv1.HealthInflux).Methods("GET")
 	router.HandleFunc("/influx/health", controllerv1.HealthInflux).Methods("GET")

--- a/writer/utils/unmarshal/otlp_metrics.go
+++ b/writer/utils/unmarshal/otlp_metrics.go
@@ -431,8 +431,16 @@ func (d *otlpMetricsDec) decodeExponentialHistogram(points []*otlpmetrics.Expone
 			}
 		}
 
+		// +Inf carries the running sum so the bucket series stays monotonic even
+		// when a producer's count disagrees with its bucket counts; _count
+		// reports the producer's total. With no positive buckets, dp.Count is
+		// the total.
+		infValue := cumulative
+		if dp.Positive == nil || len(dp.Positive.BucketCounts) == 0 {
+			infValue = dp.Count
+		}
 		lblsInf := d.seriesLabels(name+"_bucket", rs, dp.Attributes, [][2]string{{"le", "+Inf"}}, "histogram", metric)
-		if err := d.emit(lblsInf, ts, traceID, float64(dp.Count)); err != nil {
+		if err := d.emit(lblsInf, ts, traceID, float64(infValue)); err != nil {
 			return err
 		}
 		if dp.Sum != nil {

--- a/writer/utils/unmarshal/otlp_metrics.go
+++ b/writer/utils/unmarshal/otlp_metrics.go
@@ -1,0 +1,518 @@
+package unmarshal
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	otlpcommon "go.opentelemetry.io/proto/otlp/common/v1"
+	otlpmetrics "go.opentelemetry.io/proto/otlp/metrics/v1"
+)
+
+const noRecordedValueMask = 1
+
+const maxRejectionReasons = 5
+
+// OTLPMetricsStats accumulates per-request ingestion outcomes that the OTLP
+// partial_success response reports: how many data points were rejected and
+// why. Decode runs on a single goroutine and the parser response channel
+// provides the happens-before edge, so plain fields suffice: read the stats
+// only after the response channel is closed.
+type OTLPMetricsStats struct {
+	rejected int64
+	reasons  []string
+}
+
+func (s *OTLPMetricsStats) reject(count int, reason string) {
+	s.rejected += int64(count)
+	for _, r := range s.reasons {
+		if r == reason {
+			return
+		}
+	}
+	if len(s.reasons) < maxRejectionReasons {
+		s.reasons = append(s.reasons, reason)
+	}
+}
+
+// RejectedDataPoints returns the number of data points dropped by policy or
+// validation, for the partial_success.rejected_data_points response field.
+func (s *OTLPMetricsStats) RejectedDataPoints() int64 {
+	return s.rejected
+}
+
+// ErrorMessage returns a human-readable summary of the distinct rejection
+// reasons, for the partial_success.error_message response field.
+func (s *OTLPMetricsStats) ErrorMessage() string {
+	switch len(s.reasons) {
+	case 0:
+		return ""
+	case 1:
+		return s.reasons[0]
+	}
+	msg := s.reasons[0]
+	for _, r := range s.reasons[1:] {
+		msg += "; " + r
+	}
+	return msg
+}
+
+// identifyingResourceAttrs are the resource attributes that become the job and
+// instance labels instead of target_info labels.
+var identifyingResourceAttrs = map[string]bool{
+	"service.name":        true,
+	"service.namespace":   true,
+	"service.instance.id": true,
+}
+
+type otlpMetricsDec struct {
+	ctx       *ParserCtx
+	onEntries onEntriesHandler
+	stats     *OTLPMetricsStats
+}
+
+func (d *otlpMetricsDec) SetOnEntries(h onEntriesHandler) {
+	d.onEntries = h
+}
+
+// resourceScope carries the per-resource and per-scope label context every
+// series in that scope inherits: job/instance identity, otel_scope_* labels,
+// target_info labels, and the latest accepted sample timestamp used to emit
+// target_info.
+type resourceScope struct {
+	job         string
+	instance    string
+	targetAttrs map[string]string
+	scopeLabels [][2]string
+	lastTs      int64
+}
+
+// mergeSanitizedAttrs writes attrs into dst keyed by prefix + SanitizeKey.
+// Distinct attribute keys that sanitize to the same label name have their
+// values concatenated with ";" in lexicographic order of the original keys,
+// as the OTel Prometheus compatibility spec requires, instead of silently
+// overwriting one another.
+func mergeSanitizedAttrs(dst map[string]string, prefix string, attrs []*otlpcommon.KeyValue) {
+	grouped := make(map[string][][2]string, len(attrs))
+	for _, kv := range attrs {
+		if kv.Value == nil {
+			continue
+		}
+		key := prefix + SanitizeKey(kv.Key)
+		grouped[key] = append(grouped[key], [2]string{kv.Key, SanitizeValue(kv.Value)})
+	}
+	for key, entries := range grouped {
+		if len(entries) > 1 {
+			sort.Slice(entries, func(i, j int) bool { return entries[i][0] < entries[j][0] })
+		}
+		val := entries[0][1]
+		for _, e := range entries[1:] {
+			val += ";" + e[1]
+		}
+		dst[key] = val
+	}
+}
+
+func (d *otlpMetricsDec) Decode() error {
+	md := d.ctx.bodyObject.(*otlpmetrics.MetricsData)
+
+	for _, rm := range md.ResourceMetrics {
+		rs := &resourceScope{targetAttrs: map[string]string{}}
+		if rm.Resource != nil {
+			var serviceName, serviceNamespace string
+			var extraAttrs []*otlpcommon.KeyValue
+			for _, kv := range rm.Resource.Attributes {
+				if kv.Value == nil {
+					continue
+				}
+				switch kv.Key {
+				case "service.name":
+					serviceName = SanitizeValue(kv.Value)
+				case "service.namespace":
+					serviceNamespace = SanitizeValue(kv.Value)
+				case "service.instance.id":
+					rs.instance = SanitizeValue(kv.Value)
+				default:
+					extraAttrs = append(extraAttrs, kv)
+				}
+			}
+			mergeSanitizedAttrs(rs.targetAttrs, "", extraAttrs)
+			rs.job = serviceName
+			if serviceNamespace != "" && serviceName != "" {
+				rs.job = serviceNamespace + "/" + serviceName
+			}
+		}
+
+		for _, sm := range rm.ScopeMetrics {
+			rs.scopeLabels = rs.scopeLabels[:0]
+			if sm.Scope != nil {
+				if sm.Scope.Name != "" {
+					rs.scopeLabels = append(rs.scopeLabels, [2]string{"otel_scope_name", sm.Scope.Name})
+				}
+				if sm.Scope.Version != "" {
+					rs.scopeLabels = append(rs.scopeLabels, [2]string{"otel_scope_version", sm.Scope.Version})
+				}
+				scopeAttrs := make(map[string]string, len(sm.Scope.Attributes))
+				mergeSanitizedAttrs(scopeAttrs, "otel_scope_", sm.Scope.Attributes)
+				for k, v := range scopeAttrs {
+					switch k {
+					case "otel_scope_name", "otel_scope_version", "otel_scope_schema_url":
+						// A scope attribute that collides with the scope's own
+						// identity labels MUST be dropped, per the OTel
+						// Prometheus compatibility spec.
+						continue
+					}
+					rs.scopeLabels = append(rs.scopeLabels, [2]string{k, v})
+				}
+			}
+			if sm.SchemaUrl != "" {
+				rs.scopeLabels = append(rs.scopeLabels, [2]string{"otel_scope_schema_url", sm.SchemaUrl})
+			}
+			for _, metric := range sm.Metrics {
+				if err := d.decodeMetric(metric, rs); err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := d.emitTargetInfo(rs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *otlpMetricsDec) decodeMetric(metric *otlpmetrics.Metric, rs *resourceScope) error {
+	switch data := metric.Data.(type) {
+	case *otlpmetrics.Metric_Gauge:
+		name := buildMetricName(metric.Name, metric.Unit, false)
+		return d.decodeNumberPoints(data.Gauge.DataPoints, name, "gauge", metric, rs)
+	case *otlpmetrics.Metric_Sum:
+		if !d.checkTemporality(metric.Name, data.Sum.AggregationTemporality, len(data.Sum.DataPoints)) {
+			return nil
+		}
+		metricType := "gauge"
+		if data.Sum.IsMonotonic {
+			metricType = "counter"
+		}
+		name := buildMetricName(metric.Name, metric.Unit, data.Sum.IsMonotonic)
+		return d.decodeNumberPoints(data.Sum.DataPoints, name, metricType, metric, rs)
+	case *otlpmetrics.Metric_Histogram:
+		if !d.checkTemporality(metric.Name, data.Histogram.AggregationTemporality, len(data.Histogram.DataPoints)) {
+			return nil
+		}
+		name := buildMetricName(metric.Name, metric.Unit, false)
+		return d.decodeHistogram(data.Histogram.DataPoints, name, metric, rs)
+	case *otlpmetrics.Metric_ExponentialHistogram:
+		if !d.checkTemporality(metric.Name, data.ExponentialHistogram.AggregationTemporality, len(data.ExponentialHistogram.DataPoints)) {
+			return nil
+		}
+		name := buildMetricName(metric.Name, metric.Unit, false)
+		return d.decodeExponentialHistogram(data.ExponentialHistogram.DataPoints, name, metric, rs)
+	case *otlpmetrics.Metric_Summary:
+		name := buildMetricName(metric.Name, metric.Unit, false)
+		return d.decodeSummary(data.Summary.DataPoints, name, metric, rs)
+	default:
+		d.stats.reject(0, fmt.Sprintf("metric %q: unknown data type", metric.Name))
+	}
+	return nil
+}
+
+// checkTemporality enforces the cumulative-only storage model: data points
+// with delta or unspecified temporality are rejected and counted, never
+// stored, because PromQL rate()/increase() over raw delta values is wrong.
+func (d *otlpMetricsDec) checkTemporality(name string, t otlpmetrics.AggregationTemporality, points int) bool {
+	if t == otlpmetrics.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE {
+		return true
+	}
+	d.stats.reject(points, fmt.Sprintf("metric %q: unsupported aggregation temporality %s, only cumulative is supported", name, t.String()))
+	return false
+}
+
+// seriesLabels assembles the full label set of one stored series. Precedence,
+// lowest to highest: scope labels, data point attributes, identity labels
+// (__name__, job, instance) and explicitly passed extras (le, quantile),
+// metric metadata labels.
+func (d *otlpMetricsDec) seriesLabels(name string, rs *resourceScope, pointAttrs []*otlpcommon.KeyValue,
+	extra [][2]string, metricType string, metric *otlpmetrics.Metric) [][]string {
+	merged := make(map[string]string, len(rs.scopeLabels)+len(pointAttrs)+len(extra)+8)
+	for _, p := range rs.scopeLabels {
+		merged[p[0]] = p[1]
+	}
+	mergeSanitizedAttrs(merged, "", pointAttrs)
+	merged["__name__"] = name
+	if rs.job != "" {
+		merged["job"] = rs.job
+	}
+	if rs.instance != "" {
+		merged["instance"] = rs.instance
+	}
+	for _, p := range extra {
+		merged[p[0]] = p[1]
+	}
+	merged["__metric_type__"] = metricType
+	if metric.Description != "" {
+		merged["__metric_help__"] = metric.Description
+	}
+	if u, _ := unitWords(metric.Unit); u != "" {
+		merged["__metric_unit__"] = u
+	}
+
+	lbls := make([][]string, 0, len(merged))
+	for k, v := range merged {
+		lbls = append(lbls, []string{k, v})
+	}
+	sort.Slice(lbls, func(i, j int) bool { return lbls[i][0] < lbls[j][0] })
+	return lbls
+}
+
+// acceptTimestamp validates a data point timestamp and tracks the resource's
+// latest accepted timestamp for target_info emission. Zero timestamps are
+// rejected: TimeUnixNano is the canonical sample time and a zero would store
+// a bogus epoch row. The name is the raw OTLP metric name — rejection reasons
+// are user-facing and consistently name the metric as the exporter sent it.
+func (d *otlpMetricsDec) acceptTimestamp(name string, tsNano uint64, rs *resourceScope) (int64, bool) {
+	if tsNano == 0 {
+		d.stats.reject(1, fmt.Sprintf("metric %q: data point with zero time_unix_nano", name))
+		return 0, false
+	}
+	ts := int64(tsNano)
+	if ts > rs.lastTs {
+		rs.lastTs = ts
+	}
+	return ts, true
+}
+
+func noRecordedValue(flags uint32) bool {
+	return flags&noRecordedValueMask != 0
+}
+
+// firstExemplarTraceID returns the hex-encoded trace_id of the first exemplar
+// carrying a non-zero 16-byte trace_id, or "" if none exist. The ID is stored
+// in the sample's string column for metric-to-trace correlation.
+func firstExemplarTraceID(exemplars []*otlpmetrics.Exemplar) string {
+	for _, ex := range exemplars {
+		if len(ex.TraceId) == 16 && !isZeroBytes(ex.TraceId) {
+			return hex.EncodeToString(ex.TraceId)
+		}
+	}
+	return ""
+}
+
+func (d *otlpMetricsDec) emit(lbls [][]string, ts int64, str string, val float64) error {
+	return d.onEntries(lbls, []int64{ts}, []string{str}, []float64{val},
+		[]uint8{model.SAMPLE_TYPE_METRIC})
+}
+
+func (d *otlpMetricsDec) decodeNumberPoints(points []*otlpmetrics.NumberDataPoint, name, metricType string,
+	metric *otlpmetrics.Metric, rs *resourceScope) error {
+	for _, pt := range points {
+		if noRecordedValue(pt.Flags) {
+			continue
+		}
+		ts, ok := d.acceptTimestamp(metric.Name, pt.TimeUnixNano, rs)
+		if !ok {
+			continue
+		}
+		var val float64
+		switch v := pt.Value.(type) {
+		case *otlpmetrics.NumberDataPoint_AsDouble:
+			val = v.AsDouble
+		case *otlpmetrics.NumberDataPoint_AsInt:
+			val = float64(v.AsInt)
+		default:
+			d.stats.reject(1, fmt.Sprintf("metric %q: number data point with no value", metric.Name))
+			continue
+		}
+		lbls := d.seriesLabels(name, rs, pt.Attributes, nil, metricType, metric)
+		if err := d.emit(lbls, ts, firstExemplarTraceID(pt.Exemplars), val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *otlpMetricsDec) decodeHistogram(points []*otlpmetrics.HistogramDataPoint, name string,
+	metric *otlpmetrics.Metric, rs *resourceScope) error {
+	for _, dp := range points {
+		if noRecordedValue(dp.Flags) {
+			continue
+		}
+		if len(dp.BucketCounts) > 0 && len(dp.BucketCounts) != len(dp.ExplicitBounds)+1 {
+			d.stats.reject(1, fmt.Sprintf("metric %q: histogram bucket_counts length %d does not match explicit_bounds length %d + 1",
+				metric.Name, len(dp.BucketCounts), len(dp.ExplicitBounds)))
+			continue
+		}
+		ts, ok := d.acceptTimestamp(metric.Name, dp.TimeUnixNano, rs)
+		if !ok {
+			continue
+		}
+		traceID := firstExemplarTraceID(dp.Exemplars)
+
+		cumulative := uint64(0)
+		infEmitted := false
+		for i, count := range dp.BucketCounts {
+			cumulative += count
+			le := "+Inf"
+			emitCount := cumulative
+			if i < len(dp.ExplicitBounds) {
+				le = strconv.FormatFloat(dp.ExplicitBounds[i], 'f', -1, 64)
+			} else {
+				emitCount = dp.Count
+				infEmitted = true
+			}
+			lbls := d.seriesLabels(name+"_bucket", rs, dp.Attributes, [][2]string{{"le", le}}, "histogram", metric)
+			if err := d.emit(lbls, ts, traceID, float64(emitCount)); err != nil {
+				return err
+			}
+		}
+		if !infEmitted {
+			lbls := d.seriesLabels(name+"_bucket", rs, dp.Attributes, [][2]string{{"le", "+Inf"}}, "histogram", metric)
+			if err := d.emit(lbls, ts, traceID, float64(dp.Count)); err != nil {
+				return err
+			}
+		}
+
+		if dp.Sum != nil {
+			lbls := d.seriesLabels(name+"_sum", rs, dp.Attributes, nil, "histogram", metric)
+			if err := d.emit(lbls, ts, "", *dp.Sum); err != nil {
+				return err
+			}
+		}
+		lbls := d.seriesLabels(name+"_count", rs, dp.Attributes, nil, "histogram", metric)
+		if err := d.emit(lbls, ts, "", float64(dp.Count)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *otlpMetricsDec) decodeExponentialHistogram(points []*otlpmetrics.ExponentialHistogramDataPoint, name string,
+	metric *otlpmetrics.Metric, rs *resourceScope) error {
+	for _, dp := range points {
+		if noRecordedValue(dp.Flags) {
+			continue
+		}
+		if dp.Negative != nil && len(dp.Negative.BucketCounts) > 0 {
+			d.stats.reject(1, fmt.Sprintf("metric %q: exponential histogram with negative buckets is not supported", metric.Name))
+			continue
+		}
+		ts, ok := d.acceptTimestamp(metric.Name, dp.TimeUnixNano, rs)
+		if !ok {
+			continue
+		}
+		traceID := firstExemplarTraceID(dp.Exemplars)
+
+		cumulative := dp.ZeroCount
+		if dp.Positive != nil {
+			offset := dp.Positive.Offset
+			for i, count := range dp.Positive.BucketCounts {
+				cumulative += count
+				// Bucket index k has upper bound 2^(k / 2^scale). Computing it
+				// as Exp2 of one product keeps the bound exact at every power
+				// of two, where the equivalent Pow(base, k) with a pre-computed
+				// inexact base accumulates floating-point error that would leak
+				// into the `le` label and break cross-source aggregation.
+				upperBound := math.Exp2(float64(int32(i)+offset+1) * math.Exp2(-float64(dp.Scale)))
+				le := strconv.FormatFloat(upperBound, 'f', -1, 64)
+				lbls := d.seriesLabels(name+"_bucket", rs, dp.Attributes, [][2]string{{"le", le}}, "histogram", metric)
+				if err := d.emit(lbls, ts, traceID, float64(cumulative)); err != nil {
+					return err
+				}
+			}
+		}
+
+		lblsInf := d.seriesLabels(name+"_bucket", rs, dp.Attributes, [][2]string{{"le", "+Inf"}}, "histogram", metric)
+		if err := d.emit(lblsInf, ts, traceID, float64(dp.Count)); err != nil {
+			return err
+		}
+		if dp.Sum != nil {
+			lbls := d.seriesLabels(name+"_sum", rs, dp.Attributes, nil, "histogram", metric)
+			if err := d.emit(lbls, ts, "", *dp.Sum); err != nil {
+				return err
+			}
+		}
+		lbls := d.seriesLabels(name+"_count", rs, dp.Attributes, nil, "histogram", metric)
+		if err := d.emit(lbls, ts, "", float64(dp.Count)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *otlpMetricsDec) decodeSummary(points []*otlpmetrics.SummaryDataPoint, name string,
+	metric *otlpmetrics.Metric, rs *resourceScope) error {
+	for _, dp := range points {
+		if noRecordedValue(dp.Flags) {
+			continue
+		}
+		ts, ok := d.acceptTimestamp(metric.Name, dp.TimeUnixNano, rs)
+		if !ok {
+			continue
+		}
+		for _, q := range dp.QuantileValues {
+			quantile := strconv.FormatFloat(q.Quantile, 'f', -1, 64)
+			lbls := d.seriesLabels(name, rs, dp.Attributes, [][2]string{{"quantile", quantile}}, "summary", metric)
+			if err := d.emit(lbls, ts, "", q.Value); err != nil {
+				return err
+			}
+		}
+		lbls := d.seriesLabels(name+"_sum", rs, dp.Attributes, nil, "summary", metric)
+		if err := d.emit(lbls, ts, "", dp.Sum); err != nil {
+			return err
+		}
+		lbls = d.seriesLabels(name+"_count", rs, dp.Attributes, nil, "summary", metric)
+		if err := d.emit(lbls, ts, "", float64(dp.Count)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitTargetInfo writes the target_info gauge for one resource: a single
+// sample of value 1 at the latest accepted data-point timestamp, labeled with
+// job/instance identity plus the non-identifying resource attributes — one
+// sample per target per export, matching Prometheus's one-per-scrape shape.
+// Nothing is emitted when the resource carries no attributes beyond its
+// identity or contributed no accepted data points.
+func (d *otlpMetricsDec) emitTargetInfo(rs *resourceScope) error {
+	if len(rs.targetAttrs) == 0 || rs.lastTs == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(rs.targetAttrs)+3)
+	for k, v := range rs.targetAttrs {
+		merged[k] = v
+	}
+	merged["__name__"] = "target_info"
+	if rs.job != "" {
+		merged["job"] = rs.job
+	}
+	if rs.instance != "" {
+		merged["instance"] = rs.instance
+	}
+	merged["__metric_type__"] = "gauge"
+	lbls := make([][]string, 0, len(merged))
+	for k, v := range merged {
+		lbls = append(lbls, []string{k, v})
+	}
+	sort.Slice(lbls, func(i, j int) bool { return lbls[i][0] < lbls[j][0] })
+
+	return d.emit(lbls, rs.lastTs, "", 1)
+}
+
+// OTLPMetricsFromData builds a parser over an already-decoded MetricsData.
+// Both transports use it: gRPC passes the framework-decoded request, HTTP
+// passes the body it decoded from protobuf or JSON. Rejection counts for the
+// partial_success response accumulate into stats, which is safe to read once
+// the parser response channel closes.
+func OTLPMetricsFromData(md *otlpmetrics.MetricsData, stats *OTLPMetricsStats) ParsingFunction {
+	return Build(
+		withPreParsedBody(md),
+		withLogsParser(func(ctx *ParserCtx) iLogsParser {
+			return &otlpMetricsDec{ctx: ctx, stats: stats}
+		}),
+	)
+}

--- a/writer/utils/unmarshal/otlp_metrics.go
+++ b/writer/utils/unmarshal/otlp_metrics.go
@@ -357,15 +357,21 @@ func (d *otlpMetricsDec) decodeHistogram(points []*otlpmetrics.HistogramDataPoin
 		for i, count := range dp.BucketCounts {
 			cumulative += count
 			le := "+Inf"
-			emitCount := cumulative
 			if i < len(dp.ExplicitBounds) {
 				le = strconv.FormatFloat(dp.ExplicitBounds[i], 'f', -1, 64)
 			} else {
-				emitCount = dp.Count
+				// The +Inf bucket carries the running sum rather than dp.Count.
+				// The two disagree whenever a producer is lossy, and taking
+				// dp.Count here can place +Inf BELOW the last finite bucket.
+				// histogram_quantile does not error on a non-monotonic bucket
+				// series, it silently returns a wrong number, so monotonicity
+				// has to hold by construction. The producer's own total is
+				// still reported by _count, leaving any mismatch visible as
+				// _bucket{le="+Inf"} != _count.
 				infEmitted = true
 			}
 			lbls := d.seriesLabels(name+"_bucket", rs, dp.Attributes, [][2]string{{"le", le}}, "histogram", metric)
-			if err := d.emit(lbls, ts, traceID, float64(emitCount)); err != nil {
+			if err := d.emit(lbls, ts, traceID, float64(cumulative)); err != nil {
 				return err
 			}
 		}

--- a/writer/utils/unmarshal/otlp_metrics_naming.go
+++ b/writer/utils/unmarshal/otlp_metrics_naming.go
@@ -1,0 +1,170 @@
+package unmarshal
+
+import (
+	"strings"
+)
+
+// unitWordMap maps UCUM unit codes to the Prometheus word equivalents used as
+// metric name suffixes, per the OpenTelemetry Prometheus compatibility spec.
+var unitWordMap = map[string]string{
+	// Time
+	"d":   "days",
+	"h":   "hours",
+	"min": "minutes",
+	"s":   "seconds",
+	"ms":  "milliseconds",
+	"us":  "microseconds",
+	"ns":  "nanoseconds",
+	// Bytes
+	"By":   "bytes",
+	"KiBy": "kibibytes",
+	"MiBy": "mebibytes",
+	"GiBy": "gibibytes",
+	"TiBy": "tibibytes",
+	"KBy":  "kilobytes",
+	"MBy":  "megabytes",
+	"GBy":  "gigabytes",
+	"TBy":  "terabytes",
+	// SI
+	"m": "meters",
+	"V": "volts",
+	"A": "amperes",
+	"J": "joules",
+	"W": "watts",
+	"g": "grams",
+	// Misc
+	"Cel": "celsius",
+	"Hz":  "hertz",
+	"%":   "percent",
+}
+
+// perUnitWordMap maps UCUM rate denominators (the "s" in "By/s") to the word
+// used in a "_per_<word>" metric name suffix.
+var perUnitWordMap = map[string]string{
+	"s":  "second",
+	"m":  "minute",
+	"h":  "hour",
+	"d":  "day",
+	"w":  "week",
+	"mo": "month",
+	"y":  "year",
+}
+
+// stripUnitAnnotations removes UCUM curly-brace annotations ("{packets}") from
+// a unit string.
+func stripUnitAnnotations(unit string) string {
+	var b strings.Builder
+	depth := 0
+	for _, r := range unit {
+		switch {
+		case r == '{':
+			depth++
+		case r == '}':
+			if depth > 0 {
+				depth--
+			}
+		case depth == 0:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// unitWords converts a UCUM unit into (main, per) Prometheus suffix words:
+// "By/s" -> ("bytes", "second"). Unknown units pass through only if they are
+// already safe to embed in a metric name; otherwise they yield "".
+func unitWords(unit string) (string, string) {
+	unit = stripUnitAnnotations(unit)
+	if unit == "" || unit == "1" {
+		return "", ""
+	}
+	main, per := unit, ""
+	if idx := strings.LastIndex(unit, "/"); idx >= 0 {
+		main = strings.TrimSpace(unit[:idx])
+		perRaw := strings.TrimSpace(unit[idx+1:])
+		if w, ok := perUnitWordMap[perRaw]; ok {
+			per = w
+		} else if isWordSafe(perRaw) {
+			per = perRaw
+		}
+	}
+	if w, ok := unitWordMap[main]; ok {
+		main = w
+	} else if !isWordSafe(main) {
+		main = ""
+	}
+	return main, per
+}
+
+// isWordSafe reports whether s can be embedded into a metric name verbatim.
+func isWordSafe(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeMetricName maps an OTLP metric name onto the Prometheus name
+// charset: invalid characters become "_", consecutive "_" runs collapse to
+// one, and a leading digit gets a "_" prefix.
+func normalizeMetricName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	prevUnderscore := false
+	for _, r := range name {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == ':'
+		if !valid {
+			r = '_'
+		}
+		if r == '_' {
+			if prevUnderscore {
+				continue
+			}
+			prevUnderscore = true
+		} else {
+			prevUnderscore = false
+		}
+		b.WriteRune(r)
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "_"
+	}
+	if out[0] >= '0' && out[0] <= '9' {
+		out = "_" + out
+	}
+	return out
+}
+
+// buildMetricName produces the stored Prometheus-style metric name from an
+// OTLP metric name and unit: normalized charset, unit word suffixes, and
+// "_total" for monotonic counters.
+func buildMetricName(name, unit string, monotonicCounter bool) string {
+	out := normalizeMetricName(name)
+	mainUnit, perUnit := unitWords(unit)
+	if mainUnit != "" && !hasNameToken(out, mainUnit) {
+		out += "_" + mainUnit
+	}
+	if perUnit != "" && !strings.Contains(out, "_per_"+perUnit) {
+		out += "_per_" + perUnit
+	}
+	if monotonicCounter && !strings.HasSuffix(out, "_total") {
+		out += "_total"
+	}
+	return out
+}
+
+// hasNameToken reports whether name already contains the "_"-delimited token,
+// so unit suffixes are not appended twice.
+func hasNameToken(name, token string) bool {
+	return name == token ||
+		strings.HasSuffix(name, "_"+token) ||
+		strings.Contains(name, "_"+token+"_") ||
+		strings.HasPrefix(name, token+"_")
+}

--- a/writer/utils/unmarshal/otlp_metrics_test.go
+++ b/writer/utils/unmarshal/otlp_metrics_test.go
@@ -1,0 +1,684 @@
+package unmarshal
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	clconfig "github.com/metrico/cloki-config"
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/writer/config"
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+func TestBuildMetricName(t *testing.T) {
+	cases := []struct {
+		name, unit string
+		counter    bool
+		want       string
+	}{
+		{"http.server.duration", "s", false, "http_server_duration_seconds"},
+		{"http.server.requests", "{requests}", true, "http_server_requests_total"},
+		{"network.io", "By/s", false, "network_io_bytes_per_second"},
+		{"process.cpu.time", "s", true, "process_cpu_time_seconds_total"},
+		{"request.duration.seconds", "s", false, "request_duration_seconds"},
+		{"my.counter.total", "", true, "my_counter_total"},
+		{"2xx.count", "", false, "_2xx_count"},
+		{"weird..name", "", false, "weird_name"},
+		{"queue.size", "1", false, "queue_size"},
+		{"temp", "Cel", false, "temp_celsius"},
+		{"disk.usage", "MiBy", false, "disk_usage_mebibytes"},
+	}
+	for _, c := range cases {
+		if got := buildMetricName(c.name, c.unit, c.counter); got != c.want {
+			t.Errorf("buildMetricName(%q, %q, %v) = %q, want %q", c.name, c.unit, c.counter, got, c.want)
+		}
+	}
+}
+
+type collectedSample struct {
+	labels string
+	ts     int64
+	value  float64
+	str    string
+}
+
+type metricsCollector struct {
+	samples  []collectedSample
+	metadata map[string]string
+}
+
+// collectMetrics runs the OTLP metrics parser over md and joins emitted
+// samples with their series labels via fingerprint.
+func collectMetrics(t *testing.T, md *metricsv1.MetricsData, stats *OTLPMetricsStats) *metricsCollector {
+	t.Helper()
+	// onEntries -> fingerprintLabels reads config.Cloki.Setting.FingerPrintType;
+	// install a minimal global config so that read does not nil-pointer panic.
+	old := config.Cloki
+	config.Cloki = &clconfig.ClokiConfig{Setting: &clokiconfig.ClokiBaseSettingServer{}}
+	t.Cleanup(func() { config.Cloki = old })
+	cache := numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, map[string]*model.DataDatabasesMap{})
+	defer cache.Stop()
+
+	ch := OTLPMetricsFromData(md, stats)(context.Background(), nil, cache)
+	fpLabels := map[uint64]string{}
+	fpMetadata := map[uint64]string{}
+	type rawSample struct {
+		fp    uint64
+		ts    int64
+		value float64
+		str   string
+	}
+	var raw []rawSample
+	for resp := range ch {
+		if resp.Error != nil {
+			t.Fatalf("unexpected parser error: %v", resp.Error)
+		}
+		if tsReq, ok := resp.TimeSeriesRequest.(*model.TimeSeriesData); ok && tsReq != nil {
+			for i, fp := range tsReq.MFingerprint {
+				fpLabels[fp] = tsReq.MLabels[i]
+				fpMetadata[fp] = tsReq.MMetadata[i]
+			}
+		}
+		if splReq, ok := resp.SamplesRequest.(*model.TimeSamplesData); ok && splReq != nil {
+			for i, fp := range splReq.MFingerprint {
+				raw = append(raw, rawSample{fp, splReq.MTimestampNS[i], splReq.MValue[i], splReq.MMessage[i]})
+			}
+		}
+	}
+	col := &metricsCollector{metadata: map[string]string{}}
+	for _, r := range raw {
+		lbls := fpLabels[r.fp]
+		col.samples = append(col.samples, collectedSample{lbls, r.ts, r.value, r.str})
+		col.metadata[lbls] = fpMetadata[r.fp]
+	}
+	return col
+}
+
+func (c *metricsCollector) find(substrs ...string) []collectedSample {
+	var out []collectedSample
+	for _, s := range c.samples {
+		match := true
+		for _, sub := range substrs {
+			if !strings.Contains(s.labels, sub) {
+				match = false
+				break
+			}
+		}
+		if match {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func kv(key, val string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{Key: key, Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: val}}}
+}
+
+func testResource() *resourcev1.Resource {
+	return &resourcev1.Resource{Attributes: []*commonv1.KeyValue{
+		kv("service.name", "checkout"),
+		kv("service.namespace", "shop"),
+		kv("service.instance.id", "pod-1"),
+		kv("host.name", "node-a"),
+	}}
+}
+
+func wrapMetrics(res *resourcev1.Resource, metrics ...*metricsv1.Metric) *metricsv1.MetricsData {
+	return &metricsv1.MetricsData{ResourceMetrics: []*metricsv1.ResourceMetrics{{
+		Resource: res,
+		ScopeMetrics: []*metricsv1.ScopeMetrics{{
+			Scope:   &commonv1.InstrumentationScope{Name: "test-lib", Version: "1.2.3"},
+			Metrics: metrics,
+		}},
+	}}}
+}
+
+const testTS = uint64(1700000000_000000000)
+
+func TestOTLPMetrics_GaugeWithResourceAndScope(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "queue.depth", Unit: "1", Description: "queue depth",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+			TimeUnixNano: testTS,
+			Attributes:   []*commonv1.KeyValue{kv("queue", "q1")},
+			Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 42.5},
+		}}}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+
+	got := col.find(`"__name__":"queue_depth"`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 queue_depth sample, got %d; all: %+v", len(got), col.samples)
+	}
+	s := got[0]
+	if s.value != 42.5 || s.ts != int64(testTS) {
+		t.Errorf("bad sample: %+v", s)
+	}
+	for _, want := range []string{`"job":"shop/checkout"`, `"instance":"pod-1"`, `"queue":"q1"`,
+		`"otel_scope_name":"test-lib"`, `"otel_scope_version":"1.2.3"`} {
+		if !strings.Contains(s.labels, want) {
+			t.Errorf("labels missing %s: %s", want, s.labels)
+		}
+	}
+	if strings.Contains(s.labels, "__metric_type__") {
+		t.Errorf("metadata label leaked into stored labels: %s", s.labels)
+	}
+	if !strings.Contains(col.metadata[s.labels], `"type":"gauge"`) {
+		t.Errorf("metadata missing gauge type: %s", col.metadata[s.labels])
+	}
+	if stats.RejectedDataPoints() != 0 {
+		t.Errorf("expected 0 rejected, got %d", stats.RejectedDataPoints())
+	}
+}
+
+func TestOTLPMetrics_MonotonicSumBecomesCounter(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "http.requests", Unit: "{requests}",
+		Data: &metricsv1.Metric_Sum{Sum: &metricsv1.Sum{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			IsMonotonic:            true,
+			DataPoints: []*metricsv1.NumberDataPoint{{
+				TimeUnixNano: testTS,
+				Value:        &metricsv1.NumberDataPoint_AsInt{AsInt: 7},
+			}},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+	got := col.find(`"__name__":"http_requests_total"`)
+	if len(got) != 1 || got[0].value != 7 {
+		t.Fatalf("expected http_requests_total=7, got %+v", got)
+	}
+	if !strings.Contains(col.metadata[got[0].labels], `"type":"counter"`) {
+		t.Errorf("metadata missing counter type: %s", col.metadata[got[0].labels])
+	}
+}
+
+func TestOTLPMetrics_DeltaSumRejected(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "delta.counter",
+		Data: &metricsv1.Metric_Sum{Sum: &metricsv1.Sum{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+			IsMonotonic:            true,
+			DataPoints: []*metricsv1.NumberDataPoint{
+				{TimeUnixNano: testTS, Value: &metricsv1.NumberDataPoint_AsInt{AsInt: 1}},
+				{TimeUnixNano: testTS + 1, Value: &metricsv1.NumberDataPoint_AsInt{AsInt: 2}},
+			},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+	if len(col.samples) != 0 {
+		t.Fatalf("expected no samples for delta sum, got %+v", col.samples)
+	}
+	if stats.RejectedDataPoints() != 2 {
+		t.Errorf("expected 2 rejected, got %d", stats.RejectedDataPoints())
+	}
+	if !strings.Contains(stats.ErrorMessage(), "temporality") {
+		t.Errorf("error message should mention temporality: %q", stats.ErrorMessage())
+	}
+}
+
+func TestOTLPMetrics_NoRecordedValueDroppedSilently(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "sparse.gauge",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+			TimeUnixNano: testTS,
+			Flags:        noRecordedValueMask,
+		}}}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+	if len(col.samples) != 0 {
+		t.Fatalf("expected no samples, got %+v", col.samples)
+	}
+	if stats.RejectedDataPoints() != 0 {
+		t.Errorf("staleness markers must not count as rejected, got %d", stats.RejectedDataPoints())
+	}
+}
+
+func TestOTLPMetrics_ZeroTimestampRejected(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "bad.ts",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+			Value: &metricsv1.NumberDataPoint_AsDouble{AsDouble: 1},
+		}}}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+	if len(col.samples) != 0 {
+		t.Fatalf("expected no samples, got %+v", col.samples)
+	}
+	if stats.RejectedDataPoints() != 1 {
+		t.Errorf("expected 1 rejected, got %d", stats.RejectedDataPoints())
+	}
+}
+
+func float64p(f float64) *float64 { return &f }
+
+func TestOTLPMetrics_HistogramFlattening(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "req.duration", Unit: "s",
+		Data: &metricsv1.Metric_Histogram{Histogram: &metricsv1.Histogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.HistogramDataPoint{{
+				TimeUnixNano:   testTS,
+				Count:          10,
+				Sum:            float64p(9.5),
+				ExplicitBounds: []float64{0.1, 1},
+				BucketCounts:   []uint64{4, 3, 3},
+			}},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+
+	checks := []struct {
+		sub  []string
+		want float64
+	}{
+		{[]string{`"__name__":"req_duration_seconds_bucket"`, `"le":"0.1"`}, 4},
+		{[]string{`"__name__":"req_duration_seconds_bucket"`, `"le":"1"`}, 7},
+		{[]string{`"__name__":"req_duration_seconds_bucket"`, `"le":"+Inf"`}, 10},
+		{[]string{`"__name__":"req_duration_seconds_sum"`}, 9.5},
+		{[]string{`"__name__":"req_duration_seconds_count"`}, 10},
+	}
+	for _, c := range checks {
+		got := col.find(c.sub...)
+		if len(got) != 1 || got[0].value != c.want {
+			t.Errorf("series %v: want value %v, got %+v", c.sub, c.want, got)
+		}
+	}
+	if stats.RejectedDataPoints() != 0 {
+		t.Errorf("expected 0 rejected, got %d", stats.RejectedDataPoints())
+	}
+}
+
+func TestOTLPMetrics_HistogramEmptyBucketsStillEmitsInf(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "sparse.hist",
+		Data: &metricsv1.Metric_Histogram{Histogram: &metricsv1.Histogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.HistogramDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        5,
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	got := col.find(`"__name__":"sparse_hist_bucket"`, `"le":"+Inf"`)
+	if len(got) != 1 || got[0].value != 5 {
+		t.Fatalf("expected +Inf bucket with count 5, got %+v", got)
+	}
+}
+
+func TestOTLPMetrics_HistogramBucketBoundsMismatchRejected(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "broken.hist",
+		Data: &metricsv1.Metric_Histogram{Histogram: &metricsv1.Histogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.HistogramDataPoint{{
+				TimeUnixNano:   testTS,
+				Count:          3,
+				ExplicitBounds: []float64{1, 2},
+				BucketCounts:   []uint64{1, 2},
+			}},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+	if len(col.samples) != 0 {
+		t.Fatalf("expected no samples, got %+v", col.samples)
+	}
+	if stats.RejectedDataPoints() != 1 {
+		t.Errorf("expected 1 rejected, got %d", stats.RejectedDataPoints())
+	}
+}
+
+func TestOTLPMetrics_ExponentialHistogramConversion(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "exp.duration", Unit: "s",
+		Data: &metricsv1.Metric_ExponentialHistogram{ExponentialHistogram: &metricsv1.ExponentialHistogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.ExponentialHistogramDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        7,
+				Sum:          float64p(20),
+				Scale:        0,
+				ZeroCount:    1,
+				Positive: &metricsv1.ExponentialHistogramDataPoint_Buckets{
+					Offset:       0,
+					BucketCounts: []uint64{2, 4},
+				},
+			}},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+
+	// scale 0 -> base 2; bucket 0 upper bound 2^1=2, bucket 1 upper 2^2=4.
+	checks := []struct {
+		sub  []string
+		want float64
+	}{
+		{[]string{`"__name__":"exp_duration_seconds_bucket"`, `"le":"2"`}, 3},
+		{[]string{`"__name__":"exp_duration_seconds_bucket"`, `"le":"4"`}, 7},
+		{[]string{`"__name__":"exp_duration_seconds_bucket"`, `"le":"+Inf"`}, 7},
+		{[]string{`"__name__":"exp_duration_seconds_sum"`}, 20},
+		{[]string{`"__name__":"exp_duration_seconds_count"`}, 7},
+	}
+	for _, c := range checks {
+		got := col.find(c.sub...)
+		if len(got) != 1 || got[0].value != c.want {
+			t.Errorf("series %v: want value %v, got %+v", c.sub, c.want, got)
+		}
+	}
+}
+
+func TestOTLPMetrics_ExponentialHistogramNegativeBucketsRejected(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "neg.exp",
+		Data: &metricsv1.Metric_ExponentialHistogram{ExponentialHistogram: &metricsv1.ExponentialHistogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.ExponentialHistogramDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        3,
+				Negative: &metricsv1.ExponentialHistogramDataPoint_Buckets{
+					BucketCounts: []uint64{3},
+				},
+			}},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+	if len(col.samples) != 0 {
+		t.Fatalf("expected no samples, got %+v", col.samples)
+	}
+	if stats.RejectedDataPoints() != 1 {
+		t.Errorf("expected 1 rejected, got %d", stats.RejectedDataPoints())
+	}
+}
+
+func TestOTLPMetrics_Summary(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "gc.pause",
+		Data: &metricsv1.Metric_Summary{Summary: &metricsv1.Summary{
+			DataPoints: []*metricsv1.SummaryDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        100,
+				Sum:          12.5,
+				QuantileValues: []*metricsv1.SummaryDataPoint_ValueAtQuantile{
+					{Quantile: 0.5, Value: 0.1},
+					{Quantile: 0.99, Value: 0.9},
+				},
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	checks := []struct {
+		sub  []string
+		want float64
+	}{
+		{[]string{`"__name__":"gc_pause"`, `"quantile":"0.5"`}, 0.1},
+		{[]string{`"__name__":"gc_pause"`, `"quantile":"0.99"`}, 0.9},
+		{[]string{`"__name__":"gc_pause_sum"`}, 12.5},
+		{[]string{`"__name__":"gc_pause_count"`}, 100},
+	}
+	for _, c := range checks {
+		got := col.find(c.sub...)
+		if len(got) != 1 || got[0].value != c.want {
+			t.Errorf("series %v: want value %v, got %+v", c.sub, c.want, got)
+		}
+	}
+}
+
+func TestOTLPMetrics_TargetInfo(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "some.gauge",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+			TimeUnixNano: testTS,
+			Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 1},
+		}}}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	got := col.find(`"__name__":"target_info"`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 target_info sample, got %+v", got)
+	}
+	s := got[0]
+	if s.value != 1 || s.ts != int64(testTS) {
+		t.Errorf("bad target_info sample: %+v", s)
+	}
+	for _, want := range []string{`"host_name":"node-a"`, `"job":"shop/checkout"`, `"instance":"pod-1"`} {
+		if !strings.Contains(s.labels, want) {
+			t.Errorf("target_info missing %s: %s", want, s.labels)
+		}
+	}
+	// The shared insert pipeline injects a service_name label on every stored
+	// series (discoverServiceName), so it is expected here alongside job.
+	if !strings.Contains(s.labels, `"service_name"`) {
+		t.Errorf("expected pipeline-injected service_name label: %s", s.labels)
+	}
+	if strings.Contains(s.labels, "otel_scope") {
+		t.Errorf("target_info must not carry scope labels: %s", s.labels)
+	}
+}
+
+func TestOTLPMetrics_NoTargetInfoWithoutExtraAttrs(t *testing.T) {
+	res := &resourcev1.Resource{Attributes: []*commonv1.KeyValue{kv("service.name", "svc")}}
+	md := wrapMetrics(res, &metricsv1.Metric{
+		Name: "g",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+			TimeUnixNano: testTS,
+			Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 1},
+		}}}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	if got := col.find(`"__name__":"target_info"`); len(got) != 0 {
+		t.Fatalf("expected no target_info, got %+v", got)
+	}
+}
+
+func TestOTLPMetrics_ExemplarTraceIDStored(t *testing.T) {
+	traceID := []byte("0123456789abcdef")
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "with.exemplar",
+		Data: &metricsv1.Metric_Sum{Sum: &metricsv1.Sum{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			IsMonotonic:            true,
+			DataPoints: []*metricsv1.NumberDataPoint{{
+				TimeUnixNano: testTS,
+				Value:        &metricsv1.NumberDataPoint_AsInt{AsInt: 1},
+				Exemplars:    []*metricsv1.Exemplar{{TraceId: traceID}},
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	got := col.find(`"__name__":"with_exemplar_total"`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 sample, got %+v", got)
+	}
+	if got[0].str != "30313233343536373839616263646566" {
+		t.Errorf("expected hex trace id in string column, got %q", got[0].str)
+	}
+}
+
+// TestOTLPMetrics_ExponentialHistogramExactBounds pins the bucket bounds to
+// the exact powers of two the OTLP scale defines: at scale 1 the even-index
+// bounds are exactly 2, 4, 8, 16. The bound is stringified into the `le`
+// label, so any floating-point drift (e.g. 2.0000000000000004) produces a
+// series no other OTLP->Prometheus translator emits and feeds nonsense
+// boundaries to histogram_quantile.
+func TestOTLPMetrics_ExponentialHistogramExactBounds(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "exact.bounds",
+		Data: &metricsv1.Metric_ExponentialHistogram{ExponentialHistogram: &metricsv1.ExponentialHistogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.ExponentialHistogramDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        8,
+				Scale:        1,
+				Positive: &metricsv1.ExponentialHistogramDataPoint_Buckets{
+					Offset:       0,
+					BucketCounts: []uint64{1, 1, 1, 1, 1, 1, 1, 1},
+				},
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	// scale 1 -> bucket index k has upper bound 2^((k+1)/2), so the exact
+	// power-of-two bounds land on indices 1, 3, 5, 7; the cumulative count at
+	// each is index+1.
+	for le, want := range map[string]float64{"2": 2, "4": 4, "8": 6, "16": 8} {
+		got := col.find(`"__name__":"exact_bounds_bucket"`, `"le":"`+le+`"`)
+		if len(got) != 1 || got[0].value != want {
+			t.Errorf("bucket le=%s: want exactly one sample with value %v, got %+v", le, want, got)
+		}
+	}
+}
+
+// TestOTLPMetrics_RejectionReasonsUseRawMetricNames asserts every rejection
+// reason names the metric as the exporter sent it (raw OTLP name), never the
+// translated Prometheus name: partial_success.error_message is read by
+// whoever is debugging their exporter config, where only the raw name exists.
+func TestOTLPMetrics_RejectionReasonsUseRawMetricNames(t *testing.T) {
+	md := wrapMetrics(testResource(),
+		&metricsv1.Metric{
+			Name: "a.delta",
+			Data: &metricsv1.Metric_Sum{Sum: &metricsv1.Sum{
+				AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+				IsMonotonic:            true,
+				DataPoints: []*metricsv1.NumberDataPoint{{
+					TimeUnixNano: testTS, Value: &metricsv1.NumberDataPoint_AsInt{AsInt: 1},
+				}},
+			}},
+		},
+		&metricsv1.Metric{
+			Name: "b.zerots",
+			Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{
+				DataPoints: []*metricsv1.NumberDataPoint{{
+					TimeUnixNano: 0, Value: &metricsv1.NumberDataPoint_AsInt{AsInt: 1},
+				}},
+			}},
+		},
+	)
+	stats := &OTLPMetricsStats{}
+	collectMetrics(t, md, stats)
+	msg := stats.ErrorMessage()
+	for _, want := range []string{`"a.delta"`, `"b.zerots"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("rejection reasons must use the raw OTLP metric name %s: %s", want, msg)
+		}
+	}
+}
+
+// TestOTLPMetrics_ScopeAttrCannotOverwriteScopeIdentity asserts that scope
+// attributes colliding with otel_scope_name/version/schema_url after
+// prefixing are dropped, per the OTel Prometheus compatibility spec: they
+// must never displace the real instrumentation scope identity.
+func TestOTLPMetrics_ScopeAttrCannotOverwriteScopeIdentity(t *testing.T) {
+	md := &metricsv1.MetricsData{ResourceMetrics: []*metricsv1.ResourceMetrics{{
+		Resource: testResource(),
+		ScopeMetrics: []*metricsv1.ScopeMetrics{{
+			Scope: &commonv1.InstrumentationScope{
+				Name:    "real-scope",
+				Version: "9.9.9",
+				Attributes: []*commonv1.KeyValue{
+					kv("name", "impostor"),
+					kv("version", "0.0.0"),
+					kv("schema_url", "https://impostor.example"),
+					kv("kept", "yes"),
+				},
+			},
+			Metrics: []*metricsv1.Metric{{
+				Name: "g",
+				Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+					TimeUnixNano: testTS,
+					Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 1},
+				}}}},
+			}},
+		}},
+	}}}
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	got := col.find(`"__name__":"g"`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 series, got %+v", got)
+	}
+	lbls := got[0].labels
+	for _, want := range []string{`"otel_scope_name":"real-scope"`, `"otel_scope_version":"9.9.9"`, `"otel_scope_kept":"yes"`} {
+		if !strings.Contains(lbls, want) {
+			t.Errorf("missing %s: %s", want, lbls)
+		}
+	}
+	for _, banned := range []string{"impostor", "0.0.0", `"otel_scope_schema_url"`} {
+		if strings.Contains(lbls, banned) {
+			t.Errorf("colliding scope attribute leaked (%s): %s", banned, lbls)
+		}
+	}
+}
+
+// TestOTLPMetrics_AttributeKeyCollisionsConcatenated asserts that attribute
+// keys sanitizing to the same label name have their values concatenated with
+// ";" in lexicographic order of the original keys, per the OTel Prometheus
+// compatibility spec, instead of last-write-wins dropping data.
+func TestOTLPMetrics_AttributeKeyCollisionsConcatenated(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "g",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: []*metricsv1.NumberDataPoint{{
+			TimeUnixNano: testTS,
+			Value:        &metricsv1.NumberDataPoint_AsDouble{AsDouble: 1},
+			Attributes: []*commonv1.KeyValue{
+				kv("a.b", "first"),
+				kv("a-b", "second"),
+			},
+		}}}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	got := col.find(`"__name__":"g"`)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 series, got %+v", got)
+	}
+	// Lexicographic order of the ORIGINAL keys: "a-b" ('-' 0x2D) sorts before
+	// "a.b" ('.' 0x2E), so "second" comes first.
+	if want := `"a_b":"second;first"`; !strings.Contains(got[0].labels, want) {
+		t.Errorf("colliding attribute values: want %s in %s", want, got[0].labels)
+	}
+}
+
+// TestOTLPMetrics_TargetInfoSingleSamplePerResource asserts target_info is
+// emitted once per resource per export, at the latest accepted data-point
+// timestamp — not once per distinct timestamp, which would multiply it by the
+// request's timestamp cardinality.
+func TestOTLPMetrics_TargetInfoSingleSamplePerResource(t *testing.T) {
+	const points = 50
+	dps := make([]*metricsv1.NumberDataPoint, points)
+	for i := range dps {
+		dps[i] = &metricsv1.NumberDataPoint{
+			TimeUnixNano: testTS + uint64(i),
+			Value:        &metricsv1.NumberDataPoint_AsInt{AsInt: int64(i)},
+		}
+	}
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "g",
+		Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{DataPoints: dps}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+	got := col.find(`"__name__":"target_info"`)
+	if len(got) != 1 {
+		t.Fatalf("target_info: want exactly 1 sample for one target, got %d", len(got))
+	}
+	if got[0].ts != int64(testTS+points-1) {
+		t.Errorf("target_info timestamp: want the latest accepted (%d), got %d", int64(testTS+points-1), got[0].ts)
+	}
+}

--- a/writer/utils/unmarshal/otlp_metrics_test.go
+++ b/writer/utils/unmarshal/otlp_metrics_test.go
@@ -682,3 +682,65 @@ func TestOTLPMetrics_TargetInfoSingleSamplePerResource(t *testing.T) {
 		t.Errorf("target_info timestamp: want the latest accepted (%d), got %d", int64(testTS+points-1), got[0].ts)
 	}
 }
+
+// TestOTLPMetrics_HistogramInfBucketUsesCumulative pins the +Inf bucket to the
+// running sum of bucket_counts rather than the data point's own count field.
+// The two disagree whenever a producer is lossy or buggy, and taking count
+// there can place +Inf BELOW the last finite bucket. histogram_quantile does
+// not error on a non-monotonic bucket series — it silently returns a wrong
+// number — so monotonicity has to hold by construction.
+func TestOTLPMetrics_HistogramInfBucketUsesCumulative(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "lossy.hist",
+		Data: &metricsv1.Metric_Histogram{Histogram: &metricsv1.Histogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.HistogramDataPoint{{
+				TimeUnixNano:   testTS,
+				Count:          99, // deliberately disagrees with the buckets below
+				ExplicitBounds: []float64{0.1, 1},
+				BucketCounts:   []uint64{4, 3, 3}, // sums to 10, not 99
+			}},
+		}},
+	})
+	stats := &OTLPMetricsStats{}
+	col := collectMetrics(t, md, stats)
+
+	checks := []struct {
+		sub  []string
+		want float64
+	}{
+		{[]string{`"__name__":"lossy_hist_bucket"`, `"le":"0.1"`}, 4},
+		{[]string{`"__name__":"lossy_hist_bucket"`, `"le":"1"`}, 7},
+		// The running sum, NOT dp.Count (99).
+		{[]string{`"__name__":"lossy_hist_bucket"`, `"le":"+Inf"`}, 10},
+		// _count still reports what the producer claimed, so the discrepancy
+		// stays visible as _bucket{le="+Inf"} != _count.
+		{[]string{`"__name__":"lossy_hist_count"`}, 99},
+	}
+	for _, c := range checks {
+		got := col.find(c.sub...)
+		if len(got) != 1 || got[0].value != c.want {
+			t.Errorf("series %v: want value %v, got %+v", c.sub, c.want, got)
+		}
+	}
+
+	// Monotonicity is the property that actually matters downstream.
+	var prev float64
+	for _, le := range []string{`"le":"0.1"`, `"le":"1"`, `"le":"+Inf"`} {
+		got := col.find(`"__name__":"lossy_hist_bucket"`, le)
+		if len(got) != 1 {
+			t.Fatalf("expected exactly one bucket series for %s, got %d", le, len(got))
+		}
+		if got[0].value < prev {
+			t.Errorf("bucket series is not monotonic: %s = %v is below the previous bucket %v",
+				le, got[0].value, prev)
+		}
+		prev = got[0].value
+	}
+
+	// A count mismatch is well-formed data, merely inconsistent, so the point
+	// is accepted rather than rejected.
+	if stats.RejectedDataPoints() != 0 {
+		t.Errorf("expected 0 rejected, got %d", stats.RejectedDataPoints())
+	}
+}

--- a/writer/utils/unmarshal/otlp_metrics_test.go
+++ b/writer/utils/unmarshal/otlp_metrics_test.go
@@ -784,3 +784,69 @@ func TestOTLPMetrics_HistogramInfBucketStaysMonotonicWhenCountIsLow(t *testing.T
 		t.Errorf("+Inf bucket: want the running sum 10, got %v", prev)
 	}
 }
+
+// TestOTLPMetrics_ExpHistogramInfBucketStaysMonotonicWhenCountIsLow is the
+// exponential-histogram counterpart of the classic case. Sourcing +Inf from the
+// data point's count field puts the catch-all bucket below every finite one
+// when count falls under the buckets' own total, so "<= infinity" reads as
+// smaller than "<= 2", which cumulative buckets can never be.
+func TestOTLPMetrics_ExpHistogramInfBucketStaysMonotonicWhenCountIsLow(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "undercounted.exp",
+		Data: &metricsv1.Metric_ExponentialHistogram{ExponentialHistogram: &metricsv1.ExponentialHistogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.ExponentialHistogramDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        5, // below the buckets' own total of 10
+				Scale:        0,
+				ZeroCount:    0,
+				Positive: &metricsv1.ExponentialHistogramDataPoint_Buckets{
+					Offset:       0,
+					BucketCounts: []uint64{4, 3, 3},
+				},
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+
+	// scale 0 -> base 2; bucket k's upper bound is 2^(k+1): 2, 4, 8.
+	var prev float64
+	for _, le := range []string{`"le":"2"`, `"le":"4"`, `"le":"8"`, `"le":"+Inf"`} {
+		got := col.find(`"__name__":"undercounted_exp_bucket"`, le)
+		if len(got) != 1 {
+			t.Fatalf("expected exactly one bucket series for %s, got %d", le, len(got))
+		}
+		if got[0].value < prev {
+			t.Errorf("bucket series is not monotonic: %s = %v is below the previous bucket %v",
+				le, got[0].value, prev)
+		}
+		prev = got[0].value
+	}
+	if prev != 10 {
+		t.Errorf("+Inf bucket: want the running sum 10, got %v", prev)
+	}
+}
+
+// TestOTLPMetrics_ExpHistogramInfBucketWithoutPositiveBuckets pins the
+// zero-bucket-only case, where no finite bucket series is emitted and +Inf
+// therefore reports the producer's own total rather than a running sum.
+func TestOTLPMetrics_ExpHistogramInfBucketWithoutPositiveBuckets(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "zeros.only",
+		Data: &metricsv1.Metric_ExponentialHistogram{ExponentialHistogram: &metricsv1.ExponentialHistogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.ExponentialHistogramDataPoint{{
+				TimeUnixNano: testTS,
+				Count:        3,
+				Scale:        0,
+				ZeroCount:    3,
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+
+	got := col.find(`"__name__":"zeros_only_bucket"`, `"le":"+Inf"`)
+	if len(got) != 1 || got[0].value != 3 {
+		t.Errorf(`+Inf bucket: want 3, got %+v`, got)
+	}
+}

--- a/writer/utils/unmarshal/otlp_metrics_test.go
+++ b/writer/utils/unmarshal/otlp_metrics_test.go
@@ -744,3 +744,43 @@ func TestOTLPMetrics_HistogramInfBucketUsesCumulative(t *testing.T) {
 		t.Errorf("expected 0 rejected, got %d", stats.RejectedDataPoints())
 	}
 }
+
+// TestOTLPMetrics_HistogramInfBucketStaysMonotonicWhenCountIsLow covers the
+// severe half of the same defect. When the data point's count field is BELOW
+// the sum of its bucket_counts, sourcing +Inf from count places the catch-all
+// bucket underneath a finite one: "<= infinity" ends up smaller than "<= 1",
+// which is arithmetically impossible for cumulative buckets.
+// histogram_quantile interpolates across that broken staircase without
+// complaint, so the guarantee has to come from the encoder.
+func TestOTLPMetrics_HistogramInfBucketStaysMonotonicWhenCountIsLow(t *testing.T) {
+	md := wrapMetrics(testResource(), &metricsv1.Metric{
+		Name: "undercounted.hist",
+		Data: &metricsv1.Metric_Histogram{Histogram: &metricsv1.Histogram{
+			AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+			DataPoints: []*metricsv1.HistogramDataPoint{{
+				TimeUnixNano:   testTS,
+				Count:          5, // below the buckets' own total of 10
+				ExplicitBounds: []float64{0.1, 1},
+				BucketCounts:   []uint64{4, 3, 3},
+			}},
+		}},
+	})
+	col := collectMetrics(t, md, &OTLPMetricsStats{})
+
+	// Walk the buckets in ascending `le` order; each must be >= the last.
+	var prev float64
+	for _, le := range []string{`"le":"0.1"`, `"le":"1"`, `"le":"+Inf"`} {
+		got := col.find(`"__name__":"undercounted_hist_bucket"`, le)
+		if len(got) != 1 {
+			t.Fatalf("expected exactly one bucket series for %s, got %d", le, len(got))
+		}
+		if got[0].value < prev {
+			t.Errorf("bucket series is not monotonic: %s = %v is below the previous bucket %v",
+				le, got[0].value, prev)
+		}
+		prev = got[0].value
+	}
+	if prev != 10 {
+		t.Errorf("+Inf bucket: want the running sum 10, got %v", prev)
+	}
+}


### PR DESCRIPTION
Middle of the 3-PR stack — **base is `refactor/writer-ingest-core` (#940)**; retarget to `master` after #940 merges. Squashed final state:

- `/v1/metrics` accepts OTLP/HTTP exports in binary protobuf and JSON, responding per the OTLP/HTTP spec: 200 with `partial_success` when data points were rejected, 400 `google.rpc.Status` for undecodable payloads, 413 for oversize bodies, 503 for transient ingest failures.
- The decode layer translates OTLP metrics to Prometheus-shaped series per the OTel↔Prometheus compatibility spec: name/unit/suffix mapping, `job`/`instance` from `service.*`, `target_info` (one sample per resource per export at the latest accepted data-point timestamp), `otel_scope_*` labels with identity-label collisions dropped, colliding sanitized attribute keys concatenated with `;` in original-key order, exact exponential-histogram bucket bounds, delta temporality rejected.
- The payload bound is `system_settings.otlp_max_message_size` from cloki-config v0.0.96 (env `QRYN_SYSTEM_SETTINGS_OTLP_MAX_MESSAGE_SIZE`), default 64 MiB, applied to the decompressed body.
- `withPreParsedBody` lets a parser run over an already-decoded proto object, which is how the handler feeds the shared ingest core (and how the gRPC receiver PR feeds it next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)