### PR TITLE
feat(writer): OTLP/gRPC receiver for traces, logs, metrics, and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [Profiling API](docs/profiling-api.md) — profiling endpoints, DOT format export, Graphviz visualization
 - [OTLP Profiles Ingestion](docs/otlp-profiles.md) — OpenTelemetry profiles signal ingestion via `/v1development/profiles`
 - [OTLP Metrics Ingestion](docs/otlp-metrics.md) — OpenTelemetry metrics signal ingestion via `/v1/metrics` (protobuf + JSON)
-- [OTLP over gRPC](docs/otlp-grpc.md) — OTLP/gRPC receiver (`OTLP_GRPC_ADDR`) for traces, logs, and profiles
+- [OTLP over gRPC](docs/otlp-grpc.md) — OTLP/gRPC receiver for traces, logs, metrics, and profiles
 - [Contributing](docs/contributing.md) — development setup, testing, CLA requirement
 - [Full Documentation](https://gigapipe.com/docs/oss) — hosted docs at gigapipe.com
 - [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/metrico/gigapipe)

--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -381,6 +381,35 @@ func stop() {
 // background flushes to complete before forcibly exiting.
 const shutdownTimeout = 30 * time.Second
 
+// servesGRPC reports whether a node in this mode mounts the OTLP/gRPC
+// receiver. The receiver ingests through the write path (controller.Registry,
+// populated by writer.Init), so it follows exactly the modes that boot the
+// writer subsystem — see bootSequence, whose in("all", "writer", "") gate this
+// mirrors. TestServesGRPCFollowsWriterModes pins the two together.
+func servesGRPC(mode string) bool {
+	return mode == "all" || mode == "writer" || mode == ""
+}
+
+// httpRoot returns the root handler and protocol set for the shared HTTP
+// server. It is split out of httpStart so the mode gating can be asserted
+// directly: httpStart binds a listener and blocks on signals, so the decision
+// is untestable while it stays inline.
+//
+// Both return values are gated on the same condition, deliberately. Reader-only
+// nodes have no write path, so they get neither the OTLP/gRPC dispatcher nor
+// the protocol set that carries it: writergrpc.Protocols() enables cleartext
+// (prior-knowledge) HTTP/2, which exists only to carry gRPC. Setting it on a
+// node with no gRPC handler behind it would widen the protocols that node
+// accepts for no gain. A nil *http.Protocols leaves net/http's default
+// (HTTP/1 plus HTTP/2 over TLS), which is what reader-only nodes served before
+// the receiver existed.
+func httpRoot(server http.Handler, mode string, grpcOpts writergrpc.Options) (http.Handler, *http.Protocols) {
+	if !servesGRPC(mode) {
+		return server, nil
+	}
+	return writergrpc.Mux(server, grpcOpts), writergrpc.Protocols()
+}
+
 func httpStart(server *mux.Router, httpURL string, mode string, grpcOpts writergrpc.Options) {
 	logger.Info("Starting service")
 	var err error
@@ -390,13 +419,8 @@ func httpStart(server *mux.Router, httpURL string, mode string, grpcOpts writerg
 		panic(err)
 	}
 
-	// Reader-only nodes have no write path (controller.Registry is nil there),
-	// so only wrap with the OTLP/gRPC dispatcher when this node writes.
-	var root http.Handler = server
-	if mode == "all" || mode == "writer" || mode == "" {
-		root = writergrpc.Mux(server, grpcOpts)
-	}
-	httpServer := &http.Server{Handler: root, Protocols: writergrpc.Protocols()}
+	root, protocols := httpRoot(server, mode, grpcOpts)
+	httpServer := &http.Server{Handler: root, Protocols: protocols}
 
 	// Start serving in a goroutine so we can block on the signal below.
 	go func() {

--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -328,7 +328,11 @@ func start() {
 		step.run(cfg, app)
 	}
 	httpURL := fmt.Sprintf("%s:%d", cfg.Setting.HTTP_SETTINGS.Host, cfg.Setting.HTTP_SETTINGS.Port)
-	httpStart(app, httpURL, cfg.Setting.SYSTEM_SETTINGS.Mode)
+	grpcOpts := writergrpc.Options{
+		BasicAuthUser: cfg.Setting.AUTH_SETTINGS.BASIC.Username,
+		BasicAuthPass: cfg.Setting.AUTH_SETTINGS.BASIC.Password,
+	}
+	httpStart(app, httpURL, cfg.Setting.SYSTEM_SETTINGS.Mode, grpcOpts)
 
 }
 
@@ -377,7 +381,7 @@ func stop() {
 // background flushes to complete before forcibly exiting.
 const shutdownTimeout = 30 * time.Second
 
-func httpStart(server *mux.Router, httpURL string, mode string) {
+func httpStart(server *mux.Router, httpURL string, mode string, grpcOpts writergrpc.Options) {
 	logger.Info("Starting service")
 	var err error
 	listener, err = net.Listen("tcp", httpURL)
@@ -386,7 +390,13 @@ func httpStart(server *mux.Router, httpURL string, mode string) {
 		panic(err)
 	}
 
-	httpServer := &http.Server{Handler: server}
+	// Reader-only nodes have no write path (controller.Registry is nil there),
+	// so only wrap with the OTLP/gRPC dispatcher when this node writes.
+	var root http.Handler = server
+	if mode == "all" || mode == "writer" || mode == "" {
+		root = writergrpc.Mux(server, grpcOpts)
+	}
+	httpServer := &http.Server{Handler: root, Protocols: writergrpc.Protocols()}
 
 	// Start serving in a goroutine so we can block on the signal below.
 	go func() {
@@ -398,14 +408,6 @@ func httpStart(server *mux.Router, httpURL string, mode string) {
 
 	logger.Info("Server is listening on", httpURL)
 
-	// Start the OTLP gRPC receiver. Returns (nil, nil) when OTLP_GRPC_ADDR is
-	// empty, leaving existing behavior unchanged (no listener opened).
-	grpcServer, err := writergrpc.Start(os.Getenv("OTLP_GRPC_ADDR"))
-	if err != nil {
-		logger.Error("Error starting OTLP gRPC receiver:", err)
-		panic(err)
-	}
-
 	// Block until SIGTERM or SIGINT.
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
@@ -413,19 +415,13 @@ func httpStart(server *mux.Router, httpURL string, mode string) {
 	logger.Info(fmt.Sprintf("Received signal %v, starting graceful shutdown...", received))
 
 	// 1. Stop accepting new connections and drain in-flight HTTP requests.
+	// gRPC is served through this same http.Server (see writergrpc.Mux), and
+	// grpc.Server.GracefulStop has no effect on RPCs served via ServeHTTP, so
+	// this Shutdown call is what drains in-flight gRPC requests too.
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 	if err := httpServer.Shutdown(ctx); err != nil {
 		logger.Error("HTTP server shutdown error:", err)
-	}
-	if grpcServer != nil {
-		stopped := make(chan struct{})
-		go func() { grpcServer.GracefulStop(); close(stopped) }()
-		select {
-		case <-stopped:
-		case <-time.After(shutdownTimeout):
-			grpcServer.Stop()
-		}
 	}
 
 	// 2. Stop the ruler (cancels evaluation loops, waits for in-flight evals).

--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -383,11 +383,11 @@ const shutdownTimeout = 30 * time.Second
 
 // servesGRPC reports whether a node in this mode mounts the OTLP/gRPC
 // receiver. The receiver ingests through the write path (controller.Registry,
-// populated by writer.Init), so it follows exactly the modes that boot the
-// writer subsystem — see bootSequence, whose in("all", "writer", "") gate this
-// mirrors. TestServesGRPCFollowsWriterModes pins the two together.
+// populated by writer.Init), so it is derived from bootSequence rather than
+// restating its mode literals: a mode that mounts the receiver without booting
+// the writer would resolve services against an empty registry.
 func servesGRPC(mode string) bool {
-	return mode == "all" || mode == "writer" || mode == ""
+	return slices.ContainsFunc(bootSequence(mode), func(s bootStep) bool { return s.name == "writer" })
 }
 
 // httpRoot returns the root handler and protocol set for the shared HTTP
@@ -395,14 +395,10 @@ func servesGRPC(mode string) bool {
 // directly: httpStart binds a listener and blocks on signals, so the decision
 // is untestable while it stays inline.
 //
-// Both return values are gated on the same condition, deliberately. Reader-only
-// nodes have no write path, so they get neither the OTLP/gRPC dispatcher nor
-// the protocol set that carries it: writergrpc.Protocols() enables cleartext
-// (prior-knowledge) HTTP/2, which exists only to carry gRPC. Setting it on a
-// node with no gRPC handler behind it would widen the protocols that node
-// accepts for no gain. A nil *http.Protocols leaves net/http's default
-// (HTTP/1 plus HTTP/2 over TLS), which is what reader-only nodes served before
-// the receiver existed.
+// Both return values come from one gate, deliberately: cleartext
+// (prior-knowledge) HTTP/2 exists here only to carry gRPC, so a node that
+// mounts no gRPC dispatcher must not advertise it either. A nil
+// *http.Protocols leaves net/http's default of HTTP/1 plus HTTP/2 over TLS.
 func httpRoot(server http.Handler, mode string, grpcOpts writergrpc.Options) (http.Handler, *http.Protocols) {
 	if !servesGRPC(mode) {
 		return server, nil

--- a/cmd/gigapipe/main_test.go
+++ b/cmd/gigapipe/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"slices"
 	"strings"
 	"testing"
@@ -123,27 +124,39 @@ func TestBootSequenceModesScope(t *testing.T) {
 	}
 }
 
-// nopHandler stands in for the mux router in httpRoot tests. It is a pointer
-// type so the returned handler can be compared by identity: func values (and
-// so http.HandlerFunc) are not comparable in Go.
-type nopHandler struct{}
+// nopHandler stands in for the mux router in httpRoot tests. It records
+// whether it was reached, so a test can assert that gRPC traffic was
+// intercepted rather than passed through. It is a pointer type so the
+// returned handler can also be compared by identity: func values (and so
+// http.HandlerFunc) are not comparable in Go.
+type nopHandler struct{ served bool }
 
-func (*nopHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
+func (h *nopHandler) ServeHTTP(http.ResponseWriter, *http.Request) { h.served = true }
 
-// TestServesGRPCFollowsWriterModes pins the OTLP/gRPC receiver's mode gate to
-// the modes that actually boot the writer subsystem. The receiver ingests
-// through controller.Registry, which only writer.Init populates, so the two
-// gates must not drift apart: a mode that mounts the receiver without booting
-// the writer would resolve services against a nil registry.
-func TestServesGRPCFollowsWriterModes(t *testing.T) {
-	for _, mode := range []string{"all", "writer", "", "reader", "init_only"} {
-		t.Run("mode="+mode, func(t *testing.T) {
-			bootsWriter := slices.Contains(stepNames(mode), "writer")
-			if got := servesGRPC(mode); got != bootsWriter {
-				t.Errorf("mode %q: servesGRPC=%v but bootSequence boots writer=%v",
-					mode, got, bootsWriter)
-			}
-		})
+// grpcRequest builds the request shape Mux dispatches on: HTTP/2 carrying a
+// gRPC content type, on a real OTLP method path.
+func grpcRequest() *http.Request {
+	r := httptest.NewRequest(http.MethodPost,
+		"/opentelemetry.proto.collector.trace.v1.TraceService/Export", http.NoBody)
+	r.ProtoMajor, r.ProtoMinor, r.Proto = 2, 0, "HTTP/2.0"
+	r.Header.Set("Content-Type", "application/grpc")
+	return r
+}
+
+// TestServesGRPCModes pins the OTLP/gRPC receiver's mode gate to literal
+// expectations. servesGRPC derives its answer from bootSequence, so asserting
+// against bootSequence again would be a tautology; literals are what catch a
+// change to bootSequence — a renamed step, a dropped mode — that would
+// silently stop mounting the receiver on a node that ingests.
+func TestServesGRPCModes(t *testing.T) {
+	want := map[string]bool{
+		"all": true, "writer": true, "": true,
+		"reader": false, "init_only": false,
+	}
+	for mode, w := range want {
+		if got := servesGRPC(mode); got != w {
+			t.Errorf("servesGRPC(%q) = %v, want %v", mode, got, w)
+		}
 	}
 }
 
@@ -156,8 +169,9 @@ func TestHTTPRootWriterModes(t *testing.T) {
 		t.Run("mode="+mode, func(t *testing.T) {
 			base := &nopHandler{}
 			root, protocols := httpRoot(base, mode, writergrpc.Options{})
-			if root == http.Handler(base) {
-				t.Error("expected the router to be wrapped by the OTLP/gRPC dispatcher, got it unwrapped")
+			root.ServeHTTP(httptest.NewRecorder(), grpcRequest())
+			if base.served {
+				t.Error("a gRPC request reached the HTTP router: it must be intercepted by the OTLP/gRPC dispatcher")
 			}
 			if protocols == nil {
 				t.Fatal("expected a protocol set enabling cleartext HTTP/2, got nil")

--- a/cmd/gigapipe/main_test.go
+++ b/cmd/gigapipe/main_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"net/http"
 	"slices"
 	"strings"
 	"testing"
+
+	writergrpc "github.com/metrico/qryn/v5/writer/grpc"
 )
 
 // stepNames renders the boot sequence for a mode as an ordered slice of names.
@@ -117,5 +120,72 @@ func TestBootSequenceModesScope(t *testing.T) {
 	}
 	if slices.Contains(stepNames("writer"), "ruler") {
 		t.Error(`mode "writer" must not start the ruler`)
+	}
+}
+
+// nopHandler stands in for the mux router in httpRoot tests. It is a pointer
+// type so the returned handler can be compared by identity: func values (and
+// so http.HandlerFunc) are not comparable in Go.
+type nopHandler struct{}
+
+func (*nopHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
+// TestServesGRPCFollowsWriterModes pins the OTLP/gRPC receiver's mode gate to
+// the modes that actually boot the writer subsystem. The receiver ingests
+// through controller.Registry, which only writer.Init populates, so the two
+// gates must not drift apart: a mode that mounts the receiver without booting
+// the writer would resolve services against a nil registry.
+func TestServesGRPCFollowsWriterModes(t *testing.T) {
+	for _, mode := range []string{"all", "writer", "", "reader", "init_only"} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			bootsWriter := slices.Contains(stepNames(mode), "writer")
+			if got := servesGRPC(mode); got != bootsWriter {
+				t.Errorf("mode %q: servesGRPC=%v but bootSequence boots writer=%v",
+					mode, got, bootsWriter)
+			}
+		})
+	}
+}
+
+// TestHTTPRootWriterModes asserts that a node which serves gRPC gets both
+// halves: the dispatcher wrapping the router, and the protocol set that
+// carries it. Cleartext HTTP/2 must be enabled, since gRPC rides
+// prior-knowledge h2c on this port.
+func TestHTTPRootWriterModes(t *testing.T) {
+	for _, mode := range []string{"all", "writer", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			base := &nopHandler{}
+			root, protocols := httpRoot(base, mode, writergrpc.Options{})
+			if root == http.Handler(base) {
+				t.Error("expected the router to be wrapped by the OTLP/gRPC dispatcher, got it unwrapped")
+			}
+			if protocols == nil {
+				t.Fatal("expected a protocol set enabling cleartext HTTP/2, got nil")
+			}
+			if !protocols.UnencryptedHTTP2() {
+				t.Error("cleartext HTTP/2 must be enabled: gRPC rides prior-knowledge h2c on this port")
+			}
+			if !protocols.HTTP1() {
+				t.Error("HTTP/1 must stay enabled: OTLP/HTTP and every other route share this port")
+			}
+		})
+	}
+}
+
+// TestHTTPRootReaderModeLeavesProtocolsDefault is the negative half, and the
+// reason httpRoot returns both values from one gate. A reader-only node has no
+// write path, so it mounts no gRPC handler — and must therefore not advertise
+// cleartext HTTP/2 either. Setting Protocols unconditionally would enable h2c
+// on readers with nothing behind it, widening the protocols they accept for no
+// gain. A nil result leaves net/http's default, which is what readers served
+// before the receiver existed.
+func TestHTTPRootReaderModeLeavesProtocolsDefault(t *testing.T) {
+	base := &nopHandler{}
+	root, protocols := httpRoot(base, "reader", writergrpc.Options{})
+	if root != http.Handler(base) {
+		t.Error("reader-only nodes must serve the router unwrapped, with no gRPC dispatcher")
+	}
+	if protocols != nil {
+		t.Errorf("reader-only nodes must leave Protocols at net/http's default, got %+v", protocols)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,10 +42,6 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 - **`HOST`** - HTTP server bind address (default: `0.0.0.0`)
 - **`CORS_ALLOW_ORIGIN`** - Enable CORS and set allowed origin (e.g., `https://example.com`)
 
-## OTLP Ingestion
-
-- **`OTLP_GRPC_ADDR`** - Address for the OTLP/gRPC receiver (e.g. `:4317`, the OTel-convention gRPC port). When set, gigapipe accepts OTLP over gRPC in addition to the existing OTLP/HTTP endpoints. Unset or empty disables the receiver (default: off) and leaves existing behavior unchanged. Supports traces, logs, and profiles. See [OTLP over gRPC](otlp-grpc.md).
-
 ## Write Settings
 
 - **`BULK_MAX_SIZE_BYTES`** - Maximum batch size in bytes before flushing to ClickHouse

--- a/docs/otlp-grpc.md
+++ b/docs/otlp-grpc.md
@@ -1,21 +1,24 @@
 # OTLP over gRPC
 
 gigapipe accepts OpenTelemetry (OTLP) data over **gRPC** in addition to the
-existing OTLP/HTTP endpoints. The gRPC receiver is disabled by default and is
-enabled by setting the `OTLP_GRPC_ADDR` environment variable.
+existing OTLP/HTTP endpoints. The gRPC receiver requires no configuration: it
+is always on for nodes running in writer mode.
 
-## Enabling the receiver
+## Where it listens
 
-Set `OTLP_GRPC_ADDR` to a listen address. `4317` is the OTel-convention gRPC
-port; OTLP/HTTP continues to be served on the existing HTTP port (`PORT`,
-default `3100`).
+There is no environment variable to set. On any node running with `MODE=all`,
+`MODE=writer`, or `MODE` unset, the gRPC receiver is multiplexed onto the same
+port as OTLP/HTTP — `PORT` (default `3100`). Requests are dispatched by
+protocol: HTTP/2 requests with `Content-Type: application/grpc*` are routed to
+the gRPC server, everything else is served as ordinary HTTP. Reader-only nodes
+(`MODE=reader`) do not mount the gRPC receiver, since they have no write path.
 
-```bash
-OTLP_GRPC_ADDR=:4317
-```
-
-When `OTLP_GRPC_ADDR` is unset or empty the receiver is not started, no listener
-is opened, and existing behavior is unchanged.
+The transport is cleartext HTTP/2 using prior-knowledge negotiation (no TLS,
+no ALPN) — the same mode grpc-go clients use by default when configured for an
+insecure channel. An HTTP/1.1-only proxy or load balancer placed in front of
+gigapipe will break gRPC traffic even though OTLP/HTTP keeps working; put a
+proxy capable of passing through HTTP/2 prior-knowledge (or terminate gRPC
+before it, and forward OTLP/HTTP separately) if you need one in the path.
 
 ## Supported signals
 
@@ -23,7 +26,12 @@ is opened, and existing behavior is unchanged.
 |-----------|-----------|-----------|
 | Traces    | ✅        | ✅        |
 | Logs      | ✅        | ✅        |
+| Metrics   | ✅        | ✅ (`/v1/metrics`, protobuf + JSON) |
 | Profiles  | ✅        | ✅ (`/v1development/profiles`) |
+
+Metrics ingestion semantics (translation to Prometheus-style series,
+partial-success reporting, supported data point types) are transport
+independent and documented in [otlp-metrics.md](otlp-metrics.md).
 
 ## Multitenancy and per-request options
 
@@ -44,7 +52,9 @@ of, or alongside, `otlphttp`:
 ```yaml
 exporters:
   otlp:
-    endpoint: <gigapipe-writer-host>:4317
+    endpoint: <gigapipe-host>:3100
+    tls:
+      insecure: true
     headers:
       x-ch-dsn: <tenant-dsn>
 service:
@@ -61,5 +71,97 @@ For profiles specifically, see [OTLP Profiles Ingestion](otlp-profiles.md).
 
 ## Graceful shutdown
 
-On `SIGTERM`/`SIGINT` the gRPC receiver drains in-flight requests alongside the
-HTTP server during graceful shutdown.
+On `SIGTERM`/`SIGINT` in-flight gRPC requests are drained by the shared HTTP
+server's shutdown, alongside in-flight HTTP requests. See the second bullet
+under [Limitations](#limitations) for why grpc-go's own `GracefulStop` plays no
+part in this.
+
+## Request compression and size limits
+
+Requests compressed with **gzip** are supported and decompressed
+transparently — this is what the OpenTelemetry Collector's OTLP gRPC
+exporter sends by default, so no exporter configuration is needed to get
+compression working.
+
+The maximum accepted request size is **64 MiB** by default. Both transports
+read the same configured value — `system_settings.otlp_max_message_size`
+(env: `QRYN_SYSTEM_SETTINGS_OTLP_MAX_MESSAGE_SIZE`, bytes) — so a batch
+accepted over OTLP/HTTP is never rejected over OTLP/gRPC or vice versa.
+Batches larger than the limit are rejected with a `ResourceExhausted` error;
+if you hit it, consider tuning the collector's `batch` processor to emit
+smaller batches before raising the limit on the gigapipe side.
+
+## Authentication
+
+OTLP/gRPC requests bypass the HTTP mux's middleware chain, but two of its
+middlewares are ported as gRPC unary interceptors: basic auth and access
+logging. (CORS and response gzip are not — see [Limitations](#limitations).)
+
+Auth is off by default. It turns on exactly when it does on the HTTP side:
+when both `AUTH_SETTINGS.BASIC.Username` and `AUTH_SETTINGS.BASIC.Password`
+are set. When it's on, every gRPC request must carry an `authorization`
+metadata key with value `Basic <base64(user:pass)>`. A missing key, a
+malformed value, or wrong credentials are all rejected with gRPC status code
+`Unauthenticated` (16).
+
+**Warning:** the gRPC port is cleartext HTTP/2 — there is no TLS on this
+path (see [Where it listens](#where-it-listens)). Basic-auth credentials are
+base64, not encryption, so they travel in the clear. Only enable
+`AUTH_SETTINGS.BASIC` for gRPC over a trusted network, or put a TLS-terminating
+proxy capable of HTTP/2 prior-knowledge in front of gigapipe.
+
+An OpenTelemetry Collector authenticates with the `basicauth` extension,
+wired to the `otlp` exporter via `auth:`:
+
+```yaml
+extensions:
+  basicauth:
+    client_auth:
+      username: <user>
+      password: <pass>
+
+exporters:
+  otlp:
+    endpoint: <gigapipe-host>:3100
+    tls:
+      insecure: true
+    auth:
+      authenticator: basicauth
+
+service:
+  extensions: [basicauth]
+  pipelines:
+    traces:
+      receivers:  [otlp]
+      exporters:  [otlp]
+    logs:
+      receivers:  [otlp]
+      exporters:  [otlp]
+```
+
+gRPC requests also now appear in the access log, in the same line format as
+HTTP requests, with the gRPC status code and the full method name (e.g.
+`/opentelemetry.proto.collector.trace.v1.TraceService/Export`) standing in
+for the HTTP status and URL.
+
+## Limitations
+
+- **CORS and response gzip do not apply to gRPC.** CORS is a browser
+  preflight mechanism — gRPC clients never send `Origin` and never issue
+  `OPTIONS` preflights, and a browser cannot make an `application/grpc`
+  HTTP/2 request at all (that's what grpc-web is for, and grpc-web isn't
+  supported here). Response gzip compresses based on `Accept-Encoding`;
+  gRPC negotiates per-message compression itself via `grpc-encoding` /
+  `grpc-accept-encoding`, which already works, and OTLP export responses are
+  empty messages anyway.
+- **`grpc.Server.GracefulStop` does not apply here.** Because the gRPC server
+  is served through `ServeHTTP` on the shared `http.Server` rather than its
+  own listener, grpc-go's own `GracefulStop` has no effect on it. Draining is
+  handled entirely by the HTTP server's shutdown (`httpServer.Shutdown`),
+  which closes idle connections and waits for in-flight requests, gRPC
+  included, to finish.
+- **Serving gRPC through `net/http`'s HTTP/2 stack is slower than grpc-go's
+  native transport.** RPCs traverse `net/http`'s HTTP/2 implementation
+  instead of grpc-go's own transport layer, which carries a measurable
+  performance cost compared to a standalone grpc-go server. This is the
+  accepted tradeoff for running OTLP/gRPC and OTLP/HTTP on a single port.

--- a/docs/otlp-profiles.md
+++ b/docs/otlp-profiles.md
@@ -10,9 +10,9 @@ Only the protobuf encoding is supported. Requests with
 A successful request returns `200 OK`; a request that carries no profiles is a
 no-op that still returns `200 OK`.
 
-Profiles can also be ingested over **OTLP/gRPC** when the receiver is enabled via
-`OTLP_GRPC_ADDR`. See [OTLP over gRPC](otlp-grpc.md) for the gRPC transport,
-supported signals, and tenant metadata keys.
+Profiles can also be ingested over **OTLP/gRPC**, on the same port as the
+endpoint above. See [OTLP over gRPC](otlp-grpc.md) for the gRPC transport and
+supported signals.
 
 ## Routing via an OpenTelemetry Collector
 

--- a/writer/controller/builder.go
+++ b/writer/controller/builder.go
@@ -56,6 +56,13 @@ func Bind(p Parser, body io.Reader) BoundParser {
 	}
 }
 
+// PreDecoded binds a parser built over an already-decoded payload, such as the
+// OTLP *FromData builders. Those parsers take their input from the object
+// captured at construction and never read the body, so an empty one is bound.
+func PreDecoded(p Parser) BoundParser {
+	return Bind(p, http.NoBody)
+}
+
 type BuildOption func(ctx *PusherCtx) *PusherCtx
 
 type PusherCtx struct {

--- a/writer/grpc/auth.go
+++ b/writer/grpc/auth.go
@@ -1,0 +1,112 @@
+package grpc
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// invalidCredentialsMsg is the single, generic message returned for every
+// auth failure (missing header, malformed header, bad base64, wrong
+// credentials). Deliberately generic: it must not tell a caller which part
+// failed. There is no gRPC analogue of HTTP's WWW-Authenticate response
+// header, so none is emulated here.
+const invalidCredentialsMsg = "invalid credentials"
+
+// newAuthInterceptor returns a unary interceptor that requires HTTP Basic
+// credentials in the "authorization" gRPC metadata key, mirroring
+// reader/utils/middleware/basic_auth.go's BasicAuthMiddleware but for gRPC.
+//
+// An OpenTelemetry Collector authenticates against this with its `basicauth`
+// extension, which sets exactly this metadata key/value shape
+// ("authorization: Basic <base64(user:pass)>") on every RPC.
+//
+// This is checked on a cleartext port: like the HTTP path, credentials
+// travel unencrypted unless TLS terminates in front of it, so this should
+// only be exposed off a trusted network, or behind TLS.
+//
+// Callers gate construction on user/pass both being non-empty (see
+// NewServer) — this function itself does not special-case empty
+// credentials, so the auth failure path also protects against a
+// misconfigured empty user or pass.
+func newAuthInterceptor(user, pass string) grpc.UnaryServerInterceptor {
+	check := newCredentialCheck(user, pass)
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := check(ctx); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// newAuthStreamInterceptor is newAuthInterceptor's counterpart for streaming
+// RPCs: it verifies the same "authorization" metadata once, when the stream
+// is opened, before any handler runs. No registered service declares
+// streaming methods today; this exists so that the first one added is
+// authenticated instead of silently bypassing auth.
+func newAuthStreamInterceptor(user, pass string) grpc.StreamServerInterceptor {
+	check := newCredentialCheck(user, pass)
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := check(ss.Context()); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// newCredentialCheck returns the credential verification shared by the unary
+// and stream auth interceptors: it inspects the context's "authorization"
+// metadata and returns nil on valid Basic credentials, or a
+// codes.Unauthenticated status otherwise.
+func newCredentialCheck(user, pass string) func(ctx context.Context) error {
+	// Hash the configured credentials once, not per request. Comparing
+	// SHA-256 digests rather than the raw strings keeps both operands a
+	// fixed 32 bytes, so the comparison below cannot leak credential length
+	// (subtle.ConstantTimeCompare returns early when lengths differ).
+	expectedUser := sha256.Sum256([]byte(user))
+	expectedPass := sha256.Sum256([]byte(pass))
+
+	return func(ctx context.Context) error {
+		md, _ := metadata.FromIncomingContext(ctx)
+		auth := mdFirst(md, "authorization")
+		if auth == "" {
+			return status.Error(codes.Unauthenticated, invalidCredentialsMsg)
+		}
+
+		// The auth-scheme token is case-insensitive (RFC 7235 §2.1).
+		parts := strings.SplitN(auth, " ", 2)
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Basic") {
+			return status.Error(codes.Unauthenticated, invalidCredentialsMsg)
+		}
+
+		payload, err := base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return status.Error(codes.Unauthenticated, invalidCredentialsMsg)
+		}
+
+		pair := strings.SplitN(string(payload), ":", 2)
+		if len(pair) != 2 {
+			return status.Error(codes.Unauthenticated, invalidCredentialsMsg)
+		}
+
+		// Both comparisons are evaluated before branching: folding them
+		// into one short-circuiting condition would leak, by timing,
+		// whether the user alone was correct.
+		gotUser := sha256.Sum256([]byte(pair[0]))
+		gotPass := sha256.Sum256([]byte(pair[1]))
+		userOK := subtle.ConstantTimeCompare(gotUser[:], expectedUser[:]) == 1
+		passOK := subtle.ConstantTimeCompare(gotPass[:], expectedPass[:]) == 1
+		if !userOK || !passOK {
+			return status.Error(codes.Unauthenticated, invalidCredentialsMsg)
+		}
+
+		return nil
+	}
+}

--- a/writer/grpc/auth_test.go
+++ b/writer/grpc/auth_test.go
@@ -1,0 +1,176 @@
+package grpc
+
+import (
+	"context"
+	"encoding/base64"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// authTestOpts are the Options used by every test in this file: auth
+// enabled with a fixed user/pass pair.
+var authTestOpts = Options{BasicAuthUser: "user", BasicAuthPass: "pass"}
+
+// startAuthTestServer boots the real Mux/http.Server stack (not a bare
+// grpc.Server) over a bufconn listener with opts, and returns a dialed
+// client connection plus the spans recorder to assert against.
+func startAuthTestServer(t *testing.T, opts Options) (coltracepb.TraceServiceClient, *recorderSvc) {
+	t.Helper()
+	spans := installFakeRegistry(t)
+	installFPCache(t, "n")
+	installConfig(t)
+
+	lis := bufconn.Listen(1 << 20)
+	sentinel := &sentinelHandler{}
+	httpServer := &http.Server{Handler: Mux(sentinel, opts), Protocols: Protocols()}
+	go func() { _ = httpServer.Serve(lis) }()
+	t.Cleanup(func() { httpServer.Close() })
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return coltracepb.NewTraceServiceClient(conn), spans
+}
+
+// basicAuthHeader base64-encodes "user:pass" the way a well-behaved client
+// (or the OTel Collector's basicauth extension) would.
+func basicAuthHeader(user, pass string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}
+
+// assertUnauthenticatedAndEmpty exports req against client with the given
+// outgoing context, asserting BOTH that the RPC failed with
+// codes.Unauthenticated AND that the insert recorder received nothing --
+// a status-code check alone would not prove the business handler was
+// skipped.
+func assertUnauthenticatedAndEmpty(t *testing.T, ctx context.Context, client coltracepb.TraceServiceClient, spans *recorderSvc) {
+	t.Helper()
+	_, err := client.Export(ctx, sampleTraceRequest())
+	if err == nil {
+		t.Fatalf("expected export to fail with Unauthenticated, got success")
+	}
+	if got := status.Code(err); got != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got %v (err=%v)", got, err)
+	}
+
+	// Give any (incorrect) async path a moment to land, then assert nothing
+	// arrived.
+	time.Sleep(20 * time.Millisecond)
+	if got := spans.reqs(); len(got) != 0 {
+		t.Fatalf("expected insert recorder to receive nothing for an unauthenticated request, got %d requests", len(got))
+	}
+}
+
+// TestAuthInterceptor_NoMetadata covers plan Task E case 1: auth enabled, no
+// authorization metadata at all.
+func TestAuthInterceptor_NoMetadata(t *testing.T) {
+	client, spans := startAuthTestServer(t, authTestOpts)
+	assertUnauthenticatedAndEmpty(t, context.Background(), client, spans)
+}
+
+// TestAuthInterceptor_WrongPassword covers plan Task E case 2.
+func TestAuthInterceptor_WrongPassword(t *testing.T) {
+	client, spans := startAuthTestServer(t, authTestOpts)
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", basicAuthHeader("user", "wrong"))
+	assertUnauthenticatedAndEmpty(t, ctx, client, spans)
+}
+
+// TestAuthInterceptor_Malformed covers plan Task E case 3: "Basic" alone (no
+// payload), a Bearer-scheme header, and a non-base64 payload.
+func TestAuthInterceptor_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		auth string
+	}{
+		{"BasicAlone", "Basic"},
+		{"BearerScheme", "Bearer xyz"},
+		{"NonBase64Payload", "Basic not-valid-base64!!!"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client, spans := startAuthTestServer(t, authTestOpts)
+			ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", c.auth)
+			assertUnauthenticatedAndEmpty(t, ctx, client, spans)
+		})
+	}
+}
+
+// TestAuthInterceptor_CorrectCredentials covers plan Task E case 4: correct
+// credentials succeed, and a real span row reaches the insert layer.
+func TestAuthInterceptor_CorrectCredentials(t *testing.T) {
+	client, spans := startAuthTestServer(t, authTestOpts)
+	ctx := metadata.AppendToOutgoingContext(context.Background(),
+		"authorization", basicAuthHeader("user", "pass"),
+		"x-ch-dsn", "test-dsn")
+
+	if _, err := client.Export(ctx, sampleTraceRequest()); err != nil {
+		t.Fatalf("export with correct credentials failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(spans.reqs()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := spans.reqs()
+	if len(got) == 0 {
+		t.Fatalf("spans insert service received no requests; expected at least one span row")
+	}
+	ts, ok := got[0].(*model.TempoSamples)
+	if !ok {
+		t.Fatalf("spans request had unexpected type %T", got[0])
+	}
+	if len(ts.MName) == 0 || ts.MName[0] != "op" {
+		t.Fatalf("span name did not flow through: %#v", ts)
+	}
+}
+
+// TestAuthInterceptor_LowercaseScheme: the auth-scheme token is
+// case-insensitive (RFC 7235 §2.1), so a "basic" header must authenticate.
+// A successful Export is proof by itself that the interceptor passed the
+// request through.
+func TestAuthInterceptor_LowercaseScheme(t *testing.T) {
+	client, _ := startAuthTestServer(t, authTestOpts)
+	ctx := metadata.AppendToOutgoingContext(context.Background(),
+		"authorization", "basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")),
+		"x-ch-dsn", "test-dsn")
+
+	if _, err := client.Export(ctx, sampleTraceRequest()); err != nil {
+		t.Fatalf("export with lowercase scheme failed: %v", err)
+	}
+}
+
+// TestAuthInterceptor_Disabled covers plan Task E case 5: with Options{}
+// (empty user/pass), auth is disabled entirely and export succeeds with no
+// metadata at all. TestGRPCTraces_EndToEnd in integration_test.go already
+// exercises this path through Mux(sentinel, Options{}); this test exists
+// alongside the negative-control discipline of this file to make the
+// "disabled" contract explicit here too.
+func TestAuthInterceptor_Disabled(t *testing.T) {
+	client, spans := startAuthTestServer(t, Options{})
+	if _, err := client.Export(context.Background(), sampleTraceRequest()); err != nil {
+		t.Fatalf("export with auth disabled and no metadata failed: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for len(spans.reqs()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(spans.reqs()) == 0 {
+		t.Fatalf("expected export to reach the insert layer with auth disabled")
+	}
+}

--- a/writer/grpc/codec_test.go
+++ b/writer/grpc/codec_test.go
@@ -1,0 +1,169 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// NOTE: this file must NOT import google.golang.org/grpc/encoding/gzip, not
+// even blank. Compressor registration in grpc-go is process-global via
+// package init(); if this test binary imported the gzip codec anywhere, the
+// server side would have it registered regardless of whether
+// writer/grpc/server.go carries its own import, and TestGRPCTraces_EndToEnd_Gzip
+// would pass even with the production import reverted. The client below uses
+// grpc.UseCompressor("gzip") by name only — it relies entirely on
+// server.go's blank import to make "gzip" resolvable process-wide.
+
+// TestGRPCTraces_EndToEnd_Gzip is the same shape as TestGRPCTraces_EndToEnd,
+// but the client compresses the request with gzip, as the OpenTelemetry
+// Collector's OTLP gRPC exporter does by default. It exists to guard the
+// blank gzip codec import in writer/grpc/server.go: without that import the
+// server cannot decompress and this test fails with an "Unimplemented:
+// Decompressor is not installed" error.
+func TestGRPCTraces_EndToEnd_Gzip(t *testing.T) {
+	spans := installFakeRegistry(t)
+	installFPCache(t, "n")
+	installConfig(t)
+
+	lis := bufconn.Listen(1 << 20)
+	sentinel := &sentinelHandler{}
+	httpServer := &http.Server{Handler: Mux(sentinel, Options{}), Protocols: Protocols()}
+	go func() { _ = httpServer.Serve(lis) }()
+	defer httpServer.Close()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-ch-dsn", "test-dsn")
+	client := coltracepb.NewTraceServiceClient(conn)
+	if _, err := client.Export(ctx, sampleTraceRequest()); err != nil {
+		t.Fatalf("gzip export failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(spans.reqs()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := spans.reqs()
+	if len(got) == 0 {
+		t.Fatalf("spans insert service received no requests; expected at least one span row")
+	}
+	ts, ok := got[0].(*model.TempoSamples)
+	if !ok {
+		t.Fatalf("spans request had unexpected type %T", got[0])
+	}
+	if len(ts.MTraceId) == 0 || len(ts.MName) == 0 {
+		t.Fatalf("spans request carried no span rows: %#v", ts)
+	}
+	if ts.MName[0] != "op" {
+		t.Fatalf("span name did not flow through: got %q, want %q", ts.MName[0], "op")
+	}
+}
+
+// largeTraceRequest builds an ExportTraceServiceRequest whose serialized size
+// is comfortably above grpc-go's default 4 MiB receive cap (roughly 5-6 MB
+// here), using a small number of spans that each carry one large attribute
+// string value rather than many tiny spans, to keep the test fast.
+func largeTraceRequest() *coltracepb.ExportTraceServiceRequest {
+	const spanCount = 6
+	const valueSize = 1 << 20 // 1 MB per attribute value
+	bigValue := strings.Repeat("x", valueSize)
+
+	spans := make([]*tracev1.Span, spanCount)
+	for i := 0; i < spanCount; i++ {
+		spans[i] = &tracev1.Span{
+			Name:    "op",
+			TraceId: []byte("0123456789abcdef"),
+			SpanId:  []byte("01234567"),
+			Attributes: []*commonv1.KeyValue{{
+				Key:   "payload",
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: bigValue}},
+			}},
+		}
+	}
+
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{{
+			Resource: &resourcev1.Resource{Attributes: []*commonv1.KeyValue{{
+				Key:   "service.name",
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "svc"}},
+			}}},
+			ScopeSpans: []*tracev1.ScopeSpans{{Spans: spans}},
+		}},
+	}
+}
+
+// TestGRPCTraces_EndToEnd_LargeMessage proves a request larger than grpc-go's
+// default 4 MiB receive cap is accepted, guarding the grpc.MaxRecvMsgSize
+// option set in NewServer (see maxRecvMsgSize in writer/grpc/server.go).
+// Without that option this test fails with a ResourceExhausted error.
+func TestGRPCTraces_EndToEnd_LargeMessage(t *testing.T) {
+	spans := installFakeRegistry(t)
+	installFPCache(t, "n")
+	installConfig(t)
+
+	req := largeTraceRequest()
+
+	lis := bufconn.Listen(1 << 20)
+	sentinel := &sentinelHandler{}
+	httpServer := &http.Server{Handler: Mux(sentinel, Options{}), Protocols: Protocols()}
+	go func() { _ = httpServer.Serve(lis) }()
+	defer httpServer.Close()
+
+	// The client must also be willing to send/receive a message this size;
+	// grpc-go's client-side defaults for send are effectively unbounded for
+	// our purposes but the receive default on the client applies to
+	// responses only (the Export response here is tiny), so no client-side
+	// size option is required here beyond a generous max call recv size for
+	// safety.
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(16<<20)))
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-ch-dsn", "test-dsn")
+	client := coltracepb.NewTraceServiceClient(conn)
+	if _, err := client.Export(ctx, req); err != nil {
+		t.Fatalf("large export failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(spans.reqs()) == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := spans.reqs()
+	if len(got) == 0 {
+		t.Fatalf("spans insert service received no requests; expected at least one span row")
+	}
+	ts, ok := got[0].(*model.TempoSamples)
+	if !ok {
+		t.Fatalf("spans request had unexpected type %T", got[0])
+	}
+	if len(ts.MTraceId) == 0 || len(ts.MName) == 0 {
+		t.Fatalf("spans request carried no span rows: %#v", ts)
+	}
+}

--- a/writer/grpc/integration_test.go
+++ b/writer/grpc/integration_test.go
@@ -3,6 +3,8 @@ package grpc
 import (
 	"context"
 	"net"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,8 +19,10 @@ import (
 	"github.com/metrico/qryn/v5/writer/utils/helpers"
 	"github.com/metrico/qryn/v5/writer/utils/numbercache"
 	"github.com/metrico/qryn/v5/writer/utils/promise"
-	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
@@ -67,18 +71,26 @@ func (r *recorderSvc) PlanFlush() {}
 
 // fakeRegistry is an in-memory registry.ServiceRegistry test double. For traces,
 // ResolveTraceServices reads GetSpansSeriesService (SpanAttrs slot) and
-// GetSpansService (Spans slot); every other method exists only to satisfy the
-// interface and returns nil.
+// GetSpansService (Spans slot); ResolveLogServices reads GetSamplesService and
+// GetTimeSeriesService. Unset slots return nil to satisfy the interface.
 type fakeRegistry struct {
-	spans     *recorderSvc
-	spanAttrs *recorderSvc
+	spans      *recorderSvc
+	spanAttrs  *recorderSvc
+	samples    *recorderSvc
+	timeSeries *recorderSvc
 }
 
 func (f *fakeRegistry) GetTimeSeriesService(id string) (service.IInsertServiceV2, error) {
-	return nil, nil
+	if f.timeSeries == nil {
+		return nil, nil
+	}
+	return f.timeSeries, nil
 }
 func (f *fakeRegistry) GetSamplesService(id string) (service.IInsertServiceV2, error) {
-	return nil, nil
+	if f.samples == nil {
+		return nil, nil
+	}
+	return f.samples, nil
 }
 func (f *fakeRegistry) GetMetricsService(id string) (service.IInsertServiceV2, error) {
 	return nil, nil
@@ -108,6 +120,20 @@ func installFakeRegistry(t *testing.T) *recorderSvc {
 	controller.Registry = fr
 	t.Cleanup(func() { controller.Registry = old })
 	return spans
+}
+
+// installFakeMetricsRegistry installs a fakeRegistry (save/restore) whose
+// samples and time-series insert services record pushed rows, and returns the
+// two recorders to assert on.
+func installFakeMetricsRegistry(t *testing.T) (samples, timeSeries *recorderSvc) {
+	t.Helper()
+	samples = &recorderSvc{node: "n"}
+	timeSeries = &recorderSvc{node: "n"}
+	fr := &fakeRegistry{samples: samples, timeSeries: timeSeries}
+	old := controller.Registry
+	controller.Registry = fr
+	t.Cleanup(func() { controller.Registry = old })
+	return samples, timeSeries
 }
 
 // installFPCache registers a trivial per-node fingerprint cache for node "n" and
@@ -156,18 +182,43 @@ func sampleTraceRequest() *coltracepb.ExportTraceServiceRequest {
 	}
 }
 
+// sentinelHandler is a plain http.Handler that records whether it was
+// invoked, used to prove gRPC requests never reach the non-gRPC fallback
+// handler (and that non-gRPC requests do).
+type sentinelHandler struct {
+	mu     sync.Mutex
+	called bool
+}
+
+func (s *sentinelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	s.called = true
+	s.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *sentinelHandler) wasCalled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.called
+}
+
 // TestGRPCTraces_EndToEnd drives the OTLP gRPC TraceService over an in-memory
-// bufconn connection and asserts a span row reaches the insert layer (the Spans
-// recorder receives at least one pushed request).
+// bufconn connection, served through the same production stack used in
+// production (Mux + Protocols on a shared http.Server, not a bare
+// grpc.Server), and asserts a span row reaches the insert layer (the Spans
+// recorder receives at least one pushed request). It also asserts the gRPC
+// request never falls through to the sentinel non-gRPC handler.
 func TestGRPCTraces_EndToEnd(t *testing.T) {
 	spans := installFakeRegistry(t)
 	installFPCache(t, "n")
 	installConfig(t)
 
 	lis := bufconn.Listen(1 << 20)
-	srv := NewServer()
-	go func() { _ = srv.Serve(lis) }()
-	defer srv.Stop()
+	sentinel := &sentinelHandler{}
+	httpServer := &http.Server{Handler: Mux(sentinel, Options{}), Protocols: Protocols()}
+	go func() { _ = httpServer.Serve(lis) }()
+	defer httpServer.Close()
 
 	conn, err := grpc.NewClient("passthrough:///bufnet",
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
@@ -209,5 +260,158 @@ func TestGRPCTraces_EndToEnd(t *testing.T) {
 	}
 	if ts.MName[0] != "op" {
 		t.Fatalf("span name did not flow through: got %q, want %q", ts.MName[0], "op")
+	}
+
+	if sentinel.wasCalled() {
+		t.Fatalf("sentinel non-gRPC handler was called for a gRPC request; Mux dispatch is broken")
+	}
+}
+
+// TestGRPCMetrics_EndToEnd drives the OTLP gRPC MetricsService over an
+// in-memory bufconn connection through the production Mux stack. The request
+// mixes an ingestible cumulative monotonic sum with a delta sum that the
+// ingest policy rejects, asserting both halves of the contract at once: the
+// stored half reaches the samples and time-series insert services with the
+// translated name, and the rejected half is reported via partial_success.
+func TestGRPCMetrics_EndToEnd(t *testing.T) {
+	samples, timeSeries := installFakeMetricsRegistry(t)
+	installFPCache(t, "n")
+	installConfig(t)
+
+	lis := bufconn.Listen(1 << 20)
+	sentinel := &sentinelHandler{}
+	httpServer := &http.Server{Handler: Mux(sentinel, Options{}), Protocols: Protocols()}
+	go func() { _ = httpServer.Serve(lis) }()
+	defer httpServer.Close()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	req := &colmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricsv1.ResourceMetrics{{
+			Resource: &resourcev1.Resource{Attributes: []*commonv1.KeyValue{{
+				Key:   "service.name",
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "svc"}},
+			}}},
+			ScopeMetrics: []*metricsv1.ScopeMetrics{{Metrics: []*metricsv1.Metric{
+				{
+					Name: "http.requests",
+					Data: &metricsv1.Metric_Sum{Sum: &metricsv1.Sum{
+						AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+						IsMonotonic:            true,
+						DataPoints: []*metricsv1.NumberDataPoint{{
+							TimeUnixNano: 1700000000_000000000,
+							Value:        &metricsv1.NumberDataPoint_AsInt{AsInt: 5},
+						}},
+					}},
+				},
+				{
+					Name: "delta.requests",
+					Data: &metricsv1.Metric_Sum{Sum: &metricsv1.Sum{
+						AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+						IsMonotonic:            true,
+						DataPoints: []*metricsv1.NumberDataPoint{{
+							TimeUnixNano: 1700000000_000000000,
+							Value:        &metricsv1.NumberDataPoint_AsInt{AsInt: 3},
+						}},
+					}},
+				},
+			}}},
+		}},
+	}
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-ch-dsn", "test-dsn")
+	client := colmetricspb.NewMetricsServiceClient(conn)
+	resp, err := client.Export(ctx, req)
+	if err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+
+	if resp.PartialSuccess == nil {
+		t.Fatal("expected partial_success for the delta data point")
+	}
+	if resp.PartialSuccess.RejectedDataPoints != 1 {
+		t.Fatalf("expected 1 rejected data point, got %d", resp.PartialSuccess.RejectedDataPoints)
+	}
+	if resp.PartialSuccess.ErrorMessage == "" {
+		t.Fatal("expected a non-empty partial_success error message")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for (len(samples.reqs()) == 0 || len(timeSeries.reqs()) == 0) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	gotSamples := samples.reqs()
+	if len(gotSamples) == 0 {
+		t.Fatal("samples insert service received no requests")
+	}
+	spl, ok := gotSamples[0].(*model.TimeSamplesData)
+	if !ok {
+		t.Fatalf("samples request had unexpected type %T", gotSamples[0])
+	}
+	if len(spl.MValue) != 1 || spl.MValue[0] != 5 {
+		t.Fatalf("expected exactly the cumulative sample value 5, got %#v", spl.MValue)
+	}
+
+	gotTS := timeSeries.reqs()
+	if len(gotTS) == 0 {
+		t.Fatal("time series insert service received no requests")
+	}
+	ts, ok := gotTS[0].(*model.TimeSeriesData)
+	if !ok {
+		t.Fatalf("time series request had unexpected type %T", gotTS[0])
+	}
+	var sawTotal bool
+	for _, lbls := range ts.MLabels {
+		if strings.Contains(lbls, `"__name__":"http_requests_total"`) {
+			sawTotal = true
+		}
+		if strings.Contains(lbls, "delta_requests") {
+			t.Fatalf("delta metric series must not be stored: %s", lbls)
+		}
+	}
+	if !sawTotal {
+		t.Fatalf("expected a stored series named http_requests_total, got %v", ts.MLabels)
+	}
+
+	if sentinel.wasCalled() {
+		t.Fatal("sentinel non-gRPC handler was called for a gRPC request")
+	}
+}
+
+// TestMux_HTTPPassthrough proves that plain HTTP/1.1 requests are routed to
+// next unchanged — Mux's gRPC dispatch does not swallow ordinary routes.
+func TestMux_HTTPPassthrough(t *testing.T) {
+	lis := bufconn.Listen(1 << 20)
+	sentinel := &sentinelHandler{}
+	httpServer := &http.Server{Handler: Mux(sentinel, Options{}), Protocols: Protocols()}
+	go func() { _ = httpServer.Serve(lis) }()
+	defer httpServer.Close()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return lis.Dial()
+			},
+		},
+	}
+
+	resp, err := client.Get("http://bufnet/")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if !sentinel.wasCalled() {
+		t.Fatalf("sentinel handler was not called for a plain HTTP/1.1 request")
 	}
 }

--- a/writer/grpc/logging.go
+++ b/writer/grpc/logging.go
@@ -1,0 +1,47 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/metrico/qryn/v5/writer/utils/logger"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// loggingInterceptor emits one access-log line per unary RPC, mirroring the
+// shape of the HTTP access log configured at cmd/gigapipe/main.go's start()
+// ("[{{.status}}] {{.method}} {{.url}} - LAT:{{.latency}}"), e.g.:
+//
+//	[OK] gRPC /opentelemetry.proto.collector.trace.v1.TraceService/Export - LAT:1.2ms
+//
+// It intentionally does not reuse LoggingMiddleware's text/template
+// machinery (reader/utils/middleware/logging.go): that machinery is
+// HTTP-shaped (url, referer, user_agent, response length) and lives in the
+// reader package, which this package does not depend on.
+func loggingInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	start := time.Now()
+	resp, err := handler(ctx, req)
+	d := time.Since(start)
+	logger.Info(formatAccessLog(info.FullMethod, status.Code(err), d))
+	return resp, err
+}
+
+// streamLoggingInterceptor is loggingInterceptor's counterpart for streaming
+// RPCs: one access-log line per stream, emitted when the stream ends, with
+// the latency spanning the stream's whole lifetime.
+func streamLoggingInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	start := time.Now()
+	err := handler(srv, ss)
+	logger.Info(formatAccessLog(info.FullMethod, status.Code(err), time.Since(start)))
+	return err
+}
+
+// formatAccessLog builds the access-log line for one gRPC call. It is a pure
+// function, factored out of loggingInterceptor so it can be unit-tested
+// without capturing logger output.
+func formatAccessLog(fullMethod string, code codes.Code, d time.Duration) string {
+	return fmt.Sprintf("[%s] gRPC %s - LAT:%s", code, fullMethod, d)
+}

--- a/writer/grpc/logging_test.go
+++ b/writer/grpc/logging_test.go
@@ -1,0 +1,78 @@
+package grpc
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+)
+
+// TestFormatAccessLog table-tests formatAccessLog over a range of
+// (method, code, duration) combinations, including a non-OK code, without
+// capturing logger output.
+func TestFormatAccessLog(t *testing.T) {
+	cases := []struct {
+		name       string
+		fullMethod string
+		code       codes.Code
+		d          time.Duration
+		wantParts  []string
+	}{
+		{
+			name:       "OK trace export",
+			fullMethod: "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+			code:       codes.OK,
+			d:          1200 * time.Microsecond,
+			wantParts: []string{
+				"[OK]",
+				"gRPC /opentelemetry.proto.collector.trace.v1.TraceService/Export",
+				"LAT:",
+			},
+		},
+		{
+			name:       "Unauthenticated",
+			fullMethod: "/opentelemetry.proto.collector.logs.v1.LogsService/Export",
+			code:       codes.Unauthenticated,
+			d:          500 * time.Microsecond,
+			wantParts: []string{
+				"[Unauthenticated]",
+				"gRPC /opentelemetry.proto.collector.logs.v1.LogsService/Export",
+				"LAT:",
+			},
+		},
+		{
+			name:       "Internal (panic recovered)",
+			fullMethod: "/opentelemetry.proto.collector.profiles.v1development.ProfilesService/Export",
+			code:       codes.Internal,
+			d:          10 * time.Millisecond,
+			wantParts: []string{
+				"[Internal]",
+				"gRPC /opentelemetry.proto.collector.profiles.v1development.ProfilesService/Export",
+				"LAT:",
+			},
+		},
+		{
+			name:       "zero duration",
+			fullMethod: "/x/Y",
+			code:       codes.OK,
+			d:          0,
+			wantParts: []string{
+				"[OK]",
+				"gRPC /x/Y",
+				"LAT:0s",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatAccessLog(c.fullMethod, c.code, c.d)
+			for _, want := range c.wantParts {
+				if !strings.Contains(got, want) {
+					t.Fatalf("formatAccessLog(%q, %v, %v) = %q; want substring %q", c.fullMethod, c.code, c.d, got, want)
+				}
+			}
+		})
+	}
+}

--- a/writer/grpc/logs.go
+++ b/writer/grpc/logs.go
@@ -27,11 +27,9 @@ func (s *logsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	ld := &logsv1.LogsData{ResourceLogs: req.ResourceLogs}
-	// Body is nil: the *FromData parsers are built with withPreParsedBody,
-	// so the payload is already supplied and no reader is ever read.
-	parser := controller.Bind(controller.Parser(unmarshal.OTLPLogsFromData(ld)), nil)
+	parser := controller.PreDecoded(controller.Parser(unmarshal.OTLPLogsFromData(ld)))
 	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ingestFailure("logs", err)
 	}
 	return &collogspb.ExportLogsServiceResponse{}, nil
 }

--- a/writer/grpc/metrics.go
+++ b/writer/grpc/metrics.go
@@ -1,0 +1,51 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	"github.com/metrico/qryn/v5/writer/utils/unmarshal"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// metricsServer implements the OTLP MetricsService gRPC handler, converting
+// the already-decoded ExportMetricsServiceRequest into the shared
+// parse/ingest path.
+type metricsServer struct {
+	colmetricspb.UnimplementedMetricsServiceServer
+}
+
+// Export resolves the tenant's metric insert services from the request
+// metadata and ingests the pre-decoded metrics through the transport-agnostic
+// core. Data points dropped by ingest policy (delta temporality, invalid
+// points) are reported via partial_success rather than failing the request.
+func (s *metricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetricsServiceRequest) (*colmetricspb.ExportMetricsServiceResponse, error) {
+	dsn, ctx := dsnCtx(ctx)
+	svcs, err := controller.ResolveMetricServices(dsn)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	md := &metricsv1.MetricsData{ResourceMetrics: req.ResourceMetrics}
+	stats := &unmarshal.OTLPMetricsStats{}
+	parser := controller.PreDecoded(controller.Parser(unmarshal.OTLPMetricsFromData(md, stats)))
+	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
+		return nil, ingestFailure("metrics", err)
+	}
+	resp := &colmetricspb.ExportMetricsServiceResponse{}
+	if rejected := stats.RejectedDataPoints(); rejected > 0 {
+		resp.PartialSuccess = &colmetricspb.ExportMetricsPartialSuccess{
+			RejectedDataPoints: rejected,
+			ErrorMessage:       stats.ErrorMessage(),
+		}
+	}
+	return resp, nil
+}
+
+// registerMetrics wires the metrics handler onto a gRPC server.
+func registerMetrics(g *grpc.Server) {
+	colmetricspb.RegisterMetricsServiceServer(g, &metricsServer{})
+}

--- a/writer/grpc/metrics_test.go
+++ b/writer/grpc/metrics_test.go
@@ -1,0 +1,128 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/metrico/qryn/v5/writer/controller"
+	"github.com/metrico/qryn/v5/writer/service"
+	"github.com/metrico/qryn/v5/writer/utils/helpers"
+	"github.com/metrico/qryn/v5/writer/utils/promise"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestMetricsExport_NoTenantErrors asserts that with no service registry
+// configured, Export returns an InvalidArgument status rather than panicking.
+func TestMetricsExport_NoTenantErrors(t *testing.T) {
+	saved := controller.Registry
+	controller.Registry = nil
+	defer func() { controller.Registry = saved }()
+
+	srv := &metricsServer{}
+	_, err := srv.Export(context.Background(), &colmetricspb.ExportMetricsServiceRequest{})
+	if err == nil {
+		t.Fatal("expected error without registry")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", status.Code(err))
+	}
+}
+
+// failingSvc is an insert service whose every push fails with a transient
+// backend error, standing in for a ClickHouse outage.
+type failingSvc struct{ err error }
+
+func (f *failingSvc) Request(helpers.SizeGetter, int) *promise.Promise[uint32] {
+	return promise.Fulfilled[uint32](f.err, 0)
+}
+func (f *failingSvc) Run()                     {}
+func (f *failingSvc) Stop()                    {}
+func (f *failingSvc) Ping() (time.Time, error) { return time.Time{}, nil }
+func (f *failingSvc) GetState(int) int         { return service.INSERT_STATE_IDLE }
+func (f *failingSvc) GetNodeName() string      { return "n" }
+func (f *failingSvc) Init()                    {}
+func (f *failingSvc) PlanFlush()               {}
+
+// failingRegistry hands out the same failing insert service for every signal.
+type failingRegistry struct{ svc *failingSvc }
+
+func (r *failingRegistry) GetTimeSeriesService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) GetSamplesService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) GetMetricsService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) GetSpansService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) GetSpansSeriesService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) GetProfileInsertService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) GetPatternInsertService(string) (service.IInsertServiceV2, error) {
+	return r.svc, nil
+}
+func (r *failingRegistry) Run()  {}
+func (r *failingRegistry) Stop() {}
+
+func sampleMetricsRequest() *colmetricspb.ExportMetricsServiceRequest {
+	return &colmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricsv1.ResourceMetrics{{
+			Resource: &resourcev1.Resource{Attributes: []*commonv1.KeyValue{{
+				Key:   "service.name",
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "svc"}},
+			}}},
+			ScopeMetrics: []*metricsv1.ScopeMetrics{{Metrics: []*metricsv1.Metric{{
+				Name: "g",
+				Data: &metricsv1.Metric_Gauge{Gauge: &metricsv1.Gauge{
+					DataPoints: []*metricsv1.NumberDataPoint{{
+						TimeUnixNano: 1_700_000_000_000_000_000,
+						Value:        &metricsv1.NumberDataPoint_AsInt{AsInt: 1},
+					}},
+				}},
+			}}}},
+		}},
+	}
+}
+
+// TestMetricsExport_TransientFailureRetryableAndOpaque asserts two properties
+// of the status returned for an ingest-path failure. First, the code must be
+// retryable per the OTLP spec: codes.Internal is in the client's
+// MUST-NOT-retry set, so returning it would turn a recoverable ClickHouse
+// outage into permanent data loss at the collector. Second, the message must
+// not echo the backend error, which carries the ClickHouse DSN — node name,
+// connection string, and any credentials embedded in it.
+func TestMetricsExport_TransientFailureRetryableAndOpaque(t *testing.T) {
+	installFPCache(t, "n")
+	installConfig(t)
+	old := controller.Registry
+	controller.Registry = &failingRegistry{svc: &failingSvc{
+		err: errors.New("n-clickhouse://user:secret@ch-1.internal:9000/gigapipe?secure=false: dial: connection refused"),
+	}}
+	t.Cleanup(func() { controller.Registry = old })
+
+	_, err := (&metricsServer{}).Export(context.Background(), sampleMetricsRequest())
+	if err == nil {
+		t.Fatal("expected an error when every insert fails")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unavailable {
+		t.Errorf("transient ingest failure returned code %s, want %s", st.Code(), codes.Unavailable)
+	}
+	if strings.Contains(st.Message(), "clickhouse://") || strings.Contains(st.Message(), "secret") {
+		t.Errorf("gRPC status leaks backend connection details to the client: %q", st.Message())
+	}
+}

--- a/writer/grpc/mux.go
+++ b/writer/grpc/mux.go
@@ -1,0 +1,48 @@
+package grpc
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Mux returns an http.Handler that routes gRPC requests to a gRPC server
+// built by NewServer, and every other request to next. Dispatch is by
+// transport shape, not by path: HTTP/2 requests whose Content-Type starts
+// with "application/grpc" (e.g. "application/grpc", "application/grpc+proto")
+// go to the gRPC server; everything else goes to next unchanged. grpc-web is
+// NOT supported: grpc-go's ServeHTTP does not speak grpc-web framing, and
+// grpc-web clients normally use HTTP/1.1, which the ProtoMajor check sends to
+// next anyway.
+//
+// gRPC requests bypass the mux middleware chain entirely. Of the four HTTP
+// middlewares that would otherwise apply, two are ported as gRPC unary
+// interceptors inside NewServer (logging, basic auth via opts); CORS and
+// response gzip are deliberately not ported — see NewServer/auth.go/logging.go
+// and the package docs for why.
+//
+// One limitation is accepted here, not fixed: grpc-go's Server.GracefulStop
+// does not drain RPCs served through ServeHTTP (as used here) — it only
+// affects connections accepted via Server.Serve. When gRPC is multiplexed
+// onto the shared http.Server like this, draining in-flight gRPC requests is
+// the responsibility of http.Server.Shutdown alone.
+func Mux(next http.Handler, opts Options) http.Handler {
+	g := NewServer(opts)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			g.ServeHTTP(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Protocols returns the http.Server protocol set required to accept gRPC on
+// a cleartext port: HTTP/1 plus unencrypted (prior-knowledge) HTTP/2. This is
+// what lets a single http.Server serve both regular HTTP/1.1 traffic and
+// gRPC's HTTP/2 traffic on one address without TLS.
+func Protocols() *http.Protocols {
+	p := &http.Protocols{}
+	p.SetHTTP1(true)
+	p.SetUnencryptedHTTP2(true)
+	return p
+}

--- a/writer/grpc/profiles.go
+++ b/writer/grpc/profiles.go
@@ -25,11 +25,9 @@ func (s *profilesServer) Export(ctx context.Context, req pprofileotlp.ExportRequ
 	if err != nil {
 		return pprofileotlp.NewExportResponse(), status.Error(codes.InvalidArgument, err.Error())
 	}
-	// Body is nil: the *FromData parsers are built with withPreParsedBody,
-	// so the payload is already supplied and no reader is ever read.
-	parser := controller.Bind(controller.Parser(unmarshal.OTLPProfilesFromProfiles(req.Profiles())), nil)
+	parser := controller.PreDecoded(controller.Parser(unmarshal.OTLPProfilesFromProfiles(req.Profiles())))
 	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
-		return pprofileotlp.NewExportResponse(), status.Error(codes.Internal, err.Error())
+		return pprofileotlp.NewExportResponse(), ingestFailure("profiles", err)
 	}
 	return pprofileotlp.NewExportResponse(), nil
 }

--- a/writer/grpc/register.go
+++ b/writer/grpc/register.go
@@ -2,9 +2,10 @@ package grpc
 
 import "google.golang.org/grpc"
 
-// registerServices wires all three OTLP signal handlers onto the gRPC server.
+// registerServices wires all four OTLP signal handlers onto the gRPC server.
 func registerServices(s *grpc.Server) {
 	registerTrace(s)
 	registerLogs(s)
+	registerMetrics(s)
 	registerProfiles(s)
 }

--- a/writer/grpc/server.go
+++ b/writer/grpc/server.go
@@ -2,13 +2,40 @@ package grpc
 
 import (
 	"context"
-	"net"
 
+	"github.com/metrico/qryn/v5/writer/controller"
 	"github.com/metrico/qryn/v5/writer/utils/logger"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+
+	// Register the gzip compressor codec. grpc-go compressors are wired up
+	// purely via package init() side effects, and nothing else in this
+	// binary's dependency graph pulls this package in. The OpenTelemetry
+	// Collector's OTLP gRPC exporter compresses with gzip BY DEFAULT
+	// (otlpexporter's factory sets clientCfg.Compression =
+	// configcompression.TypeGzip), so without this import every export from
+	// a default-configured collector fails with:
+	//   Unimplemented: grpc: Decompressor is not installed for
+	//   grpc-encoding "gzip"
+	// This import looks unused to static analysis and to a casual reader —
+	// do NOT remove it as part of an "unused import" cleanup. Removing it
+	// silently breaks all default collector exports; that is exactly why
+	// there is a regression test (TestGRPCTraces_EndToEnd_Gzip) guarding it.
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
 )
+
+// ingestFailure maps an ingest-path error to the gRPC status surfaced to the
+// client. The OTLP spec requires codes.Unavailable for transient server
+// failures — it is in the client's retry set, while codes.Internal is in the
+// MUST-NOT-retry set and would turn a recoverable backend outage into
+// permanent data loss at the collector. The detailed error is only logged: it
+// can carry backend DSNs, node names and credentials that must not leave the
+// process. The generic message mirrors the OTLP/HTTP handlers' 503 body.
+func ingestFailure(signal string, err error) error {
+	logger.Error("OTLP gRPC "+signal+" ingest failed: ", err)
+	return status.Error(codes.Unavailable, "temporary ingestion failure")
+}
 
 // recoveryInterceptor recovers from panics in unary handlers, logs them, and
 // returns codes.Internal — mirroring the HTTP ErrorHandler so a panicking
@@ -24,31 +51,65 @@ func recoveryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInf
 	return handler(ctx, req)
 }
 
-// NewServer builds a gRPC server with all three OTLP signal handlers
-// (traces, logs, profiles) registered.
-func NewServer() *grpc.Server {
-	s := grpc.NewServer(grpc.ChainUnaryInterceptor(recoveryInterceptor))
-	registerServices(s)
-	return s
-}
-
-// Start listens on addr and serves in a goroutine, returning the server for
-// shutdown. An empty addr disables the receiver and returns (nil, nil). A
-// listen error is returned to the caller.
-func Start(addr string) (*grpc.Server, error) {
-	if addr == "" {
-		return nil, nil
-	}
-	lis, err := net.Listen("tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-	s := NewServer()
-	go func() {
-		logger.Info("OTLP gRPC receiver listening on", addr)
-		if err := s.Serve(lis); err != nil {
-			logger.Error("OTLP gRPC serve error:", err)
+// streamRecoveryInterceptor is recoveryInterceptor's counterpart for
+// streaming RPCs: a panic anywhere in the stream handler becomes
+// codes.Internal instead of killing the receiver.
+func streamRecoveryInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("OTLP gRPC handler panic:", r)
+			err = status.Errorf(codes.Internal, "panic: %v", r)
 		}
 	}()
-	return s, nil
+	return handler(srv, ss)
+}
+
+// Options carries the gRPC server's runtime configuration. It is an explicit
+// struct rather than positional arguments so future additions (e.g. TLS)
+// don't churn NewServer's and Mux's signatures again.
+type Options struct {
+	// BasicAuthUser and BasicAuthPass gate the auth interceptor (see auth.go).
+	// Auth is enabled only when BOTH are non-empty, mirroring the gate on
+	// BasicAuthMiddleware at cmd/gigapipe/main.go's start().
+	BasicAuthUser string
+	BasicAuthPass string
+}
+
+// NewServer builds a gRPC server with all three OTLP signal handlers
+// (traces, logs, profiles) registered.
+//
+// Interceptor chain, outermost first:
+//
+//	loggingInterceptor, recoveryInterceptor, authInterceptor (auth optional)
+//
+// Order rationale:
+//   - logging outermost, so a request rejected by auth still appears in the
+//     access log;
+//   - recovery inside logging but outside auth, so a panic anywhere below it
+//     — auth included — becomes codes.Internal instead of killing the
+//     process, and is still logged by the outer logging interceptor;
+//   - auth innermost, so no business handler ever runs for an unauthenticated
+//     request.
+//
+// The stream chain mirrors the unary one interceptor for interceptor, in the
+// same order. Unary interceptors never fire for streaming RPCs, so without
+// the mirror any streaming method a service registers would skip logging,
+// recovery, and — critically — auth. Keep the two chains in lockstep.
+func NewServer(opts Options) *grpc.Server {
+	unary := []grpc.UnaryServerInterceptor{loggingInterceptor, recoveryInterceptor}
+	stream := []grpc.StreamServerInterceptor{streamLoggingInterceptor, streamRecoveryInterceptor}
+	if opts.BasicAuthUser != "" && opts.BasicAuthPass != "" {
+		unary = append(unary, newAuthInterceptor(opts.BasicAuthUser, opts.BasicAuthPass))
+		stream = append(stream, newAuthStreamInterceptor(opts.BasicAuthUser, opts.BasicAuthPass))
+	}
+	// The receive limit is the shared OTLP payload bound, so a batch accepted
+	// over OTLP/HTTP is never rejected over OTLP/gRPC (grpc-go's own default
+	// is only 4 MiB).
+	s := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unary...),
+		grpc.ChainStreamInterceptor(stream...),
+		grpc.MaxRecvMsgSize(controller.OTLPMaxMessageSize()),
+	)
+	registerServices(s)
+	return s
 }

--- a/writer/grpc/server_test.go
+++ b/writer/grpc/server_test.go
@@ -4,9 +4,21 @@ import (
 	"context"
 	"testing"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// fakeServerStream carries a fixed context into stream interceptors under
+// test; every other ServerStream method panics via the embedded nil
+// interface, proving the interceptors only touch Context().
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f fakeServerStream) Context() context.Context { return f.ctx }
 
 // TestRecoveryInterceptor_PanicBecomesInternal asserts a panicking handler is
 // recovered and surfaced as codes.Internal, mirroring the HTTP ErrorHandler.
@@ -43,5 +55,73 @@ func TestRecoveryInterceptor_PassThrough(t *testing.T) {
 	}
 	if resp != want {
 		t.Fatalf("expected %q, got %v", want, resp)
+	}
+}
+
+// TestStreamRecoveryInterceptor_PanicBecomesInternal is the streaming
+// counterpart of TestRecoveryInterceptor_PanicBecomesInternal.
+func TestStreamRecoveryInterceptor_PanicBecomesInternal(t *testing.T) {
+	err := streamRecoveryInterceptor(
+		nil, fakeServerStream{ctx: context.Background()}, nil,
+		func(srv any, ss grpc.ServerStream) error {
+			panic("boom")
+		},
+	)
+	if got := status.Code(err); got != codes.Internal {
+		t.Fatalf("expected codes.Internal, got %v (err=%v)", got, err)
+	}
+}
+
+// TestStreamRecoveryInterceptor_PassThrough confirms a non-panicking stream
+// handler's error flows through unchanged.
+func TestStreamRecoveryInterceptor_PassThrough(t *testing.T) {
+	want := status.Error(codes.NotFound, "sentinel")
+	err := streamRecoveryInterceptor(
+		nil, fakeServerStream{ctx: context.Background()}, nil,
+		func(srv any, ss grpc.ServerStream) error {
+			return want
+		},
+	)
+	if err != want {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// TestStreamAuthInterceptor asserts the stream chain enforces the same
+// credential checks as the unary one: a streaming RPC must never bypass
+// auth. The handler-called flag proves rejection happens before any stream
+// handler runs.
+func TestStreamAuthInterceptor(t *testing.T) {
+	interceptor := newAuthStreamInterceptor("user", "pass")
+	for _, c := range []struct {
+		name     string
+		md       metadata.MD
+		wantCode codes.Code
+	}{
+		{"NoMetadata", nil, codes.Unauthenticated},
+		{"WrongPassword", metadata.Pairs("authorization", basicAuthHeader("user", "wrong")), codes.Unauthenticated},
+		{"MalformedHeader", metadata.Pairs("authorization", "Basic not-base64!!!"), codes.Unauthenticated},
+		{"CorrectCredentials", metadata.Pairs("authorization", basicAuthHeader("user", "pass")), codes.OK},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			if c.md != nil {
+				ctx = metadata.NewIncomingContext(ctx, c.md)
+			}
+			handlerRan := false
+			err := interceptor(
+				nil, fakeServerStream{ctx: ctx}, nil,
+				func(srv any, ss grpc.ServerStream) error {
+					handlerRan = true
+					return nil
+				},
+			)
+			if got := status.Code(err); got != c.wantCode {
+				t.Fatalf("expected %v, got %v (err=%v)", c.wantCode, got, err)
+			}
+			if wantRan := c.wantCode == codes.OK; handlerRan != wantRan {
+				t.Fatalf("handlerRan=%v, want %v", handlerRan, wantRan)
+			}
+		})
 	}
 }

--- a/writer/grpc/trace.go
+++ b/writer/grpc/trace.go
@@ -27,11 +27,9 @@ func (s *traceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	td := &tracev1.TracesData{ResourceSpans: req.ResourceSpans}
-	// Body is nil: the *FromData parsers are built with withPreParsedBody,
-	// so the payload is already supplied and no reader is ever read.
-	parser := controller.Bind(controller.Parser(unmarshal.OTLPTracesFromData(td)), nil)
+	parser := controller.PreDecoded(controller.Parser(unmarshal.OTLPTracesFromData(td)))
 	if err := controller.IngestParsed(ctx, parser, svcs); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ingestFailure("traces", err)
 	}
 	return &coltracepb.ExportTraceServiceResponse{}, nil
 }

--- a/writer/utils/unmarshal/otlplogs.go
+++ b/writer/utils/unmarshal/otlplogs.go
@@ -100,10 +100,13 @@ func (e *otlpLogDec) writeAttrValue(key string, value *otlpcommon.AnyValue, pref
 	(*res)[prefix+SanitizeKey(key)] = SanitizeValue(value)
 }
 
+// sanitizeKeyRe matches every character that is not valid in a Prometheus
+// label name.
+var sanitizeKeyRe = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
 func SanitizeKey(key string) string {
 	// Replace characters that are not a-z, A-Z, 0-9, or _ with _
-	re := regexp.MustCompile(`[^a-zA-Z0-9_]`)
-	sanitized := re.ReplaceAllString(key, "_")
+	sanitized := sanitizeKeyRe.ReplaceAllString(key, "_")
 
 	// Prefix with _ if the first character is not a-z or A-Z
 	if len(sanitized) == 0 || (sanitized[0] >= '0' && sanitized[0] <= '9') {


### PR DESCRIPTION
Top of the 3-PR stack — **base is `feat/otlp-http-metrics` (#941)**; retarget as the stack merges. Squashed final state:

- All four OTLP collector services are served over gRPC on the writer's existing HTTP port: `writergrpc.Mux` dispatches HTTP/2 requests whose Content-Type starts with `application/grpc` to a grpc-go server and everything else to the regular router, with `http.Protocols` enabling cleartext (prior-knowledge) HTTP/2. Reader-only nodes skip the wrapper.
- Handlers decode nothing themselves: grpc-go decodes the request, and `OTLP{Traces,Logs,Metrics}FromData` / `OTLPProfilesFromProfiles` feed the already-decoded objects to the shared ingest core through `withPreParsedBody`. Tenant metadata (DSN, TTL, async mode) is resolved from gRPC metadata the same way the HTTP middlewares resolve headers.
- Logging, panic recovery, and basic auth are ported as unary **and** stream interceptor chains (streaming RPCs never hit unary interceptors); ingest failures return `codes.Unavailable` — retryable per the OTLP spec, unlike `codes.Internal` — with an opaque message so backend DSNs never reach clients.
- The receive limit is the shared OTLP payload bound (`system_settings.otlp_max_message_size`), so a batch accepted over OTLP/HTTP is never rejected over gRPC; grpc-go's own default is 4 MiB.
- Because gRPC rides the shared `http.Server`, `http.Server.Shutdown` is what drains in-flight RPCs; `grpc.Server.GracefulStop` does not apply to ServeHTTP-served connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)