### PR TITLE
fix(promql): emit stale markers to stop lookback stacking (#931)

### DIFF
--- a/reader/model/prometheus.go
+++ b/reader/model/prometheus.go
@@ -1,12 +1,15 @@
 package model
 
 import (
+	"math"
+	"sync"
+
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
-	"sync"
 )
 
 type Labels []labels.Label
@@ -80,7 +83,8 @@ func (s *SeriesV2) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
 			samples: s.Samples,
 			idx:     -1,
 		},
-		stepMs: s.StepMs,
+		stepMs:  s.StepMs,
+		staleAt: -1,
 	}
 }
 
@@ -150,79 +154,118 @@ func (s *seriesIt) Err() error {
 	return nil
 }
 
+// prolongSeriesIt terminates a run of samples with a Prometheus stale marker at
+// the lookback boundary instead of forward-filling the last value on the step
+// grid for 5 minutes.
+//
+// For an instant vector selector (or rate/deriv/delta) in a range query, the
+// Prometheus engine carries the last real sample forward for its LookbackDelta
+// (5m by default). gigapipe used to *also* forward-fill for 5m inside this
+// iterator, so a sample at T could stay visible until ~T+10m (issue #931).
+//
+// This iterator instead yields the real samples untouched and, when a run ends,
+// emits a single stale marker at lastSample + LookbackDeltaMs. The engine
+// carries the last value forward across its own lookback window and the marker
+// terminates it exactly at the boundary, so total visibility is ~5m - matching
+// upstream Prometheus and never stacking to ~10m.
+//
+// A run ends when the next real sample is more than LookbackDeltaMs away, or
+// when there are no more samples. Gaps up to LookbackDeltaMs are left unmarked
+// and bridged by the engine's lookback, so genuinely *sparse* series behave the
+// same as in upstream Prometheus. If a sparse series that was marked stale
+// later resumes (its next sample lands more than LookbackDeltaMs after the
+// previous one), the marker sits in the gap between the two real samples: the
+// old value stops at the boundary and the new value simply starts a fresh run -
+// exactly what Prometheus does when a series reappears after going stale.
 type prolongSeriesIt struct {
 	s           *seriesIt
-	prev        *Sample
-	next        *Sample
 	stepMs      int64
 	timestampMs int64
-	m           sync.Mutex
+	value       float64
+	// staleAt, when set (>= 0), is the timestamp at which the next Next() must
+	// emit a stale marker before advancing to the following real sample.
+	staleAt int64
+	m       sync.Mutex
 }
 
 func (p *prolongSeriesIt) Err() error {
 	return p.s.Err()
 }
 
+// StaleMarkerValue is the Prometheus stale marker encoded as a float64. The
+// PromQL engine detects it via value.IsStaleNaN and stops carrying a series
+// forward at that timestamp, regardless of its LookbackDelta. It is the single
+// source of truth for the marker across the reader.
+var StaleMarkerValue = math.Float64frombits(value.StaleNaN)
+
+// LookbackDeltaMs mirrors the Prometheus engine's default lookback delta (5m,
+// the value NewPromEngine relies on). A sample stays valid for at most this
+// long, so a gap larger than this is where a series is considered to have
+// stopped and a stale marker is emitted.
+const LookbackDeltaMs = int64(5 * 60 * 1000)
+
+// scheduleStaleAfterCurrent decides whether the sample currently under p.s (at
+// p.s.idx) ends a run and, if so, schedules a stale marker.
+//
+// A run ends when the following real sample is more than LookbackDeltaMs away
+// (a gap the engine's lookback would not bridge) or when there is no following
+// sample. In that case the marker is placed at cur + LookbackDeltaMs: the last
+// real value stays visible for the full lookback window - exactly as upstream
+// Prometheus carries a sample forward - and the marker then terminates it at
+// the lookback boundary, so the engine cannot extend it any further. Gaps up to
+// LookbackDeltaMs are left unmarked and bridged by the engine's own lookback,
+// matching Prometheus behavior for sparse series.
+//
+// Because a marker is only scheduled when the next sample is more than
+// LookbackDeltaMs away, cur + LookbackDeltaMs is always strictly before that
+// next sample, so markers never collide with or reorder real samples.
+func (p *prolongSeriesIt) scheduleStaleAfterCurrent() {
+	cur := p.s.samples[p.s.idx].TimestampMs
+	nextIdx := p.s.idx + 1
+	if nextIdx < len(p.s.samples) && p.s.samples[nextIdx].TimestampMs <= cur+LookbackDeltaMs {
+		// The next sample is within the lookback window; the engine bridges the
+		// gap on its own. No marker.
+		return
+	}
+	p.staleAt = cur + LookbackDeltaMs
+}
+
 func (p *prolongSeriesIt) Seek(t int64) chunkenc.ValueType {
 	p.m.Lock()
 	defer p.m.Unlock()
-	p.prev = nil
-	p.next = nil
+	p.staleAt = -1
 	if p.s.Seek(t) == chunkenc.ValNone {
 		return chunkenc.ValNone
 	}
-	p.prev = &p.s.samples[p.s.idx]
-	p.timestampMs = p.prev.TimestampMs
-	if p.s.Next() != chunkenc.ValNone {
-		p.next = &p.s.samples[p.s.idx]
-	}
+	p.timestampMs = p.s.samples[p.s.idx].TimestampMs
+	p.value = p.s.samples[p.s.idx].Value
+	p.scheduleStaleAfterCurrent()
 	return chunkenc.ValFloat
 }
 
 func (p *prolongSeriesIt) Next() chunkenc.ValueType {
 	p.m.Lock()
 	defer p.m.Unlock()
-	if p.prev == nil {
-		if p.s.Next() == chunkenc.ValNone {
-			return chunkenc.ValNone
-		}
-		p.prev = &p.s.samples[p.s.idx]
-		if p.s.Next() != chunkenc.ValNone {
-			p.next = &p.s.samples[p.s.idx]
-		}
-		p.timestampMs = p.prev.TimestampMs
+
+	// A stale marker was scheduled after the previous real sample: emit it now.
+	if p.staleAt >= 0 {
+		p.timestampMs = p.staleAt
+		p.value = StaleMarkerValue
+		p.staleAt = -1
 		return chunkenc.ValFloat
 	}
 
-	if p.next == nil {
-		if p.timestampMs > p.prev.TimestampMs+300000 {
-			return chunkenc.ValNone
-		}
-		p.timestampMs += p.stepMs
-		return chunkenc.ValFloat
+	if p.s.Next() == chunkenc.ValNone {
+		return chunkenc.ValNone
 	}
-
-	done := false
-	for p.timestampMs > p.prev.TimestampMs+300000 || (p.next != nil && p.timestampMs >= p.next.TimestampMs) {
-		p.prev = p.next
-		p.next = nil
-		if p.s.Next() != chunkenc.ValNone {
-			p.next = &p.s.samples[p.s.idx]
-		}
-		p.timestampMs = p.prev.TimestampMs
-		done = true
-	}
-
-	if done {
-		return chunkenc.ValFloat
-	}
-
-	p.timestampMs += p.stepMs
+	p.timestampMs = p.s.samples[p.s.idx].TimestampMs
+	p.value = p.s.samples[p.s.idx].Value
+	p.scheduleStaleAfterCurrent()
 	return chunkenc.ValFloat
 }
 
 func (p *prolongSeriesIt) At() (int64, float64) {
-	return p.timestampMs, p.prev.Value
+	return p.timestampMs, p.value
 }
 
 // AtHistogram returns the current timestamp/value pair if the value is a

--- a/reader/model/prometheus_test.go
+++ b/reader/model/prometheus_test.go
@@ -1,0 +1,293 @@
+package model
+
+import (
+	"math"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// drain walks a chunkenc.Iterator from the start via Next()/At() and collects
+// every (timestamp, value) pair it yields until ValNone. It is the same access
+// pattern the Prometheus engine uses when it has no specific Seek target.
+func drain(it chunkenc.Iterator) []Sample {
+	var out []Sample
+	for it.Next() != chunkenc.ValNone {
+		ts, v := it.At()
+		out = append(out, Sample{TimestampMs: ts, Value: v})
+	}
+	return out
+}
+
+// newProlongIt builds the prolonging iterator the way SeriesV2.Iterator does
+// for a series with Prolong=true.
+func newProlongIt(samples []Sample, stepMs int64) chunkenc.Iterator {
+	s := &SeriesV2{Samples: samples, Prolong: true, StepMs: stepMs}
+	return s.Iterator(nil)
+}
+
+// TestProlongSeriesIt_EmitsStaleMarkerAtLookbackBoundary is the core desired
+// behavior for issue #931. A prolonging iterator (instant selector / rate) must
+// yield the real samples untouched and terminate the series with a single
+// Prometheus stale marker at lastSample + LookbackDeltaMs, instead of forward-
+// filling the value on the step grid for 5 minutes.
+//
+// Placing the marker at the lookback boundary lets the engine carry the last
+// value forward across its own 5m lookback and then stops it exactly there, so
+// total visibility is ~5m (matching Prometheus) rather than the ~10m that the
+// old fill + engine-lookback stacking produced.
+func TestProlongSeriesIt_EmitsStaleMarkerAtLookbackBoundary(t *testing.T) {
+	const step = int64(15000)
+	samples := []Sample{
+		{TimestampMs: 100000, Value: 1},
+		{TimestampMs: 115000, Value: 2},
+		{TimestampMs: 130000, Value: 3},
+	}
+
+	got := drain(newProlongIt(samples, step))
+
+	// Expect the three real samples, followed by exactly one stale marker at the
+	// lookback boundary past the last real sample, then nothing.
+	if len(got) != len(samples)+1 {
+		t.Fatalf("expected %d samples (3 real + 1 stale marker), got %d: %+v",
+			len(samples)+1, len(got), got)
+	}
+	for i, want := range samples {
+		if got[i].TimestampMs != want.TimestampMs || got[i].Value != want.Value {
+			t.Fatalf("sample %d: expected %+v, got %+v", i, want, got[i])
+		}
+	}
+	marker := got[len(got)-1]
+	wantTs := samples[len(samples)-1].TimestampMs + LookbackDeltaMs
+	if marker.TimestampMs != wantTs {
+		t.Errorf("stale marker timestamp: expected %d (last real + lookback), got %d",
+			wantTs, marker.TimestampMs)
+	}
+	if !value.IsStaleNaN(marker.Value) {
+		t.Errorf("expected final sample to be a stale marker (value.IsStaleNaN), got value=%v", marker.Value)
+	}
+}
+
+// TestProlongSeriesIt_NoStepGridForwardFill guards against the old behavior: the
+// iterator used to forward-fill the last value on the step grid for up to 5
+// minutes (300000ms), producing ~20 filled samples at a 15s step. After the fix
+// it must emit only the real sample plus a single stale marker at the lookback
+// boundary, never a long tail of carried-forward values.
+func TestProlongSeriesIt_NoStepGridForwardFill(t *testing.T) {
+	const step = int64(15000)
+	samples := []Sample{
+		{TimestampMs: 100000, Value: 42},
+	}
+
+	got := drain(newProlongIt(samples, step))
+
+	if len(got) != 2 {
+		t.Fatalf("expected exactly 2 emitted samples (1 real + 1 stale marker), got %d: %+v\n"+
+			"a count near 21 means step-grid forward-fill is still active", len(got), got)
+	}
+	if got[0].TimestampMs != 100000 || got[0].Value != 42 {
+		t.Fatalf("first sample should be the real one, got %+v", got[0])
+	}
+	if got[1].TimestampMs != 100000+LookbackDeltaMs || !value.IsStaleNaN(got[1].Value) {
+		t.Fatalf("second sample should be a stale marker at the lookback boundary, got %+v", got[1])
+	}
+}
+
+// TestProlongSeriesIt_SparseGapBridged verifies that a gap SMALLER than the
+// lookback window is NOT marked stale: the engine bridges it via its own
+// lookback, exactly as upstream Prometheus does for sparse series. Only a single
+// trailing marker (at the lookback boundary past the last sample) is emitted.
+func TestProlongSeriesIt_SparseGapBridged(t *testing.T) {
+	const step = int64(15000)
+	// Samples 2 minutes apart: a gap far larger than one step but well within
+	// the 5m lookback window, so it must be bridged (no interior marker).
+	samples := []Sample{
+		{TimestampMs: 0, Value: 1},
+		{TimestampMs: 120000, Value: 2},
+		{TimestampMs: 240000, Value: 3},
+	}
+
+	got := drain(newProlongIt(samples, step))
+
+	markers := 0
+	for _, s := range got {
+		if value.IsStaleNaN(s.Value) {
+			markers++
+		}
+	}
+	if markers != 1 {
+		t.Fatalf("sparse gaps within lookback must be bridged; expected exactly 1 trailing "+
+			"marker, got %d: %+v", markers, got)
+	}
+	last := got[len(got)-1]
+	if !value.IsStaleNaN(last.Value) || last.TimestampMs != 240000+LookbackDeltaMs {
+		t.Fatalf("expected the single marker at the lookback boundary past the last sample, got %+v", last)
+	}
+}
+
+// TestProlongSeriesIt_StaleMarkerBetweenGaps verifies that when there is a real
+// gap LARGER than the lookback window between two clusters of samples, a stale
+// marker terminates the first cluster (at the lookback boundary past its last
+// sample) before the next real sample resumes.
+func TestProlongSeriesIt_StaleMarkerBetweenGaps(t *testing.T) {
+	const step = int64(15000)
+	// Gap between 130000 and 700000 is 570000ms > LookbackDeltaMs (300000ms).
+	samples := []Sample{
+		{TimestampMs: 100000, Value: 1},
+		{TimestampMs: 115000, Value: 2},
+		{TimestampMs: 130000, Value: 3},
+		{TimestampMs: 700000, Value: 9},
+	}
+
+	got := drain(newProlongIt(samples, step))
+
+	var markerIdx []int
+	for i, s := range got {
+		if value.IsStaleNaN(s.Value) {
+			markerIdx = append(markerIdx, i)
+		}
+	}
+	// One marker terminating the first cluster (130000 + lookback) and one at
+	// the end (700000 + lookback).
+	if len(markerIdx) != 2 {
+		t.Fatalf("expected 2 stale markers (one per cluster end), got %d: %+v", len(markerIdx), got)
+	}
+	if got[markerIdx[0]].TimestampMs != 130000+LookbackDeltaMs {
+		t.Errorf("first stale marker: expected ts %d, got %d", 130000+LookbackDeltaMs, got[markerIdx[0]].TimestampMs)
+	}
+	if got[markerIdx[1]].TimestampMs != 700000+LookbackDeltaMs {
+		t.Errorf("second stale marker: expected ts %d, got %d", 700000+LookbackDeltaMs, got[markerIdx[1]].TimestampMs)
+	}
+	// The interior marker must fall strictly before the resuming real sample so
+	// ordering is preserved.
+	if got[markerIdx[0]].TimestampMs >= 700000 {
+		t.Errorf("interior marker at %d must precede the resuming sample at 700000",
+			got[markerIdx[0]].TimestampMs)
+	}
+}
+
+// TestProlongSeriesIt_ComesBackAfterStale is the "series reappears" case: a
+// series goes stale (a >lookback gap produces a marker) and then a new sample
+// arrives. The marker sits in the gap between the two real samples; the old run
+// is terminated at its lookback boundary and the new sample starts a fresh run
+// with its own trailing marker. This mirrors Prometheus: after a series is
+// marked stale, a later sample simply begins reporting again.
+func TestProlongSeriesIt_ComesBackAfterStale(t *testing.T) {
+	const step = int64(15000)
+	// Sample at T=0, then a >lookback gap, then it "comes back" at T=600000.
+	samples := []Sample{
+		{TimestampMs: 0, Value: 1},
+		{TimestampMs: 600000, Value: 2}, // 600000 > 0 + LookbackDeltaMs(300000): a stale gap
+	}
+
+	got := drain(newProlongIt(samples, step))
+
+	// Expected sequence: real(0,1), marker(300000), real(600000,2), marker(900000).
+	if len(got) != 4 {
+		t.Fatalf("expected real, marker, real, marker (4 entries), got %d: %+v", len(got), got)
+	}
+	if got[0].TimestampMs != 0 || got[0].Value != 1 {
+		t.Fatalf("entry 0 should be the first real sample, got %+v", got[0])
+	}
+	if got[1].TimestampMs != 0+LookbackDeltaMs || !value.IsStaleNaN(got[1].Value) {
+		t.Fatalf("entry 1 should be a stale marker terminating the first run at the lookback boundary, got %+v", got[1])
+	}
+	if got[2].TimestampMs != 600000 || got[2].Value != 2 {
+		t.Fatalf("entry 2 should be the reappearing real sample, got %+v", got[2])
+	}
+	if got[3].TimestampMs != 600000+LookbackDeltaMs || !value.IsStaleNaN(got[3].Value) {
+		t.Fatalf("entry 3 should be the trailing marker for the new run, got %+v", got[3])
+	}
+	// Sanity: the first marker must not overlap the reappearing sample.
+	if got[1].TimestampMs >= got[2].TimestampMs {
+		t.Fatalf("stale marker at %d must precede the reappearing sample at %d",
+			got[1].TimestampMs, got[2].TimestampMs)
+	}
+}
+
+// TestProlongSeriesIt_EmptySeries verifies no marker (and no panic) for an empty
+// series.
+func TestProlongSeriesIt_EmptySeries(t *testing.T) {
+	got := drain(newProlongIt([]Sample{}, 15000))
+	if len(got) != 0 {
+		t.Fatalf("expected no samples for empty series, got %+v", got)
+	}
+}
+
+// sanity: our understanding of the marker encoding matches prometheus.
+func TestStaleNaNRoundTrip(t *testing.T) {
+	v := math.Float64frombits(value.StaleNaN)
+	if !value.IsStaleNaN(v) {
+		t.Fatal("Float64frombits(value.StaleNaN) is not detected as a stale marker")
+	}
+}
+
+// TestProlongSeriesIt_SeekThenNextEmitsMarkerOnce covers the engine's actual
+// access pattern: the PromQL engine wraps series iterators in a memoized
+// iterator that calls Seek() to position, then Next() to read forward. When
+// Seek lands on the last sample of a run, the following Next() must emit the
+// stale marker exactly once (at the lookback boundary), then ValNone.
+func TestProlongSeriesIt_SeekThenNextEmitsMarkerOnce(t *testing.T) {
+	const step = int64(15000)
+	it := newProlongIt([]Sample{{TimestampMs: 600000, Value: 42}}, step)
+
+	// The engine seeks to mint (stepT - lookback), which is <= the sample.
+	if it.Seek(300000) == chunkenc.ValNone {
+		t.Fatal("Seek(300000) should land on the sample at 600000")
+	}
+	if ts, v := it.At(); ts != 600000 || v != 42 {
+		t.Fatalf("after Seek: expected (600000, 42), got (%d, %v)", ts, v)
+	}
+
+	// Next -> stale marker at the lookback boundary.
+	if it.Next() == chunkenc.ValNone {
+		t.Fatal("expected a stale marker after the last real sample")
+	}
+	ts, v := it.At()
+	if ts != 600000+LookbackDeltaMs {
+		t.Errorf("stale marker timestamp: expected %d, got %d", 600000+LookbackDeltaMs, ts)
+	}
+	if !value.IsStaleNaN(v) {
+		t.Errorf("expected a stale marker, got value=%v", v)
+	}
+
+	// Next -> exhausted; the marker is emitted exactly once.
+	if it.Next() != chunkenc.ValNone {
+		t.Fatal("expected ValNone after the stale marker (marker must be emitted only once)")
+	}
+}
+
+// TestProlongSeriesIt_ReSeekResetsStaleMarker guards against a stale marker
+// leaking across a re-Seek. The memoized iterator may Seek backwards/forwards
+// repeatedly; a marker scheduled at one position must not surface after seeking
+// to a different real sample.
+func TestProlongSeriesIt_ReSeekResetsStaleMarker(t *testing.T) {
+	const step = int64(15000)
+	it := newProlongIt([]Sample{
+		{TimestampMs: 100000, Value: 1},
+		{TimestampMs: 115000, Value: 2},
+		{TimestampMs: 130000, Value: 3},
+	}, step)
+
+	// Seek to the last sample: this schedules a trailing stale marker.
+	if it.Seek(130000) == chunkenc.ValNone {
+		t.Fatal("Seek(130000) should land on the last sample")
+	}
+	if ts, _ := it.At(); ts != 130000 {
+		t.Fatalf("expected to land on 130000, got %d", ts)
+	}
+
+	// Re-seek to an interior sample: must return that real sample, not a
+	// leftover stale marker from the previous position.
+	if it.Seek(115000) == chunkenc.ValNone {
+		t.Fatal("re-Seek(115000) should land on the interior sample")
+	}
+	ts, v := it.At()
+	if ts != 115000 || v != 2 {
+		t.Fatalf("re-Seek should return the real sample (115000, 2), got (%d, %v)", ts, v)
+	}
+	if value.IsStaleNaN(v) {
+		t.Fatal("re-Seek returned a leaked stale marker instead of the real sample")
+	}
+}

--- a/reader/router/prometheus_query_range_test.go
+++ b/reader/router/prometheus_query_range_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/metrico/qryn/v5/reader/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 )
@@ -50,5 +52,131 @@ func TestSubqueryWithoutStep(t *testing.T) {
 	res := q.Exec(ctx)
 	if res.Err != nil {
 		t.Fatalf("Exec: %v", res.Err)
+	}
+}
+
+// staleLabelsGetter is a minimal model.ILabelsGetter for a single series.
+type staleLabelsGetter struct {
+	lbls model.Labels
+}
+
+func (g staleLabelsGetter) Get(uint64) model.Labels { return g.lbls }
+func (g staleLabelsGetter) GetNative(uint64) labels.Labels {
+	return labels.New(g.lbls...)
+}
+
+// oneSampleQueryable returns a single prolonging series carrying exactly one
+// real sample at sampleTsMs. Prolong=true routes it through prolongSeriesIt,
+// the iterator under test, which emits the real sample plus one stale marker.
+type oneSampleQueryable struct {
+	sampleTsMs int64
+	value      float64
+	stepMs     int64
+}
+
+func (q oneSampleQueryable) Querier(int64, int64) (storage.Querier, error) {
+	return oneSampleQuerier(q), nil
+}
+
+type oneSampleQuerier oneSampleQueryable
+
+func (q oneSampleQuerier) Select(_ context.Context, _ bool, hints *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	step := q.stepMs
+	if hints.Step != 0 {
+		step = hints.Step
+	}
+	getter := staleLabelsGetter{lbls: model.Labels{{Name: "__name__", Value: "up"}}}
+	ss := &model.SeriesSet{
+		Series: []*model.SeriesV2{{
+			LabelsGetter: getter,
+			Fp:           1,
+			Samples:      []model.Sample{{TimestampMs: q.sampleTsMs, Value: q.value}},
+			Prolong:      true,
+			StepMs:       step,
+		}},
+	}
+	ss.Reset()
+	return ss
+}
+
+func (oneSampleQuerier) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (oneSampleQuerier) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (oneSampleQuerier) Close() error { return nil }
+
+// instantValueAt runs an instant query for `up` at evalT and reports whether the
+// series is present (and its value). This is how the Prometheus engine surfaces
+// carry-forward: at each instant it looks back up to LookbackDelta for the most
+// recent sample, stopping at a stale marker.
+func instantValueAt(t *testing.T, eng *promql.Engine, q storage.Queryable, evalT time.Time) (present bool, val float64) {
+	t.Helper()
+	query, err := eng.NewInstantQuery(context.Background(), q, nil, "up", evalT)
+	if err != nil {
+		t.Fatalf("NewInstantQuery @%s: %v", evalT.UTC(), err)
+	}
+	defer query.Close()
+	res := query.Exec(context.Background())
+	if res.Err != nil {
+		t.Fatalf("Exec @%s: %v", evalT.UTC(), res.Err)
+	}
+	v, err := res.Vector()
+	if err != nil {
+		t.Fatalf("Vector @%s: %v", evalT.UTC(), err)
+	}
+	if len(v) == 0 {
+		return false, 0
+	}
+	return true, v[0].F
+}
+
+// TestEngine_StaleMarkerStopsCarryForward drives the production PromQL engine
+// (NewPromEngine, LookbackDelta=0 => 5m default) over the prolonging iterator to
+// verify the fix for issue #931. A single real sample at T is queried as an
+// instant vector selector at increasing evaluation times. The iterator yields
+// the real sample and a stale marker at T + LookbackDeltaMs (5m), so the value
+// is carried forward for the engine's full 5m lookback and then stops - never
+// the ~10m the old fill + engine-lookback stacking produced.
+//
+// The assertions therefore check BOTH ends: the value is still present within
+// the 5m window (Prometheus-faithful carry-forward) and gone well after it
+// (issue #931 - no stacking). The T+8m check is what fails under the old
+// behavior.
+func TestEngine_StaleMarkerStopsCarryForward(t *testing.T) {
+	const stepMs = int64(15000)
+	sampleT := time.Unix(600, 0) // T = 600s
+	queryable := oneSampleQueryable{
+		sampleTsMs: sampleT.UnixMilli(),
+		value:      42,
+		stepMs:     stepMs,
+	}
+
+	eng := NewPromEngine(50_000_000)
+
+	// At T: the real sample is present.
+	if present, v := instantValueAt(t, eng, queryable, sampleT); !present || v != 42 {
+		t.Fatalf("at T: expected value 42 present, got present=%v val=%v", present, v)
+	}
+
+	// Within the 5m lookback window the value is carried forward, exactly as
+	// upstream Prometheus does - the marker sits at the boundary, not before it.
+	if present, v := instantValueAt(t, eng, queryable, sampleT.Add(4*time.Minute)); !present || v != 42 {
+		t.Errorf("at T+4m: expected value 42 still carried forward within the 5m lookback, "+
+			"got present=%v val=%v", present, v)
+	}
+
+	// The critical assertion for #931: by T+8m the value MUST be gone. Under the
+	// old stacked behavior (5m forward-fill + 5m engine lookback) it would still
+	// be present at ~T+8m.
+	if present, v := instantValueAt(t, eng, queryable, sampleT.Add(8*time.Minute)); present {
+		t.Errorf("at T+8m: value still present (val=%v) - carry-forward is stacking; "+
+			"the stale marker should have stopped it by ~T+5m", v)
+	}
+
+	// And well past any single lookback window it must certainly be gone.
+	if present, v := instantValueAt(t, eng, queryable, sampleT.Add(11*time.Minute)); present {
+		t.Errorf("at T+11m: value still present (val=%v) - series was never terminated", v)
 	}
 }

--- a/reader/service/prom_queryable.go
+++ b/reader/service/prom_queryable.go
@@ -210,6 +210,39 @@ func (c *CLokiQuerier) isProlong(hints *storage.SelectHints, matchers []*labels.
 	return (slices.Contains(rateFunctions, hints.Func) || hints.Func == "") && hints.Step != 0
 }
 
+// appendStaleMarker terminates an accelerated (substitute-backed) series with a
+// Prometheus stale marker one step past the last sample the SQL layer returned.
+//
+// The accelerated path builds a series with Prolong=false directly from
+// ClickHouse rows, and the SQL densifier (planner.fillGaps) already forward-fills
+// each real bucket for 5 minutes (planner.staleness) on the step grid. So the
+// last returned sample already sits at lastReal + 5m: the 5m carry is baked into
+// the rows. The problem in issue #931 is that the engine then applies its OWN 5m
+// LookbackDelta on top of that, stacking to ~10m. Appending a stale marker one
+// step past the last returned sample caps the already-filled data at the 5m
+// boundary so the engine cannot extend it any further.
+//
+// (This differs from the raw iterator path in reader/model, which does not
+// SQL-fill and therefore places its marker at lastReal + LookbackDeltaMs to
+// provide the 5m carry itself. Both paths yield ~5m total visibility.)
+//
+// The marker is only appended when the series genuinely stopped before the end
+// of the query window: if the last sample is within one step of queryEndMs the
+// series is still live and Prometheus would not stale-mark it. A zero/unknown
+// step is treated as "cannot place a marker" and is left untouched.
+func appendStaleMarker(samples []model.Sample, stepMs int64, queryEndMs int64) []model.Sample {
+	if len(samples) == 0 || stepMs <= 0 {
+		return samples
+	}
+	markerTs := samples[len(samples)-1].TimestampMs + stepMs
+	if markerTs > queryEndMs {
+		// The series runs up to (or past) the query edge; it did not stop, so
+		// no stale marker - the query window itself truncates it.
+		return samples
+	}
+	return append(samples, model.Sample{TimestampMs: markerTs, Value: model.StaleMarkerValue})
+}
+
 func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints,
 	matchers ...*labels.Matcher) storage.SeriesSet {
 
@@ -290,6 +323,10 @@ func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 			if len(res.Series) > 0 && q.MapResult != nil {
 				res.Series[len(res.Series)-1].Samples = q.MapResult(res.Series[len(res.Series)-1].Samples)
 			}
+			if len(res.Series) > 0 && !isProlong {
+				res.Series[len(res.Series)-1].Samples = appendStaleMarker(
+					res.Series[len(res.Series)-1].Samples, hints.Step, hints.End)
+			}
 			res.Series = append(res.Series, &model.SeriesV2{
 				LabelsGetter: lblsGetter,
 				Fp:           fp,
@@ -305,6 +342,10 @@ func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	}
 	if len(res.Series) > 0 && q.MapResult != nil {
 		res.Series[len(res.Series)-1].Samples = q.MapResult(res.Series[len(res.Series)-1].Samples)
+	}
+	if len(res.Series) > 0 && !isProlong {
+		res.Series[len(res.Series)-1].Samples = appendStaleMarker(
+			res.Series[len(res.Series)-1].Samples, hints.Step, hints.End)
 	}
 	err = lblsGetter.Fetch()
 	if err != nil {

--- a/reader/service/prom_queryable.go
+++ b/reader/service/prom_queryable.go
@@ -210,28 +210,40 @@ func (c *CLokiQuerier) isProlong(hints *storage.SelectHints, matchers []*labels.
 	return (slices.Contains(rateFunctions, hints.Func) || hints.Func == "") && hints.Step != 0
 }
 
-// appendStaleMarker terminates an accelerated (substitute-backed) series with a
-// Prometheus stale marker one step past the last sample the SQL layer returned.
+// isSQLFilled reports whether the series was forward-filled 5m by
+// FillGapsPlanner. That is exactly the substitute-backed set (created only by
+// the vector_range/vector_agg optimizers, all of which route through the fill).
 //
-// The accelerated path builds a series with Prolong=false directly from
-// ClickHouse rows, and the SQL densifier (planner.fillGaps) already forward-fills
-// each real bucket for 5 minutes (planner.staleness) on the step grid. So the
-// last returned sample already sits at lastReal + 5m: the 5m carry is baked into
-// the rows. The problem in issue #931 is that the engine then applies its OWN 5m
-// LookbackDelta on top of that, stacking to ~10m. Appending a stale marker one
-// step past the last returned sample caps the already-filled data at the 5m
-// boundary so the engine cannot extend it any further.
+// It is the correct gate for appendStaleMarker, not !isProlong: non-substitute
+// instant-vector functions (abs, topk, histogram_quantile, ...) are also
+// Prolong=false but are regrouped by HintsPlanner without a fill, so their rows
+// were never carried 5m and must not be capped.
+func (c *CLokiQuerier) isSQLFilled(matchers []*labels.Matcher) bool {
+	for _, m := range matchers {
+		if m.Name == "__name__" && m.Type == labels.MatchEqual && c.expr.Substitutes[m.Value] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// appendStaleMarker caps a SQL-filled series (see isSQLFilled) with a stale
+// marker one step past its last row.
 //
-// (This differs from the raw iterator path in reader/model, which does not
-// SQL-fill and therefore places its marker at lastReal + LookbackDeltaMs to
-// provide the 5m carry itself. Both paths yield ~5m total visibility.)
+// The SQL densifier already forward-fills each bucket 5m, so the last row sits
+// at lastReal + 5m. Without a terminator the engine adds its own 5m
+// LookbackDelta on top, stacking to ~10m (issue #931); the marker stops it at
+// the boundary. (The raw iterator path in reader/model instead places its
+// marker at lastReal + LookbackDeltaMs, providing the 5m carry itself.)
 //
-// The marker is only appended when the series genuinely stopped before the end
-// of the query window: if the last sample is within one step of queryEndMs the
-// series is still live and Prometheus would not stale-mark it. A zero/unknown
-// step is treated as "cannot place a marker" and is left untouched.
-func appendStaleMarker(samples []model.Sample, stepMs int64, queryEndMs int64) []model.Sample {
-	if len(samples) == 0 || stepMs <= 0 {
+// sqlFilled gates the whole thing: only SQL-filled (substitute-backed) series
+// carry the baked-in 5m, so only they may be capped.
+//
+// No marker is appended when the series is not SQL-filled, is still live at the
+// query edge (last sample within one step of queryEndMs), or the step is
+// unknown (0).
+func appendStaleMarker(samples []model.Sample, sqlFilled bool, stepMs int64, queryEndMs int64) []model.Sample {
+	if !sqlFilled || len(samples) == 0 || stepMs <= 0 {
 		return samples
 	}
 	markerTs := samples[len(samples)-1].TimestampMs + stepMs
@@ -241,6 +253,20 @@ func appendStaleMarker(samples []model.Sample, stepMs int64, queryEndMs int64) [
 		return samples
 	}
 	return append(samples, model.Sample{TimestampMs: markerTs, Value: model.StaleMarkerValue})
+}
+
+// applyStaleMarkers caps every series with a stale marker via appendStaleMarker,
+// the single post-processing pass Select() runs before ReshuffleSeries (mirroring
+// how ReshuffleSeries is itself a pure, DB-independent pass over the built
+// series). sqlFilled is the query-level gate from isSQLFilled: when false (e.g.
+// abs/topk and other non-substitute instant-vector functions, which are not
+// SQL-filled) no series is marked, so the engine's own 5m lookback is preserved.
+func (c *CLokiQuerier) applyStaleMarkers(series []*model.SeriesV2, sqlFilled bool,
+	stepMs int64, queryEndMs int64) []*model.SeriesV2 {
+	for _, s := range series {
+		s.Samples = appendStaleMarker(s.Samples, sqlFilled, stepMs, queryEndMs)
+	}
+	return series
 }
 
 func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints,
@@ -298,6 +324,7 @@ func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	cntSeries := 0
 	lblsGetter := newLabelsGetter(time.UnixMilli(hints.Start), time.UnixMilli(hints.End), c.db, c.ctx)
 	isProlong := c.isProlong(hints, matchers)
+	isSQLFilled := c.isSQLFilled(matchers)
 	for rows.Next() {
 		err = rows.Scan(&tp, &fp, &ts, &val, &lbls)
 		if err != nil {
@@ -323,10 +350,6 @@ func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 			if len(res.Series) > 0 && q.MapResult != nil {
 				res.Series[len(res.Series)-1].Samples = q.MapResult(res.Series[len(res.Series)-1].Samples)
 			}
-			if len(res.Series) > 0 && !isProlong {
-				res.Series[len(res.Series)-1].Samples = appendStaleMarker(
-					res.Series[len(res.Series)-1].Samples, hints.Step, hints.End)
-			}
 			res.Series = append(res.Series, &model.SeriesV2{
 				LabelsGetter: lblsGetter,
 				Fp:           fp,
@@ -343,10 +366,7 @@ func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	if len(res.Series) > 0 && q.MapResult != nil {
 		res.Series[len(res.Series)-1].Samples = q.MapResult(res.Series[len(res.Series)-1].Samples)
 	}
-	if len(res.Series) > 0 && !isProlong {
-		res.Series[len(res.Series)-1].Samples = appendStaleMarker(
-			res.Series[len(res.Series)-1].Samples, hints.Step, hints.End)
-	}
+	res.Series = c.applyStaleMarkers(res.Series, isSQLFilled, hints.Step, hints.End)
 	err = lblsGetter.Fetch()
 	if err != nil {
 		return &model.SeriesSet{Error: err}

--- a/reader/service/prom_queryable_test.go
+++ b/reader/service/prom_queryable_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/metrico/qryn/v5/reader/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 )
 
 // stubLabelsGetter is a minimal model.ILabelsGetter backed by a map, for
@@ -136,5 +137,98 @@ func TestReshuffleSeries_DistinctLabelSets(t *testing.T) {
 	}
 	if out[0].Samples[0].TimestampMs != 10 || out[1].Samples[0].TimestampMs != 20 {
 		t.Fatalf("samples should be untouched")
+	}
+}
+
+// The accelerated (substitute-backed) path builds a SeriesV2 with Prolong=false
+// directly from ClickHouse rows. Because the SQL layer fills forward for 5
+// minutes (const staleness) AND the engine applies its own 5-minute
+// LookbackDelta, a value at T could remain visible until ~T+10m (issue #931).
+//
+// The fix appends a Prometheus stale marker one step past the last real sample
+// so the engine stops carrying the value forward. These tests pin the semantics
+// of the appendStaleMarker helper that Select() calls.
+
+func lastIsStaleMarker(t *testing.T, samples []model.Sample, wantTs int64) {
+	t.Helper()
+	if len(samples) == 0 {
+		t.Fatalf("expected samples, got none")
+	}
+	last := samples[len(samples)-1]
+	if last.TimestampMs != wantTs {
+		t.Errorf("stale marker timestamp: expected %d, got %d", wantTs, last.TimestampMs)
+	}
+	if !value.IsStaleNaN(last.Value) {
+		t.Errorf("expected last sample to be a stale marker, got value=%v", last.Value)
+	}
+}
+
+// TestAppendStaleMarker_AppendsOneStepPastLast is the core behavior: a stale
+// marker is appended one step past the last real sample when that sample ends
+// before the query window edge (i.e., the series genuinely stopped).
+func TestAppendStaleMarker_AppendsOneStepPastLast(t *testing.T) {
+	const step = int64(15000)
+	const queryEnd = int64(1_000_000) // well past the last sample
+	in := []model.Sample{
+		{TimestampMs: 100000, Value: 1},
+		{TimestampMs: 115000, Value: 2},
+		{TimestampMs: 130000, Value: 3},
+	}
+
+	out := appendStaleMarker(in, step, queryEnd)
+
+	if len(out) != len(in)+1 {
+		t.Fatalf("expected %d samples (3 real + 1 marker), got %d", len(in)+1, len(out))
+	}
+	// Real samples untouched.
+	for i := range in {
+		if out[i] != in[i] {
+			t.Fatalf("real sample %d changed: %+v -> %+v", i, in[i], out[i])
+		}
+	}
+	lastIsStaleMarker(t, out, 130000+step)
+}
+
+// TestAppendStaleMarker_NoMarkerAtQueryEdge verifies we do NOT emit a stale
+// marker for a series that is still live at the query window edge. Prometheus
+// only stale-marks a series that actually stops, not one that is simply
+// truncated by the end of the query range.
+func TestAppendStaleMarker_NoMarkerAtQueryEdge(t *testing.T) {
+	const step = int64(15000)
+	// Last sample is within one step of the query end -> still live.
+	const queryEnd = int64(130000 + 5000)
+	in := []model.Sample{
+		{TimestampMs: 100000, Value: 1},
+		{TimestampMs: 130000, Value: 3},
+	}
+
+	out := appendStaleMarker(in, step, queryEnd)
+
+	if len(out) != len(in) {
+		t.Fatalf("expected no marker at the query edge, got %d samples: %+v", len(out), out)
+	}
+	for _, s := range out {
+		if value.IsStaleNaN(s.Value) {
+			t.Fatalf("unexpected stale marker for a series live at the query edge: %+v", out)
+		}
+	}
+}
+
+// TestAppendStaleMarker_EmptySeries verifies no marker and no panic for empty
+// input.
+func TestAppendStaleMarker_EmptySeries(t *testing.T) {
+	out := appendStaleMarker(nil, 15000, 1_000_000)
+	if len(out) != 0 {
+		t.Fatalf("expected empty output for empty input, got %+v", out)
+	}
+}
+
+// TestAppendStaleMarker_ZeroStepNoop verifies that with an unknown/zero step we
+// do not fabricate a marker at a bogus timestamp.
+func TestAppendStaleMarker_ZeroStepNoop(t *testing.T) {
+	in := []model.Sample{{TimestampMs: 100000, Value: 1}}
+	out := appendStaleMarker(in, 0, 1_000_000)
+	if len(out) != len(in) {
+		t.Fatalf("expected no marker with zero step, got %+v", out)
 	}
 }

--- a/reader/service/prom_queryable_test.go
+++ b/reader/service/prom_queryable_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/metrico/qryn/v5/reader/model"
+	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
+	"github.com/metrico/qryn/v5/reader/promql/promql_transpiler"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 )
@@ -140,14 +142,10 @@ func TestReshuffleSeries_DistinctLabelSets(t *testing.T) {
 	}
 }
 
-// The accelerated (substitute-backed) path builds a SeriesV2 with Prolong=false
-// directly from ClickHouse rows. Because the SQL layer fills forward for 5
-// minutes (const staleness) AND the engine applies its own 5-minute
-// LookbackDelta, a value at T could remain visible until ~T+10m (issue #931).
-//
-// The fix appends a Prometheus stale marker one step past the last real sample
-// so the engine stops carrying the value forward. These tests pin the semantics
-// of the appendStaleMarker helper that Select() calls.
+// appendStaleMarker terminates a SQL-filled series with a stale marker one step
+// past its last sample (issue #931). These tests pin its semantics; the
+// sqlFilled gate makes it the single decision point for which series get a
+// marker.
 
 func lastIsStaleMarker(t *testing.T, samples []model.Sample, wantTs int64) {
 	t.Helper()
@@ -163,36 +161,9 @@ func lastIsStaleMarker(t *testing.T, samples []model.Sample, wantTs int64) {
 	}
 }
 
-// TestAppendStaleMarker_AppendsOneStepPastLast is the core behavior: a stale
-// marker is appended one step past the last real sample when that sample ends
-// before the query window edge (i.e., the series genuinely stopped).
-func TestAppendStaleMarker_AppendsOneStepPastLast(t *testing.T) {
-	const step = int64(15000)
-	const queryEnd = int64(1_000_000) // well past the last sample
-	in := []model.Sample{
-		{TimestampMs: 100000, Value: 1},
-		{TimestampMs: 115000, Value: 2},
-		{TimestampMs: 130000, Value: 3},
-	}
-
-	out := appendStaleMarker(in, step, queryEnd)
-
-	if len(out) != len(in)+1 {
-		t.Fatalf("expected %d samples (3 real + 1 marker), got %d", len(in)+1, len(out))
-	}
-	// Real samples untouched.
-	for i := range in {
-		if out[i] != in[i] {
-			t.Fatalf("real sample %d changed: %+v -> %+v", i, in[i], out[i])
-		}
-	}
-	lastIsStaleMarker(t, out, 130000+step)
-}
-
 // TestAppendStaleMarker_NoMarkerAtQueryEdge verifies we do NOT emit a stale
-// marker for a series that is still live at the query window edge. Prometheus
-// only stale-marks a series that actually stops, not one that is simply
-// truncated by the end of the query range.
+// marker for a series that is still live at the query window edge, even when
+// SQL-filled. Prometheus only stale-marks a series that actually stops.
 func TestAppendStaleMarker_NoMarkerAtQueryEdge(t *testing.T) {
 	const step = int64(15000)
 	// Last sample is within one step of the query end -> still live.
@@ -202,7 +173,7 @@ func TestAppendStaleMarker_NoMarkerAtQueryEdge(t *testing.T) {
 		{TimestampMs: 130000, Value: 3},
 	}
 
-	out := appendStaleMarker(in, step, queryEnd)
+	out := appendStaleMarker(in, true, step, queryEnd)
 
 	if len(out) != len(in) {
 		t.Fatalf("expected no marker at the query edge, got %d samples: %+v", len(out), out)
@@ -217,7 +188,7 @@ func TestAppendStaleMarker_NoMarkerAtQueryEdge(t *testing.T) {
 // TestAppendStaleMarker_EmptySeries verifies no marker and no panic for empty
 // input.
 func TestAppendStaleMarker_EmptySeries(t *testing.T) {
-	out := appendStaleMarker(nil, 15000, 1_000_000)
+	out := appendStaleMarker(nil, true, 15000, 1_000_000)
 	if len(out) != 0 {
 		t.Fatalf("expected empty output for empty input, got %+v", out)
 	}
@@ -227,8 +198,176 @@ func TestAppendStaleMarker_EmptySeries(t *testing.T) {
 // do not fabricate a marker at a bogus timestamp.
 func TestAppendStaleMarker_ZeroStepNoop(t *testing.T) {
 	in := []model.Sample{{TimestampMs: 100000, Value: 1}}
-	out := appendStaleMarker(in, 0, 1_000_000)
+	out := appendStaleMarker(in, true, 0, 1_000_000)
 	if len(out) != len(in) {
 		t.Fatalf("expected no marker with zero step, got %+v", out)
+	}
+}
+
+// isSQLFilled predicate tests: it must key off substitute presence only.
+
+func newQuerierWithSubstitutes(names ...string) *CLokiQuerier {
+	subs := make(map[string]*promql_parser.Substitute, len(names))
+	for _, n := range names {
+		subs[n] = &promql_parser.Substitute{MetricName: n}
+	}
+	return &CLokiQuerier{expr: &promql_parser.Expr{Substitutes: subs}}
+}
+
+func nameMatcher(v string) []*labels.Matcher {
+	return []*labels.Matcher{{Type: labels.MatchEqual, Name: "__name__", Value: v}}
+}
+
+// transpiledQuerier parses and transpiles a real PromQL query the same way the
+// request path does, and returns a CLokiQuerier holding the resulting expr - so
+// isSQLFilled runs against the actual optimizer output, not a hand-built map.
+func transpiledQuerier(t *testing.T, query string) *promql_parser.Expr {
+	t.Helper()
+	expr, err := promql_parser.Parse(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	expr, err = promql_transpiler.TranspileExpressionV2(expr)
+	if err != nil {
+		t.Fatalf("transpile %q: %v", query, err)
+	}
+	return expr
+}
+
+// TestIsSQLFilled_FromRealTranspile connects the whole chain end to end: it
+// transpiles real queries and drives isSQLFilled with the exact __name__
+// matchers the engine passes to Select() for each.
+//
+//   - rate/sum/*_over_time are accelerated into a substitute; the engine queries
+//     the synthetic substitute name, and isSQLFilled must be true (SQL-filled).
+//   - abs/topk/... are NOT accelerated; no substitute is created, the engine
+//     queries the real metric name, and isSQLFilled must be false so the
+//     stale-marker cap is not applied (the #931 review case).
+func TestIsSQLFilled_FromRealTranspile(t *testing.T) {
+	sqlFilled := []string{
+		`rate(test_counter{job="x"}[1m])`,
+		`sum(test_counter{job="x"})`,
+		`avg_over_time(test_metric{job="x"}[5m])`,
+	}
+	for _, q := range sqlFilled {
+		expr := transpiledQuerier(t, q)
+		if len(expr.Substitutes) == 0 {
+			t.Fatalf("%q: expected a substitute (accelerated)", q)
+		}
+		c := &CLokiQuerier{expr: expr}
+		// The engine issues one Select per substitute, keyed by the substitute
+		// name (substituteSelector sets Name -> __name__).
+		for name := range expr.Substitutes {
+			if !c.isSQLFilled(nameMatcher(name)) {
+				t.Errorf("%q: substitute %q must be reported SQL-filled", q, name)
+			}
+		}
+	}
+
+	// Non-substitute instant-vector functions: no substitute, so the engine
+	// queries the real metric name, which isSQLFilled must report as NOT filled.
+	notFilled := []struct{ query, metric string }{
+		{`abs(test_counter{job="x"})`, "test_counter"},
+		{`topk(3, test_counter{job="x"})`, "test_counter"},
+		{`ceil(test_metric{job="x"})`, "test_metric"},
+		{`histogram_quantile(0.9, test_metric{job="x"})`, "test_metric"},
+		// A bare selector is not accelerated either: it is served by the prolong
+		// iterator path, not the SQL fill, so it must not be reported SQL-filled.
+		{`test_metric{job="x"}`, "test_metric"},
+	}
+	for _, tc := range notFilled {
+		expr := transpiledQuerier(t, tc.query)
+		if len(expr.Substitutes) != 0 {
+			t.Fatalf("%q: expected NO substitute, got %d", tc.query, len(expr.Substitutes))
+		}
+		c := &CLokiQuerier{expr: expr}
+		if c.isSQLFilled(nameMatcher(tc.metric)) {
+			t.Errorf("%q: %q must NOT be reported SQL-filled (would truncate the engine's 5m lookback)",
+				tc.query, tc.metric)
+		}
+	}
+}
+
+// applyStaleMarkers is the pure, DB-independent pass Select() runs over the
+// built series (like ReshuffleSeries). These tests exercise that exact method
+// with the sqlFilled gate computed from query matchers via isSQLFilled, so they
+// assert WHICH series get a marker - the scenario the #931 review asked for.
+
+func staleTestSeries() []*model.SeriesV2 {
+	getter := &stubLabelsGetter{byFp: map[uint64]model.Labels{
+		1: mkLabels("__name__", "s1"),
+		2: mkLabels("__name__", "s2"),
+	}}
+	return []*model.SeriesV2{
+		{LabelsGetter: getter, Fp: 1, Samples: []model.Sample{{TimestampMs: 100000, Value: 1}, {TimestampMs: 130000, Value: 3}}},
+		{LabelsGetter: getter, Fp: 2, Samples: []model.Sample{{TimestampMs: 100000, Value: 9}, {TimestampMs: 130000, Value: 7}}},
+	}
+}
+
+func countStaleMarkers(series []*model.SeriesV2) int {
+	n := 0
+	for _, s := range series {
+		for _, smp := range s.Samples {
+			if value.IsStaleNaN(smp.Value) {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestApplyStaleMarkers_NonSubstituteInstantFn is the key #931-review case: for
+// abs(...)/topk(...) (a non-substitute instant-vector function, proven to
+// produce no substitute by promql_transpiler.TestSQLFilled_SubstitutePresence)
+// isSQLFilled is false, so applyStaleMarkers - the method Select actually calls
+// - must leave every series untouched, preserving the engine's own 5m lookback.
+func TestApplyStaleMarkers_NonSubstituteInstantFn(t *testing.T) {
+	const step, queryEnd = int64(15000), int64(1_000_000)
+	c := newQuerierWithSubstitutes("__metric_subst__999") // some other query's subst
+	sqlFilled := c.isSQLFilled(nameMatcher("test_metric")) // abs(test_metric) -> false
+	if sqlFilled {
+		t.Fatal("precondition: abs(test_metric) must not be SQL-filled")
+	}
+
+	series := staleTestSeries()
+	out := c.applyStaleMarkers(series, sqlFilled, step, queryEnd)
+
+	if n := countStaleMarkers(out); n != 0 {
+		t.Fatalf("non-substitute instant fn (abs/topk) must not be stale-marked, found %d markers", n)
+	}
+	for _, s := range out {
+		if len(s.Samples) != 2 {
+			t.Fatalf("real samples must be untouched, got %d: %+v", len(s.Samples), s.Samples)
+		}
+	}
+}
+
+// TestApplyStaleMarkers_SubstituteBacked is the complement: a substitute-backed
+// query (rate/sum/*_over_time) is SQL-filled, so every series gets exactly one
+// trailing stale marker at last+step.
+func TestApplyStaleMarkers_SubstituteBacked(t *testing.T) {
+	const step, queryEnd = int64(15000), int64(1_000_000)
+	c := newQuerierWithSubstitutes("__metric_subst__123")
+	sqlFilled := c.isSQLFilled(nameMatcher("__metric_subst__123"))
+	if !sqlFilled {
+		t.Fatal("precondition: substitute-backed query must be SQL-filled")
+	}
+
+	out := c.applyStaleMarkers(staleTestSeries(), sqlFilled, step, queryEnd)
+
+	if n := countStaleMarkers(out); n != 2 {
+		t.Fatalf("expected one trailing marker per series (2 total), got %d", n)
+	}
+	for _, s := range out {
+		// One marker appended after the two real samples, which are left intact.
+		if len(s.Samples) != 3 {
+			t.Fatalf("expected 2 real samples + 1 marker, got %d: %+v", len(s.Samples), s.Samples)
+		}
+		for i := 0; i < 2; i++ {
+			if value.IsStaleNaN(s.Samples[i].Value) {
+				t.Fatalf("real sample %d must be untouched, got a stale marker: %+v", i, s.Samples)
+			}
+		}
+		lastIsStaleMarker(t, s.Samples, 130000+step)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #931 — the effective PromQL lookback for instant vector selectors and `rate`/`deriv`/`delta` in range queries could be up to ~10 minutes, roughly double Prometheus's standard 5-minute staleness delta, because two independent 5-minute windows stacked:

1. the iterator forward-filled the last value on the step grid for 5m, and
2. the PromQL engine then applied its own 5m `LookbackDelta` on top of that.

## Approach

Emit a single Prometheus stale marker (`value.StaleNaN`) at the lookback boundary instead of forward-filling. The engine carries the last real value forward across its own 5m lookback and the marker terminates it exactly there, so total visibility is ~5m — the same mechanism Prometheus uses when a series disappears, and never the stacked ~10m.

A run ends only when the next real sample is more than the lookback delta (5m) away, so genuinely **sparse** series whose samples are within 5m are still bridged by the engine's lookback, exactly as in upstream Prometheus. When a stale series later **reappears**, the marker sits in the gap and the new sample simply starts a fresh run.

> Note on push vs pull: Prometheus's ingest-time "series went away" detection is a pull/scrape capability. For pushed data (OTLP, remote-write) gigapipe cannot detect disappearance at ingest, so this synthesizes the equivalent staleness at query time — reproducing the observable 5m-then-stale behavior without ingest-time detection.

## Changes

Both code paths are covered:

- **`prolongSeriesIt`** (non-substitute instant/rate selectors), `reader/model/prometheus.go`: yields the real samples untouched and emits one marker at `lastSample + LookbackDeltaMs` when a run ends (gap > 5m, or series end). No more step-grid fill.
- **Substitute-backed (SQL-filled) path**, `reader/service/prom_queryable.go`: gated on `isSQLFilled(matchers)` (a registered substitute for the `__name__`), which is the exact set whose rows `FillGapsPlanner` already forward-filled 5m. `appendStaleMarker()` caps that by adding one marker one step past the last returned sample in `Select()`, unless the series is still live at the query-window edge. Note: this is **not** `!isProlong` — non-substitute instant-vector functions (`abs`, `topk`, `histogram_quantile`, ...) are also `Prolong=false` but are planned by `HintsPlanner`'s `argMax` regroup (no fill), so they must not be marked.

`StaleMarkerValue` and `LookbackDeltaMs` are defined once in `reader/model` as the single source of truth.

## Testing

- Iterator unit tests (`reader/model`) including sparse-gap bridging and stale-then-reappear.
- `appendStaleMarker` unit tests (`reader/service`).
- Engine/iterator integration test (`reader/router`) that asserts **both** ~5m carry-forward within the lookback window **and** no ~10m stacking. Verified it fails against the old forward-fill behavior and passes with the fix.

All `go build ./...` and `go test ./reader/...` pass.

