### PR TITLE
all: apply go fix modernizers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,9 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: gofmt
+      run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
+
     - name: Build Gigapipe
       run: |
         go mod tidy

--- a/ctrl/maintenance/shared.go
+++ b/ctrl/maintenance/shared.go
@@ -29,7 +29,7 @@ func ConnectV2(dbObject *config.ClokiBaseDataBase, database bool) (clickhouse_v2
 		MaxOpenConns:    10,
 		MaxIdleConns:    2,
 		ConnMaxLifetime: time.Hour,
-		Settings: map[string]interface{}{
+		Settings: map[string]any{
 			"allow_experimental_database_replicated": "1",
 			"materialize_ttl_after_modify":           "0",
 		},

--- a/ctrl/qryn/maintenance/update.go
+++ b/ctrl/qryn/maintenance/update.go
@@ -127,8 +127,8 @@ func getSQLFile(strContents string) ([]string, error) {
 	return res, nil
 }
 
-func getDBExec(db clickhouse.Conn, env map[string]string, logger logger.ILogger) func(query string, args ...[]interface{}) error {
-	return func(query string, args ...[]interface{}) error {
+func getDBExec(db clickhouse.Conn, env map[string]string, logger logger.ILogger) func(query string, args ...[]any) error {
+	return func(query string, args ...[]any) error {
 		name := fmt.Sprintf("tpl_%d", rand.Uint64())
 		tpl, err := template.New(name).Parse(query)
 		if err != nil {

--- a/reader/controller/tempo.go
+++ b/reader/controller/tempo.go
@@ -458,9 +458,10 @@ type traceSearchParams struct {
 
 func parseTraceSearchParams(r *http.Request) (*traceSearchParams, error) {
 	var err error
-	res := traceSearchParams{}
-	res.Q = r.URL.Query().Get("q")
-	res.Tags = r.URL.Query().Get("tags")
+	res := traceSearchParams{
+		Q:    r.URL.Query().Get("q"),
+		Tags: r.URL.Query().Get("tags"),
+	}
 	res.MinDuration, err = time.ParseDuration(orDefault(r.URL.Query().Get("minDuration"), "0"))
 	if err != nil {
 		return nil, fmt.Errorf("minDuration: %v", err)

--- a/reader/logql/logql_parser/model.go
+++ b/reader/logql/logql_parser/model.go
@@ -170,7 +170,7 @@ func (s *StrSelectorPipeline) String() string {
 }
 
 type LineFilter struct {
-	Fn  string       `@("|="|"!="|"|~"|"!~"|"|>")`
+	Fn  string        `@("|="|"!="|"|~"|"!~"|"|>")`
 	Exp LineFilterExp `@@`
 }
 
@@ -180,7 +180,7 @@ func (l *LineFilter) String() string {
 
 type LineFilterExp struct {
 	Head LineFilterHead `@@`
-	Op string `@("and"|"or")?`
+	Op   string         `@("and"|"or")?`
 	Tail *LineFilterExp `@@?`
 }
 
@@ -196,8 +196,8 @@ func (l *LineFilterExp) String() string {
 }
 
 type LineFilterHead struct {
-	Complex *LineFilterExp        `( "(" @@ ")" )`
-	Simple  *LineFilterSimple  `| @@`
+	Complex *LineFilterExp    `( "(" @@ ")" )`
+	Simple  *LineFilterSimple `| @@`
 }
 
 func (h *LineFilterHead) String() string {

--- a/reader/logql/logql_parser/parser.go
+++ b/reader/logql/logql_parser/parser.go
@@ -41,7 +41,7 @@ func FindFirst[T any](node any) *T {
 	if n, ok := node.(*T); ok {
 		return n
 	}
-	if node == nil || (reflect.ValueOf(node).Kind() == reflect.Ptr && reflect.ValueOf(node).IsNil()) {
+	if node == nil || (reflect.ValueOf(node).Kind() == reflect.Pointer && reflect.ValueOf(node).IsNil()) {
 		return nil
 	}
 	switch _node := node.(type) {

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner.go
@@ -597,7 +597,7 @@ func getLabelsAndValuesFromLabelParams(count int,
 	getParam func(i int) (logql_parser.LabelName, *logql_parser.QuotedString)) ([]string, []string, error) {
 	labels := make([]string, count)
 	vals := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		label, valParam := getParam(i)
 		labels[i] = label.Name
 		var (

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_line_filter.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_line_filter.go
@@ -124,7 +124,7 @@ func (o *lineFilterOps) re2Like() (string, bool, bool) {
 	if err != nil {
 		return "", false, false
 	}
-	if exp.Op != syntax.OpLiteral || exp.Flags& ^(syntax.PerlX|syntax.FoldCase) != 0 {
+	if exp.Op != syntax.OpLiteral || exp.Flags & ^(syntax.PerlX|syntax.FoldCase) != 0 {
 		return "", false, false
 	}
 	return string(exp.Rune), exp.Flags&syntax.FoldCase != 0, true

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_stream_select.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_stream_select.go
@@ -3,6 +3,7 @@ package clickhouse_planner
 import (
 	"fmt"
 	"github.com/metrico/qryn/v5/reader/config"
+	"slices"
 	"strings"
 	"time"
 
@@ -29,12 +30,12 @@ func (s *StreamSelectPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, 
 		from = from.Add(ctx.Offset)
 	}
 	var emptyLabels []string
-	for i := len(s.LabelNames) - 1; i >= 0; i-- {
+	for i, v := range slices.Backward(s.LabelNames) {
 		if config.Cloki.Setting.ClokiReader.OmitEmptyValues {
 			break
 		}
 		if (s.Ops[i] == "=" || s.Ops[i] == "=~") && s.Values[i] == "" {
-			emptyLabels = append(emptyLabels, s.LabelNames[i])
+			emptyLabels = append(emptyLabels, v)
 			s.LabelNames = append(s.LabelNames[:i], s.LabelNames[i+1:]...)
 			s.Ops = append(s.Ops[:i], s.Ops[i+1:]...)
 			s.Values = append(s.Values[:i], s.Values[i+1:]...)

--- a/reader/logql/logql_transpiler/internal/planner/hash.go
+++ b/reader/logql/logql_transpiler/internal/planner/hash.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"slices"
 	"sort"
 	"strings"
 
@@ -30,10 +31,5 @@ func fingerprint(labels map[string]string) uint64 {
 }
 
 func contains(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, s)
 }

--- a/reader/logql/logql_transpiler/internal/planner/hash_test.go
+++ b/reader/logql/logql_transpiler/internal/planner/hash_test.go
@@ -133,7 +133,7 @@ func (f FakePlanner) Process(context *shared.PlannerContext, c chan []shared.Log
 func TestParser(t *testing.T) {
 	out := make(chan []shared.LogEntry)
 	p := ParserPlanner{
-		GenericPlanner:  GenericPlanner{Main: &FakePlanner{out}},
+		Main:            &FakePlanner{out},
 		Op:              "logfmt",
 		ParameterNames:  []string{"lbl"},
 		ParameterValues: []string{"a"},

--- a/reader/logql/logql_transpiler/internal/planner/planner.go
+++ b/reader/logql/logql_transpiler/internal/planner/planner.go
@@ -171,11 +171,9 @@ func planAggregators(script any, init shared.RequestProcessor) (shared.RequestPr
 				proc = planByWithout(proc, aggOp.ByOrWithoutPrefix, aggOp.ByOrWithoutSuffix)
 			}
 			proc = &LRAPlanner{
-				AggregatorPlanner: AggregatorPlanner{
-					GenericPlanner: GenericPlanner{proc},
-					Duration:       duration,
-				},
-				Func: lra.Fn,
+				GenericPlanner: GenericPlanner{proc},
+				Duration:       duration,
+				Func:           lra.Fn,
 			}
 			return maybeComparison(proc, aggOp.Comparison)
 		}
@@ -184,19 +182,15 @@ func planAggregators(script any, init shared.RequestProcessor) (shared.RequestPr
 	if len(lra.StrSel.Pipelines) > 0 && lra.StrSel.Pipelines[len(lra.StrSel.Pipelines)-1].Unwrap != nil {
 		proc = planByWithout(proc, lra.ByOrWithoutPrefix, lra.ByOrWithoutSuffix)
 		proc = &UnwrapAggPlanner{
-			AggregatorPlanner: AggregatorPlanner{
-				GenericPlanner: GenericPlanner{proc},
-				Duration:       duration,
-			},
-			Function: lra.Fn,
+			GenericPlanner: GenericPlanner{proc},
+			Duration:       duration,
+			Function:       lra.Fn,
 		}
 	} else {
 		proc = &LRAPlanner{
-			AggregatorPlanner: AggregatorPlanner{
-				GenericPlanner: GenericPlanner{proc},
-				Duration:       duration,
-			},
-			Func: lra.Fn,
+			GenericPlanner: GenericPlanner{proc},
+			Duration:       duration,
+			Func:           lra.Fn,
 		}
 	}
 	proc, err = maybeComparison(proc, lra.Comparison)
@@ -210,11 +204,9 @@ func planAggregators(script any, init shared.RequestProcessor) (shared.RequestPr
 		proc = planByWithout(proc, aggOp.ByOrWithoutPrefix, aggOp.ByOrWithoutSuffix)
 	}
 	return maybeComparison(&AggOpPlanner{
-		AggregatorPlanner: AggregatorPlanner{
-			GenericPlanner: GenericPlanner{proc},
-			Duration:       duration,
-		},
-		Func: aggOp.Fn,
+		GenericPlanner: GenericPlanner{proc},
+		Duration:       duration,
+		Func:           aggOp.Fn,
 	}, aggOp.Comparison)
 }
 

--- a/reader/logql/logql_transpiler/shared/planner_clickhouse_getter.go
+++ b/reader/logql/logql_transpiler/shared/planner_clickhouse_getter.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"database/sql"
 	"io"
+	"maps"
 
 	sql2 "github.com/metrico/qryn/v5/reader/utils/sql_select"
 )
@@ -69,9 +70,7 @@ func (c *ClickhouseGetterPlanner) Scan(ctx *PlannerContext, rows *sql.Rows, res 
 			return
 		}
 		entries[i].Labels = make(map[string]string)
-		for k, v := range labels {
-			entries[i].Labels[k] = v
-		}
+		maps.Copy(entries[i].Labels, labels)
 		i++
 		if i >= 100 {
 			res <- entries
@@ -109,9 +108,7 @@ func (c *ClickhouseGetterPlanner) ScanMatrix(ctx *PlannerContext, rows *sql.Rows
 			return
 		}
 		entries[i].Labels = make(map[string]string)
-		for k, v := range labels {
-			entries[i].Labels[k] = v
-		}
+		maps.Copy(entries[i].Labels, labels)
 		i++
 		if i >= 100 {
 			res <- entries

--- a/reader/logql/logql_transpiler/shared/template_funcs.go
+++ b/reader/logql/logql_transpiler/shared/template_funcs.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"maps"
 	"regexp"
 	"strings"
 	"text/template"
@@ -67,9 +68,7 @@ func BaseTemplateFuncs() template.FuncMap {
 // EntryTemplateLabels returns label values available to line_format templates.
 func EntryTemplateLabels(entry LogEntry) map[string]string {
 	labels := make(map[string]string, len(entry.Labels)+2)
-	for k, v := range entry.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, entry.Labels)
 	labels["_entry"] = entry.Message
 	labels["__line__"] = entry.Message
 	return labels

--- a/reader/logql/logql_transpiler/shared/template_funcs_test.go
+++ b/reader/logql/logql_transpiler/shared/template_funcs_test.go
@@ -50,4 +50,3 @@ func TestPrepareLineFormatTemplateTimestamp(t *testing.T) {
 		t.Fatalf("ExecuteLineFormatTemplate() = %q, want %q", got, fmt.Sprintf("%d", ts.Unix()))
 	}
 }
-

--- a/reader/model/json_scan.go
+++ b/reader/model/json_scan.go
@@ -59,7 +59,7 @@ func (j *JSONText) UnmarshalJSON(data []byte) error {
 }
 
 // Unmarshal unmarshal's the json in j to v, as in json.Unmarshal.
-func (j *JSONText) Unmarshal(v interface{}) error {
+func (j *JSONText) Unmarshal(v any) error {
 	if len(*j) == 0 {
 		*j = emptyJSON
 	}

--- a/reader/model/tempo_metrics.go
+++ b/reader/model/tempo_metrics.go
@@ -37,7 +37,7 @@ type MetricsTimeSeries struct {
 	Labels     []MetricsKeyValue `json:"labels"`
 	Samples    []MetricsSample   `json:"samples"`
 	PromLabels string            `json:"promLabels,omitempty"`
-	Exemplars  []interface{}     `json:"exemplars,omitempty"`
+	Exemplars  []any             `json:"exemplars,omitempty"`
 }
 
 // MetricsQueryRangeResponse is the top-level response for /api/metrics/query_range.
@@ -50,7 +50,7 @@ type MetricsQueryRangeResponse struct {
 type MetricsInstantSeries struct {
 	Labels    []MetricsKeyValue `json:"labels"`
 	Value     float64           `json:"value"`
-	Exemplars []interface{}     `json:"exemplars"`
+	Exemplars []any             `json:"exemplars"`
 }
 
 // MetricsQueryInstantResponse is the top-level response for /api/metrics/query.

--- a/reader/model/user.go
+++ b/reader/model/user.go
@@ -218,7 +218,7 @@ type UserFileDownload struct {
 type UserParameterRequest struct {
 	// in: formData
 	// swagger:file
-	File interface{}
+	File any
 }
 
 //swagger:model TableUserList

--- a/reader/promql/promql_transpiler/planner/counter.go
+++ b/reader/promql/promql_transpiler/planner/counter.go
@@ -30,10 +30,7 @@ func prevValues(ctx *shared.PlannerContext, fpPlanner shared.SQLRequestPlanner,
 	}
 	withVals := sql.NewWith(vals, "cnt_vals")
 
-	lookback := ctx.Step
-	if lookback < staleness {
-		lookback = staleness
-	}
+	lookback := max(ctx.Step, staleness)
 	start, err := windowOffset(lookback)
 	if err != nil {
 		return nil, err

--- a/reader/promql/promql_transpiler/transpiler.go
+++ b/reader/promql/promql_transpiler/transpiler.go
@@ -26,9 +26,7 @@ func TranspileLabelMatchers(hints *storage.SelectHints,
 func TranspileLabelMatchersDownsample(hints *storage.SelectHints,
 	ctx *logql_transpiler_shared.PlannerContext, matchers ...*labels.Matcher) (*TranspileResponse, error) {
 	var p logql_transpiler_shared.SQLRequestPlanner = &planner.DownsampleValuesPlanner{
-		ValuesPlanner: planner.ValuesPlanner{
-			Fp: streamSelect(matchers...),
-		},
+		Fp: streamSelect(matchers...),
 	}
 	p = &planner.DownsampleHintsPlanner{Main: p, Hints: hints}
 	p = &planner.LabelsPlanner{Main: p}

--- a/reader/router/prometheus_query_range.go
+++ b/reader/router/prometheus_query_range.go
@@ -46,7 +46,7 @@ func RoutePrometheusQueryRange(app *mux.Router, dataSession model.IDBRegistry,
 ) {
 	eng := NewPromEngine(config.Cloki.Setting.SYSTEM_SETTINGS.MetricsMaxSamples)
 	svc := service.CLokiQueriable{
-		ServiceData: model.ServiceData{Session: dataSession},
+		Session: dataSession,
 	}
 	ctrl := &controllerv1.PromQueryRangeController{
 		Controller: controllerv1.Controller{},

--- a/reader/router/query_range.go
+++ b/reader/router/query_range.go
@@ -10,9 +10,7 @@ import (
 
 func RouteQueryRangeApis(app *mux.Router, dataSession model.IDBRegistry) {
 	qrService := &service.QueryRangeService{
-		ServiceData: model.ServiceData{
-			Session: dataSession,
-		},
+		Session: dataSession,
 	}
 	qrCtrl := &controllerv1.QueryRangeController{
 		QueryRangeService: qrService,

--- a/reader/service/prof.go
+++ b/reader/service/prof.go
@@ -695,9 +695,9 @@ func (ps *ProfService) detachTypeId(strQuery string) (string, string, error) {
 
 type units = string
 type Flamebearer struct {
-	Version              int                    `json:"version"`
-	FlamebearerProfileV1 FlamebearerProfileV1   `json:"flamebearerProfileV1"`
-	Telemetry            map[string]interface{} `json:"telemetry,omitempty"`
+	Version              int                  `json:"version"`
+	FlamebearerProfileV1 FlamebearerProfileV1 `json:"flamebearerProfileV1"`
+	Telemetry            map[string]any       `json:"telemetry,omitempty"`
 }
 
 type FlamebearerProfileV1 struct {

--- a/reader/service/prof_tree.go
+++ b/reader/service/prof_tree.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -376,8 +377,7 @@ func computeFlameGraphDiff(t1, t2 *Tree) *prof.FlameGraphDiff {
 
 		if childrenLeft, ok := t1.Nodes[left.NodeID]; ok {
 			childrenRight := t2.Nodes[right.NodeID]
-			for i := len(childrenLeft) - 1; i >= 0; i-- {
-				childLeft := childrenLeft[i]
+			for i, childLeft := range slices.Backward(childrenLeft) {
 				var childRight *TreeNodeV2
 				if i < len(childrenRight) {
 					childRight = childrenRight[i]
@@ -533,8 +533,8 @@ func (t *Tree) ToDot(sampleType string, profileName string, maxNodes int) string
 
 	// unit is the second part of sampleType, e.g. "nanoseconds" from "cpu:nanoseconds"
 	unit := ""
-	if idx := strings.Index(sampleType, ":"); idx >= 0 {
-		unit = sampleType[idx+1:]
+	if _, after, ok := strings.Cut(sampleType, ":"); ok {
+		unit = after
 	}
 
 	// Collect all node totals and compute a pruning threshold when maxNodes is set.
@@ -568,10 +568,7 @@ func (t *Tree) ToDot(sampleType string, profileName string, maxNodes int) string
 	// weight is an integer 1–100 proportional to the child's share of total samples.
 	// Graphviz requires weight >= 1 and works best with small integers.
 	edgeWeight := func(v int64) int {
-		w := int(pct(v))
-		if w < 1 {
-			w = 1
-		}
+		w := max(int(pct(v)), 1)
 		return w
 	}
 
@@ -661,10 +658,7 @@ func heatColor(self, total int64) string {
 	if ratio > 1 {
 		ratio = 1
 	}
-	r := 248 - int(ratio*float64(248-255))
-	if r > 255 {
-		r = 255
-	}
+	r := min(248-int(ratio*float64(248-255)), 255)
 	g := int(248 - ratio*248)
 	b := int(248 - ratio*248)
 	return fmt.Sprintf("#%02x%02x%02x", r, g, b)

--- a/reader/service/prom_queryable.go
+++ b/reader/service/prom_queryable.go
@@ -559,7 +559,7 @@ func (l *labelsGetter) Fetch() error {
 	for rows.Next() {
 		var (
 			fingerprint uint64
-			labels      [][]interface{}
+			labels      [][]any
 		)
 		err := rows.Scan(&fingerprint, &labels)
 		if err != nil {

--- a/reader/service/prom_queryable_test.go
+++ b/reader/service/prom_queryable_test.go
@@ -323,7 +323,7 @@ func countStaleMarkers(series []*model.SeriesV2) int {
 // - must leave every series untouched, preserving the engine's own 5m lookback.
 func TestApplyStaleMarkers_NonSubstituteInstantFn(t *testing.T) {
 	const step, queryEnd = int64(15000), int64(1_000_000)
-	c := newQuerierWithSubstitutes("__metric_subst__999") // some other query's subst
+	c := newQuerierWithSubstitutes("__metric_subst__999")  // some other query's subst
 	sqlFilled := c.isSQLFilled(nameMatcher("test_metric")) // abs(test_metric) -> false
 	if sqlFilled {
 		t.Fatal("precondition: abs(test_metric) must not be SQL-filled")
@@ -363,7 +363,7 @@ func TestApplyStaleMarkers_SubstituteBacked(t *testing.T) {
 		if len(s.Samples) != 3 {
 			t.Fatalf("expected 2 real samples + 1 marker, got %d: %+v", len(s.Samples), s.Samples)
 		}
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			if value.IsStaleNaN(s.Samples[i].Value) {
 				t.Fatalf("real sample %d must be untouched, got a stale marker: %+v", i, s.Samples)
 			}

--- a/reader/service/query_abels.go
+++ b/reader/service/query_abels.go
@@ -39,7 +39,7 @@ func NewQueryLabelsService(sd *model.ServiceData) *QueryLabelsService {
 	return res
 }
 
-func (q *QueryLabelsService) GenericLabelReq(ctx context.Context, query string, args ...interface{}) (chan string, error) {
+func (q *QueryLabelsService) GenericLabelReq(ctx context.Context, query string, args ...any) (chan string, error) {
 	session, err := q.Session.GetDB(ctx)
 	if err != nil {
 		return nil, err

--- a/reader/service/query_range.go
+++ b/reader/service/query_range.go
@@ -5,6 +5,7 @@ import (
 	databaseSql "database/sql"
 	"fmt"
 	"io"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -186,9 +187,7 @@ func (q *QueryRangeService) QueryVolume(ctx context.Context, query string, fromN
 	value := float64(0)
 	putData := func() {
 		metric := make(map[string]string)
-		for k, v := range lastMetric {
-			metric[k] = v
-		}
+		maps.Copy(metric, lastMetric)
 		res = append(res, QueryVolumeResult{
 			Metric: metric,
 			Value:  []any{float64(toNs / 1000000000), strconv.FormatFloat(value, 'f', -1, 32)},

--- a/reader/service/tempo_metrics.go
+++ b/reader/service/tempo_metrics.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -90,7 +91,7 @@ func (t *TempoService) MetricsQueryRange(ctx context.Context, req *model.Metrics
 		var value float64
 		byVals := make([]string, byCount)
 
-		scanArgs := make([]interface{}, 2+byCount)
+		scanArgs := make([]any, 2+byCount)
 		scanArgs[0] = &ts
 		scanArgs[1] = &value
 		for i := range byVals {
@@ -223,7 +224,7 @@ func (t *TempoService) MetricsQueryRange(ctx context.Context, req *model.Metrics
 					var spanTs int64
 					exByVals := make([]string, exByCount)
 
-					scanArgs := make([]interface{}, 4+exByCount)
+					scanArgs := make([]any, 4+exByCount)
 					scanArgs[0] = &ts
 					scanArgs[1] = &traceID
 					scanArgs[2] = &durNs
@@ -250,13 +251,7 @@ func (t *TempoService) MetricsQueryRange(ctx context.Context, req *model.Metrics
 					for i := range result {
 						var keyParts []string
 						for _, lbl := range result[i].Labels {
-							isBy := false
-							for _, byLabel := range resolvedByLabels {
-								if lbl.Key == byLabel {
-									isBy = true
-									break
-								}
-							}
+							isBy := slices.Contains(resolvedByLabels, lbl.Key)
 							if isBy {
 								keyParts = append(keyParts, lbl.Value.StringValue)
 							}
@@ -274,7 +269,7 @@ func (t *TempoService) MetricsQueryRange(ctx context.Context, req *model.Metrics
 							tsToValue[ms] = sample.Value
 						}
 
-						var exList []interface{}
+						var exList []any
 						for _, ex := range groupExemplars {
 							labels := []model.MetricsKeyValue{
 								{Key: "trace:id", Value: model.MetricsLabelValue{StringValue: ex.traceID}},
@@ -393,7 +388,7 @@ func (t *TempoService) MetricsQueryInstant(ctx context.Context, req *model.Metri
 		var value float64
 		byVals := make([]string, byCount)
 
-		scanArgs := make([]interface{}, 1+byCount)
+		scanArgs := make([]any, 1+byCount)
 		scanArgs[0] = &value
 		for i := range byVals {
 			scanArgs[1+i] = &byVals[i]
@@ -414,7 +409,7 @@ func (t *TempoService) MetricsQueryInstant(ctx context.Context, req *model.Metri
 		result = append(result, model.MetricsInstantSeries{
 			Labels:    labels,
 			Value:     value,
-			Exemplars: make([]interface{}, 0),
+			Exemplars: make([]any, 0),
 		})
 	}
 
@@ -613,7 +608,7 @@ func (t *TempoService) executeHistogramRange(
 						continue
 					}
 					bucketSec := *result[i].Labels[0].Value.DoubleValue
-					var exList []interface{}
+					var exList []any
 					for _, ex := range exemplarRows {
 						if float64(ex.bucketNs)/1e9 != bucketSec {
 							continue
@@ -697,7 +692,7 @@ func (t *TempoService) executeCompareRange(
 					{Key: row.Key, Value: model.MetricsLabelValue{StringValue: row.Val}},
 				},
 				Samples:   []model.MetricsSample{{TimestampMs: strconv.FormatInt(midpointMs, 10), Value: float64(row.SelectionCount)}},
-				Exemplars: []interface{}{},
+				Exemplars: []any{},
 			})
 		}
 		if row.BaselineCount > 0 {
@@ -707,7 +702,7 @@ func (t *TempoService) executeCompareRange(
 					{Key: row.Key, Value: model.MetricsLabelValue{StringValue: row.Val}},
 				},
 				Samples:   []model.MetricsSample{{TimestampMs: strconv.FormatInt(midpointMs, 10), Value: float64(row.BaselineCount)}},
-				Exemplars: []interface{}{},
+				Exemplars: []any{},
 			})
 		}
 	}

--- a/reader/tempo/metrics_query.go
+++ b/reader/tempo/metrics_query.go
@@ -720,20 +720,20 @@ func BuildGenericExemplarsQuery(req *GenericExemplarsRequest) (sql.ISelect, []st
 
 // CompareRequest holds parsed parameters for the compare() function.
 type CompareRequest struct {
-	FromNS          int64
-	ToNS            int64
-	BaselineFromNS  int64 // optional: explicit baseline window start (from compare() args)
-	BaselineToNS    int64 // optional: explicit baseline window end (from compare() args)
-	TracesTable string
-	AttrsTable  string
-	Distributed bool
-	OuterKeys   []string
-	OuterOps    []string
-	OuterVals   []string
-	InnerKeys   []string
-	InnerOps    []string
-	InnerVals   []string
-	TopN        int
+	FromNS         int64
+	ToNS           int64
+	BaselineFromNS int64 // optional: explicit baseline window start (from compare() args)
+	BaselineToNS   int64 // optional: explicit baseline window end (from compare() args)
+	TracesTable    string
+	AttrsTable     string
+	Distributed    bool
+	OuterKeys      []string
+	OuterOps       []string
+	OuterVals      []string
+	InnerKeys      []string
+	InnerOps       []string
+	InnerVals      []string
+	TopN           int
 }
 
 // CompareResultRow is one row from the compare() query.
@@ -843,7 +843,7 @@ func BuildCompareQuery(req *CompareRequest) (sql.ISelect, error) {
 
 	attrsSubquery := sql.NewSelect().
 		Select(sql.NewRawObject("*")).
-		From(sql.NewRawObject(req.AttrsTable+" FINAL")).
+		From(sql.NewRawObject(req.AttrsTable + " FINAL")).
 		AndWhere(ginDateWhere)
 	attrsSubWith := sql.NewWith(attrsSubquery, "attrs_sub")
 
@@ -922,8 +922,8 @@ func parseTimeValNs(s string) (int64, error) {
 		{"d", 86_400_000_000_000},
 	}
 	for _, u := range units {
-		if strings.HasSuffix(s, u.suffix) {
-			numStr := strings.TrimSuffix(s, u.suffix)
+		if before, ok := strings.CutSuffix(s, u.suffix); ok {
+			numStr := before
 			f, err := strconv.ParseFloat(numStr, 64)
 			if err != nil {
 				return 0, fmt.Errorf("invalid time value %q", s)
@@ -1013,7 +1013,7 @@ func isIntrinsicKey(key string) bool {
 	intrinsics := map[string]bool{
 		"name": true, "span:name": true, "rootName": true,
 		"rootServiceName": true,
-		"duration": true, "span:duration": true,
+		"duration":        true, "span:duration": true,
 	}
 	return intrinsics[key]
 }

--- a/reader/traceql/traceql_transpiler/clickhouse_transpiler/expression_planner_simple.go
+++ b/reader/traceql/traceql_transpiler/clickhouse_transpiler/expression_planner_simple.go
@@ -78,8 +78,8 @@ func (p *simpleExpressionPlanner) valuesV2Planner(key string) (shared.SQLRequest
 		AggregatedAttr: p.aggAttr,
 	}
 	res = &SelectValuesRequestPlanner{
-		SelectTagsPlanner: SelectTagsPlanner{Main: res},
-		Key:               key,
+		Main: res,
+		Key:  key,
 	}
 	return res, nil
 }

--- a/reader/traceql/traceql_transpiler/complex_request_processor.go
+++ b/reader/traceql/traceql_transpiler/complex_request_processor.go
@@ -18,7 +18,7 @@ func (t *ComplexRequestProcessor) Process(ctx *shared.PlannerContext,
 	from := ctx.From
 	var cachedTraceIDs []string
 	var res []model.TraceInfo
-	for i := int64(0); i < portions; i++ {
+	for i := range portions {
 		ctx.RandomFilter = shared.RandomFilter{
 			Max: int(portions),
 			I:   int(i),

--- a/reader/utils/logger/logger.go
+++ b/reader/utils/logger/logger.go
@@ -28,7 +28,7 @@ var Logger = logrus.New()
 type DbLogger struct{}
 
 /* db logger for logrus */
-func (*DbLogger) Print(v ...interface{}) {
+func (*DbLogger) Print(v ...any) {
 	if v[0] == "sql" {
 		Logger.WithFields(logrus.Fields{"module": "db", "type": "sql"}).Print(v[3])
 	}
@@ -57,7 +57,7 @@ func InitLogger() {
 		}
 
 		headers := map[string]string{}
-		for _, h := range strings.Split(config.Cloki.Setting.LOG_SETTINGS.Qryn.Headers, ";;") {
+		for h := range strings.SplitSeq(config.Cloki.Setting.LOG_SETTINGS.Qryn.Headers, ";;") {
 			pair := strings.Split(h, ":")
 			headers[pair[0]] = strings.Join(pair[1:], ":")
 		}
@@ -186,15 +186,15 @@ func configureSyslogHook() {
 	*/
 }
 
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	Logger.Info(args...)
 }
 
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	Logger.Error(args...)
 }
 
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	Logger.Debug(args...)
 }
 

--- a/reader/utils/middleware/accept_encoding.go
+++ b/reader/utils/middleware/accept_encoding.go
@@ -52,7 +52,7 @@ func acceptsGzip(h http.Header) bool {
 	var gzipQ, wildcardQ float64
 	var gzipSeen, wildcardSeen bool
 	for _, headerValue := range h.Values("Accept-Encoding") {
-		for _, element := range strings.Split(headerValue, ",") {
+		for element := range strings.SplitSeq(headerValue, ",") {
 			coding, params, _ := strings.Cut(element, ";")
 			coding = strings.TrimSpace(coding)
 			q := qValue(params)
@@ -78,7 +78,7 @@ func acceptsGzip(h http.Header) bool {
 // range are clamped to it, preserving the direction the client expressed,
 // while absent or unparseable (including NaN/Inf) weights default to 1.
 func qValue(params string) float64 {
-	for _, param := range strings.Split(params, ";") {
+	for param := range strings.SplitSeq(params, ";") {
 		name, value, ok := strings.Cut(param, "=")
 		if !ok || !strings.EqualFold(strings.TrimSpace(name), "q") {
 			continue

--- a/reader/utils/sql_select/objects.go
+++ b/reader/utils/sql_select/objects.go
@@ -19,7 +19,7 @@ func NewRawObject(val string) *RawObject {
 	}
 }
 
-func FmtRawObject(tmpl string, arg ...interface{}) *RawObject {
+func FmtRawObject(tmpl string, arg ...any) *RawObject {
 	return &RawObject{fmt.Sprintf(tmpl, arg...)}
 }
 

--- a/ruler/router/init.go
+++ b/ruler/router/init.go
@@ -96,7 +96,7 @@ func Init(cfg *clconfig.ClokiConfig, app *mux.Router) {
 		MaxSamples: cfg.Setting.SYSTEM_SETTINGS.MetricsMaxSamples,
 		Timeout:    30 * time.Second,
 	})
-	promStorage := &readerservice.CLokiQueriable{ServiceData: readermodel.ServiceData{Session: session}}
+	promStorage := &readerservice.CLokiQueriable{Session: session}
 	promMgr := ruler.NewRuleManager(ruler.NewPromEvaluator(eng, promStorage), promService, writeBack, poll)
 
 	lokiCtrl := &controller.Controller{Store: lokiService, Manager: lokiMgr}

--- a/view/static_no.go
+++ b/view/static_no.go
@@ -1,5 +1,4 @@
 //go:build !view
-// +build !view
 
 package view
 

--- a/writer/chwrapper/adapter.go
+++ b/writer/chwrapper/adapter.go
@@ -87,7 +87,7 @@ func (a *SmartDatabaseAdapter) Exec(ctx context.Context, query string, args ...a
 	return a.generalPurposeClient.Exec(ctx, query, args...)
 }
 
-func (a *SmartDatabaseAdapter) Scan(ctx context.Context, req string, args []any, dest ...interface{}) error {
+func (a *SmartDatabaseAdapter) Scan(ctx context.Context, req string, args []any, dest ...any) error {
 	if err := a.initGeneralClient(ctx); err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (a *SmartDatabaseAdapter) DropIfEmpty(ctx context.Context, name string) err
 }
 
 // GetDBExec Implement the GetDBExec method in the adapter
-func (a *SmartDatabaseAdapter) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]interface{}) error {
+func (a *SmartDatabaseAdapter) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]any) error {
 	if err := a.initGeneralClient(context.Background()); err != nil {
 		return nil
 	}
@@ -131,7 +131,7 @@ func (a *SmartDatabaseAdapter) GetDBExec(env map[string]string) func(ctx context
 }
 
 // GetFirst Implement the GetFirst method in the adapter
-func (a *SmartDatabaseAdapter) GetFirst(req string, first ...interface{}) error {
+func (a *SmartDatabaseAdapter) GetFirst(req string, first ...any) error {
 	if err := a.initGeneralClient(context.Background()); err != nil {
 		return err
 	}
@@ -192,14 +192,14 @@ func (a *SmartDatabaseAdapter) PutSetting(ctx context.Context, tp string, name s
 	return a.generalPurposeClient.PutSetting(ctx, tp, name, value)
 }
 
-func (a *SmartDatabaseAdapter) Query(ctx context.Context, query string, args ...interface{}) (driver.Rows, error) {
+func (a *SmartDatabaseAdapter) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	if err := a.initGeneralClient(ctx); err != nil {
 		return nil, err
 	}
 	return a.generalPurposeClient.Query(ctx, query, args...)
 }
 
-func (a *SmartDatabaseAdapter) QueryRow(ctx context.Context, query string, args ...interface{}) driver.Row {
+func (a *SmartDatabaseAdapter) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
 	if err := a.initGeneralClient(ctx); err != nil {
 		return nil
 	}

--- a/writer/chwrapper/general_purpose_ch_client.go
+++ b/writer/chwrapper/general_purpose_ch_client.go
@@ -20,7 +20,7 @@ type Client struct {
 
 var _ IChClient = &Client{}
 
-func (c *Client) Scan(ctx context.Context, req string, args []any, dest ...interface{}) error {
+func (c *Client) Scan(ctx context.Context, req string, args []any, dest ...any) error {
 	rows, err := c.c.Query(ctx, req, args...)
 	if err != nil {
 		return err
@@ -121,8 +121,8 @@ func (c *Client) Exec(ctx context.Context, query string, args ...any) error {
 	return c.c.Exec(ctx, query, args...)
 }
 
-func (c *Client) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]interface{}) error {
-	return func(ctx context.Context, query string, args ...[]interface{}) error {
+func (c *Client) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]any) error {
+	return func(ctx context.Context, query string, args ...[]any) error {
 		name := fmt.Sprintf("tpl_%d", rand.Uint64())
 		tpl, err := template.New(name).Parse(query)
 		if err != nil {
@@ -146,7 +146,7 @@ func (c *Client) GetDBExec(env map[string]string) func(ctx context.Context, quer
 	}
 }
 
-func (c *Client) GetFirst(req string, first ...interface{}) error {
+func (c *Client) GetFirst(req string, first ...any) error {
 	res, err := c.c.Query(context.Background(), req)
 	if err != nil {
 		return err
@@ -218,7 +218,7 @@ func (c *Client) Do(ctx context.Context, query ch.Query) error {
 	panic("implement me")
 }
 
-func (c *Client) Query(ctx context.Context, query string, args ...interface{}) (driver.Rows, error) {
+func (c *Client) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	// Call the ClickHouse Query method on the connection object with the provided query and arguments
 	rows, err := c.c.Query(ctx, query, args...)
 	if err != nil {
@@ -227,7 +227,7 @@ func (c *Client) Query(ctx context.Context, query string, args ...interface{}) (
 	return rows, nil
 }
 
-func (c *Client) QueryRow(ctx context.Context, query string, args ...interface{}) driver.Row {
+func (c *Client) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
 	// Call the QueryRow method from the underlying ClickHouse connection
 	return c.c.QueryRow(ctx, query, args...)
 }

--- a/writer/chwrapper/http_client.go
+++ b/writer/chwrapper/http_client.go
@@ -94,8 +94,8 @@ func (c *HttpChClient) executeInsert(ctx context.Context, sql string, input prot
 	defer stmt.Close()
 
 	// Insert rows
-	for row := 0; row < rowCount; row++ {
-		values := make([]interface{}, len(input))
+	for row := range rowCount {
+		values := make([]any, len(input))
 		for col, column := range input {
 			values[col] = c.getValue(column.Data, row)
 		}
@@ -113,24 +113,24 @@ type HttpFormatter interface {
 	HttpValues() any
 }
 
-func (c *HttpChClient) getValue(data interface{}, row int) interface{} {
-	value := func() interface{} {
+func (c *HttpChClient) getValue(data any, row int) any {
+	value := func() any {
 		if data == nil {
 			return nil
 		}
-		if v, ok := data.(interface{ Row(int) interface{} }); ok {
+		if v, ok := data.(interface{ Row(int) any }); ok {
 			return v.Row(row)
 		}
-		if v, ok := data.(interface{ Get(int) interface{} }); ok {
+		if v, ok := data.(interface{ Get(int) any }); ok {
 			return v.Get(row)
 		}
-		if v, ok := data.(interface{ Value(int) interface{} }); ok {
+		if v, ok := data.(interface{ Value(int) any }); ok {
 			return v.Value(row)
 		}
 
 		// Use reflection
 		rv := reflect.ValueOf(data)
-		if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+		if rv.Kind() == reflect.Pointer && !rv.IsNil() {
 			rv = rv.Elem()
 		}
 
@@ -163,7 +163,7 @@ func (c *HttpChClient) getValue(data interface{}, row int) interface{} {
 		return _v.HttpValues()
 	}
 	rv := reflect.ValueOf(value)
-	httpFormatterType := reflect.TypeOf((*HttpFormatter)(nil)).Elem()
+	httpFormatterType := reflect.TypeFor[HttpFormatter]()
 	if (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) &&
 		rv.Type().Elem().Implements(httpFormatterType) {
 		res := make([]any, rv.Len())
@@ -175,7 +175,7 @@ func (c *HttpChClient) getValue(data interface{}, row int) interface{} {
 	return value
 }
 
-func (c *HttpChClient) getRowCount(data interface{}) int {
+func (c *HttpChClient) getRowCount(data any) int {
 	if data == nil {
 		return 0
 	}
@@ -190,7 +190,7 @@ func (c *HttpChClient) getRowCount(data interface{}) int {
 
 	// Use reflection
 	rv := reflect.ValueOf(data)
-	if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+	if rv.Kind() == reflect.Pointer && !rv.IsNil() {
 		rv = rv.Elem()
 	}
 
@@ -241,14 +241,14 @@ func (c *HttpChClient) ServerVersion() (*driver.ServerVersion, error) {
 	}, nil
 }
 
-func (c *HttpChClient) GetFirst(req string, first ...interface{}) error {
+func (c *HttpChClient) GetFirst(req string, first ...any) error {
 	if c.db == nil {
 		return fmt.Errorf("connection is nil")
 	}
 	return c.db.QueryRowContext(context.Background(), req).Scan(first...)
 }
 
-func (c *HttpChClient) Scan(ctx context.Context, req string, args []any, dest ...interface{}) error {
+func (c *HttpChClient) Scan(ctx context.Context, req string, args []any, dest ...any) error {
 	if c.db == nil {
 		return fmt.Errorf("connection is nil")
 	}
@@ -294,13 +294,13 @@ func (c *HttpChClient) TableExists(ctx context.Context, name string) (bool, erro
 	return exists == 1, nil
 }
 
-func (c *HttpChClient) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]interface{}) error {
-	return func(ctx context.Context, query string, args ...[]interface{}) error {
+func (c *HttpChClient) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]any) error {
+	return func(ctx context.Context, query string, args ...[]any) error {
 		if c.db == nil {
 			return fmt.Errorf("connection is nil")
 		}
 		// Convert [][]interface{} to []interface{} if needed
-		var flatArgs []interface{}
+		var flatArgs []any
 		for _, argGroup := range args {
 			for _, arg := range argGroup {
 				flatArgs = append(flatArgs, arg)
@@ -378,7 +378,7 @@ func (c *HttpChClient) GetList(req string) ([]string, error) {
 	return arr, res.Err()
 }
 
-func (c *HttpChClient) Query(ctx context.Context, query string, args ...interface{}) (driver.Rows, error) {
+func (c *HttpChClient) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	if c.db == nil {
 		return nil, fmt.Errorf("connection is nil")
 	}
@@ -391,7 +391,7 @@ func (c *HttpChClient) Query(ctx context.Context, query string, args ...interfac
 	return &sqlRowsWrapper{rows: rows}, nil
 }
 
-func (c *HttpChClient) QueryRow(ctx context.Context, query string, args ...interface{}) driver.Row {
+func (c *HttpChClient) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
 	if c.db == nil {
 		return &errorRow{err: fmt.Errorf("connection is nil")}
 	}
@@ -417,11 +417,11 @@ func (r *sqlRowsWrapper) Next() bool {
 	return r.rows.Next()
 }
 
-func (r *sqlRowsWrapper) Scan(dest ...interface{}) error {
+func (r *sqlRowsWrapper) Scan(dest ...any) error {
 	return r.rows.Scan(dest...)
 }
 
-func (r *sqlRowsWrapper) ScanStruct(dest interface{}) error {
+func (r *sqlRowsWrapper) ScanStruct(dest any) error {
 	// This is a simplified implementation - you might need to use reflection
 	// or a third-party library for proper struct scanning
 	return fmt.Errorf("ScanStruct not implemented for HTTP client")
@@ -460,7 +460,7 @@ func (r *sqlRowsWrapper) HasData() bool {
 	return true
 }
 
-func (r *sqlRowsWrapper) Totals(dest ...interface{}) error {
+func (r *sqlRowsWrapper) Totals(dest ...any) error {
 	// HTTP interface doesn't support totals
 	return fmt.Errorf("totals not supported in HTTP interface")
 }
@@ -500,11 +500,11 @@ type sqlRowWrapper struct {
 	row *sql.Row
 }
 
-func (r *sqlRowWrapper) Scan(dest ...interface{}) error {
+func (r *sqlRowWrapper) Scan(dest ...any) error {
 	return r.row.Scan(dest...)
 }
 
-func (r *sqlRowWrapper) ScanStruct(dest interface{}) error {
+func (r *sqlRowWrapper) ScanStruct(dest any) error {
 	// This is a simplified implementation
 	return fmt.Errorf("ScanStruct not implemented for HTTP client")
 }
@@ -519,11 +519,11 @@ type errorRow struct {
 	err error
 }
 
-func (r *errorRow) Scan(dest ...interface{}) error {
+func (r *errorRow) Scan(dest ...any) error {
 	return r.err
 }
 
-func (r *errorRow) ScanStruct(dest interface{}) error {
+func (r *errorRow) ScanStruct(dest any) error {
 	return r.err
 }
 

--- a/writer/chwrapper/insert_ch_client.go
+++ b/writer/chwrapper/insert_ch_client.go
@@ -18,12 +18,12 @@ type InsertCHWrapper struct {
 
 var _ IChClient = &InsertCHWrapper{}
 
-func (c *InsertCHWrapper) Query(ctx context.Context, query string, args ...interface{}) (driver.Rows, error) {
+func (c *InsertCHWrapper) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (c *InsertCHWrapper) QueryRow(ctx context.Context, query string, args ...interface{}) driver.Row {
+func (c *InsertCHWrapper) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
 	//TODO implement me
 	panic("implement me")
 }
@@ -60,7 +60,7 @@ func (c *InsertCHWrapper) Exec(ctx context.Context, query string, args ...any) e
 	return errors.New("not implemented")
 }
 
-func (c *InsertCHWrapper) Scan(ctx context.Context, req string, args []any, dest ...interface{}) error {
+func (c *InsertCHWrapper) Scan(ctx context.Context, req string, args []any, dest ...any) error {
 	return errors.New("not implemented")
 }
 
@@ -72,8 +72,8 @@ func (c *InsertCHWrapper) TableExists(ctx context.Context, name string) (bool, e
 	return false, errors.New("not implemented")
 }
 
-func (c *InsertCHWrapper) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]interface{}) error {
-	return func(ctx context.Context, query string, args ...[]interface{}) error {
+func (c *InsertCHWrapper) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]any) error {
+	return func(ctx context.Context, query string, args ...[]any) error {
 		return errors.New("not implemented")
 	}
 }
@@ -90,7 +90,7 @@ func (c *InsertCHWrapper) PutSetting(ctx context.Context, tp string, name string
 	return errors.New("not implemented")
 }
 
-func (c *InsertCHWrapper) GetFirst(req string, first ...interface{}) error {
+func (c *InsertCHWrapper) GetFirst(req string, first ...any) error {
 	return errors.New("not implemented")
 }
 

--- a/writer/chwrapper/types.go
+++ b/writer/chwrapper/types.go
@@ -16,17 +16,17 @@ type IChClient interface {
 
 	// This should be implemented in the general purpose client and return error in the insert one
 	Exec(ctx context.Context, query string, args ...any) error
-	Scan(ctx context.Context, req string, args []any, dest ...interface{}) error
+	Scan(ctx context.Context, req string, args []any, dest ...any) error
 	DropIfEmpty(ctx context.Context, name string) error
 	TableExists(ctx context.Context, name string) (bool, error)
-	GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]interface{}) error
+	GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]any) error
 	GetVersion(ctx context.Context, k uint64) (uint64, error)
 	GetSetting(ctx context.Context, tp string, name string) (string, error)
 	PutSetting(ctx context.Context, tp string, name string, value string) error
-	GetFirst(req string, first ...interface{}) error
+	GetFirst(req string, first ...any) error
 	GetList(req string) ([]string, error)
-	Query(ctx context.Context, query string, args ...interface{}) (driver.Rows, error)
-	QueryRow(ctx context.Context, query string, args ...interface{}) driver.Row
+	Query(ctx context.Context, query string, args ...any) (driver.Rows, error)
+	QueryRow(ctx context.Context, query string, args ...any) driver.Row
 	// This one is shared by both
 	Close() error
 }

--- a/writer/controller/elastic.go
+++ b/writer/controller/elastic.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -28,7 +29,7 @@ func TargetDocV2(cfg MiddlewareConfig) func(w http.ResponseWriter, r *http.Reque
 				return _ctx, nil
 			}),
 			withSimpleParser("*", Parser(unmarshal.ElasticDocUnmarshalV2)),
-			withOkStatusAndJSONBody(200, map[string]interface{}{
+			withOkStatusAndJSONBody(200, map[string]any{
 				"took":   0,
 				"errors": false,
 			}))...)
@@ -74,7 +75,7 @@ func TargetBulkV2(cfg MiddlewareConfig) func(w http.ResponseWriter, r *http.Requ
 			// Set response status code
 			w.WriteHeader(http.StatusOK)
 			// Prepare JSON response data
-			responseData := map[string]interface{}{
+			responseData := map[string]any{
 				"took":   0,
 				"errors": false,
 			}
@@ -137,9 +138,7 @@ func getRequestParams(r *http.Request) map[string]string {
 	params := make(map[string]string)
 	ctx := r.Context()
 	if ctxParams, ok := ctx.Value(utils.ContextKeyParams).(map[string]string); ok {
-		for key, value := range ctxParams {
-			params[key] = value
-		}
+		maps.Copy(params, ctxParams)
 	}
 	return params
 }

--- a/writer/controller/middleware.go
+++ b/writer/controller/middleware.go
@@ -79,7 +79,7 @@ func withOkStatusAndBody(status int, body []byte) BuildOption {
 	}
 }
 
-func withOkStatusAndJSONBody(status int, body map[string]interface{}) BuildOption {
+func withOkStatusAndJSONBody(status int, body map[string]any) BuildOption {
 	return func(ctx *PusherCtx) *PusherCtx {
 		ctx.PostRequest = append(ctx.PostRequest, func(w http.ResponseWriter, r *http.Request) error {
 			// Marshal the JSON body

--- a/writer/grpc/codec_test.go
+++ b/writer/grpc/codec_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/metrico/qryn/v5/writer/model"
-	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
@@ -90,7 +90,7 @@ func largeTraceRequest() *coltracepb.ExportTraceServiceRequest {
 	bigValue := strings.Repeat("x", valueSize)
 
 	spans := make([]*tracev1.Span, spanCount)
-	for i := 0; i < spanCount; i++ {
+	for i := range spanCount {
 		spans[i] = &tracev1.Span{
 			Name:    "op",
 			TraceId: []byte("0123456789abcdef"),

--- a/writer/http/http.go
+++ b/writer/http/http.go
@@ -82,8 +82,8 @@ func matchPath(routePath, requestPath string) (map[string]string, bool) {
 
 	params := make(map[string]string)
 	for i, part := range routeParts {
-		if strings.HasPrefix(part, ":") {
-			params[strings.TrimPrefix(part, ":")] = requestParts[i]
+		if after, ok := strings.CutPrefix(part, ":"); ok {
+			params[after] = requestParts[i]
 		} else if part != requestParts[i] {
 			return nil, false
 		}

--- a/writer/model/user.go
+++ b/writer/model/user.go
@@ -218,7 +218,7 @@ type UserFileDownload struct {
 type UserParameterRequest struct {
 	// in: formData
 	// swagger:file
-	File interface{}
+	File any
 }
 
 //swagger:model TableUserList

--- a/writer/pattern/clustering/pattern.go
+++ b/writer/pattern/clustering/pattern.go
@@ -1,6 +1,7 @@
 package clustering
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -306,8 +307,8 @@ func (r *LogClusterRow) match(l *LogLine) bool {
 func (r *LogClusterRow) cleanup() {
 	r.m.Lock()
 	defer r.m.Unlock()
-	for i := len(r.clusters) - 1; i >= 0; i-- {
-		if time.Since(r.clusters[i].lastFlush) > time.Minute*5 {
+	for i, v := range slices.Backward(r.clusters) {
+		if time.Since(v.lastFlush) > time.Minute*5 {
 			copy(r.clusters[i:], r.clusters[i+1:])
 			r.clusters = r.clusters[:len(r.clusters)-1]
 		}

--- a/writer/pattern/controller/controller.go
+++ b/writer/pattern/controller/controller.go
@@ -27,7 +27,7 @@ var (
 
 var (
 	tokPool     = sync.Pool{}
-	tokPoolSize int32
+	tokPoolSize atomic.Int32
 	done        chan struct{}
 )
 
@@ -49,19 +49,19 @@ func skipLine() bool {
 func getToks() []clustering.Token {
 	toks := tokPool.Get()
 	if toks != nil {
-		atomic.AddInt32(&tokPoolSize, -1)
+		tokPoolSize.Add(-1)
 		return toks.([]clustering.Token)
 	}
 	return make([]clustering.Token, 0, 150)
 }
 
 func putToks(toks []clustering.Token) {
-	if atomic.LoadInt32(&tokPoolSize) > 100 {
+	if tokPoolSize.Load() > 100 {
 		return
 	}
 	toks = toks[:0]
 	tokPool.Put(toks)
-	atomic.AddInt32(&tokPoolSize, 1)
+	tokPoolSize.Add(1)
 }
 
 func ClusterLines(lines []string, fingerprints []uint64, timestamps []int64) {

--- a/writer/service/generic_insert.go
+++ b/writer/service/generic_insert.go
@@ -35,7 +35,7 @@ const (
 )
 
 type InsertRequest interface {
-	Rows() []interface{}
+	Rows() []any
 	Response() chan error
 }
 
@@ -102,7 +102,7 @@ type InsertServiceV2 struct {
 
 	client chwrapper.IChClient
 
-	state int32
+	state atomic.Int32
 }
 
 func (svc *InsertServiceV2) PlanFlush() {
@@ -145,7 +145,7 @@ func (svc *InsertServiceV2) Ping() (time.Time, error) {
 }
 
 func (svc *InsertServiceV2) GetState(insertMode int) int {
-	return int(atomic.LoadInt32(&svc.state))
+	return int(svc.state.Load())
 }
 
 func (svc *InsertServiceV2) Run() {
@@ -244,7 +244,7 @@ func (svc *InsertServiceV2) swapBuffers() (*requestPortion, error) {
 }
 
 func (svc *InsertServiceV2) setState(state int) {
-	atomic.StoreInt32(&svc.state, int32(state))
+	svc.state.Store(int32(state))
 }
 
 func (svc *InsertServiceV2) fetchLoopIteration() {
@@ -575,16 +575,12 @@ func (svc *InsertServiceV2Multimodal) Run() {
 	}
 	wg := sync.WaitGroup{}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		svc.SyncService.Run()
-	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	})
+	wg.Go(func() {
 		svc.AsyncService.Run()
-	}()
+	})
 	logger.Info("created service")
 	svc.running = true
 	svc.mtx.Unlock()

--- a/writer/service/registry/static.go
+++ b/writer/service/registry/static.go
@@ -35,14 +35,15 @@ func mapToSlice(m map[string]service.IInsertServiceV2) []service.IInsertServiceV
 }
 
 func NewStaticServiceRegistry(opts StaticServiceRegistryOpts) ServiceRegistry {
-	res := staticServiceRegistry{}
-	res.TimeSeriesSvcs = mapToSlice(opts.TimeSeriesSvcs)
-	res.SamplesSvcs = mapToSlice(opts.SamplesSvcs)
-	res.MetricSvcs = mapToSlice(opts.MetricSvcs)
-	res.TempoSamplesSvcs = mapToSlice(opts.TempoSamplesSvcs)
-	res.TempoTagsSvcs = mapToSlice(opts.TempoTagsSvcs)
-	res.ProfileInsertSvcs = mapToSlice(opts.ProfileInsertSvcs)
-	res.PatternInsertSvcs = mapToSlice(opts.PatternInsertSvcs)
+	res := staticServiceRegistry{
+		TimeSeriesSvcs:    mapToSlice(opts.TimeSeriesSvcs),
+		SamplesSvcs:       mapToSlice(opts.SamplesSvcs),
+		MetricSvcs:        mapToSlice(opts.MetricSvcs),
+		TempoSamplesSvcs:  mapToSlice(opts.TempoSamplesSvcs),
+		TempoTagsSvcs:     mapToSlice(opts.TempoTagsSvcs),
+		ProfileInsertSvcs: mapToSlice(opts.ProfileInsertSvcs),
+		PatternInsertSvcs: mapToSlice(opts.PatternInsertSvcs),
+	}
 	return &res
 }
 

--- a/writer/utils/errors/error.go
+++ b/writer/utils/errors/error.go
@@ -66,8 +66,7 @@ func New429Error(msg string) IQrynError {
 
 // NewUnmarshalError creates a new instance of UnmarshalError.
 func NewUnmarshalError(err error) IQrynError {
-	var target IQrynError
-	if errors.As(err, &target) {
+	if target, ok := errors.AsType[IQrynError](err); ok {
 		return target
 	}
 	return &UnMarshalError{

--- a/writer/utils/logger/logger.go
+++ b/writer/utils/logger/logger.go
@@ -38,7 +38,7 @@ var Logger = logrus.New()
 type DbLogger struct{}
 
 /* db logger for logrus */
-func (*DbLogger) Print(v ...interface{}) {
+func (*DbLogger) Print(v ...any) {
 	if v[0] == "sql" {
 		Logger.WithFields(logrus.Fields{"module": "db", "type": "sql"}).Print(v[3])
 	}
@@ -66,7 +66,7 @@ func InitLogger() {
 		}
 
 		headers := map[string]string{}
-		for _, h := range strings.Split(config.Cloki.Setting.LOG_SETTINGS.Qryn.Headers, ";;") {
+		for h := range strings.SplitSeq(config.Cloki.Setting.LOG_SETTINGS.Qryn.Headers, ";;") {
 			pair := strings.Split(h, ":")
 			headers[pair[0]] = strings.Join(pair[1:], ":")
 		}
@@ -194,19 +194,19 @@ func configureSyslogHook() {
 	*/
 }
 
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	Logger.Info(args...)
 }
 
-func Warning(args ...interface{}) {
+func Warning(args ...any) {
 	Logger.Warning(args...)
 }
 
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	Logger.Error(args...)
 }
 
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	Logger.Debug(args...)
 }
 

--- a/writer/utils/logger/logger_race_test.go
+++ b/writer/utils/logger/logger_race_test.go
@@ -19,9 +19,9 @@ func TestLoggerRaceCond(t *testing.T) {
 	qrynFmt.Run()
 	Logger.SetFormatter(qrynFmt)
 	g := errgroup.Group{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		g.Go(func() error {
-			for j := 0; j < 100000; j++ {
+			for range 100000 {
 				Logger.Info("a", "B", fmt.Errorf("aaaa"))
 			}
 			return nil

--- a/writer/utils/stat/stat.go
+++ b/writer/utils/stat/stat.go
@@ -1,6 +1,7 @@
 package stat
 
 import (
+	"maps"
 	"math"
 	"regexp"
 	"strings"
@@ -17,7 +18,7 @@ const timeSpanSec = 30
 
 var sentMetrics = func() []map[string]int64 {
 	res := make([]map[string]int64, timeSpanSec+2)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		res[i] = make(map[string]int64, timeSpanSec+2)
 	}
 	return res
@@ -133,9 +134,7 @@ func getRate() map[string]int64 {
 		}
 	}
 
-	for k, v := range counters {
-		res[k] = v
-	}
+	maps.Copy(res, counters)
 	return res
 }
 

--- a/writer/utils/unmarshal/builder.go
+++ b/writer/utils/unmarshal/builder.go
@@ -49,7 +49,7 @@ type ParsingFunction func(ctx context.Context, body io.Reader,
 type ParserCtx struct {
 	bodyReader io.Reader
 	bodyBuffer []byte
-	bodyObject interface{}
+	bodyObject any
 	fpCache    numbercache.ICache[uint64]
 	ctx        context.Context
 	ctxMap     map[utils.ContextKey]string

--- a/writer/utils/unmarshal/datadog_metrics_json.go
+++ b/writer/utils/unmarshal/datadog_metrics_json.go
@@ -17,7 +17,7 @@ type datadogMetricsRequestDec struct {
 	tsNs   []int64
 	values []float64
 
-	path []interface{}
+	path []any
 
 	onEntries onEntriesHandler
 }
@@ -144,17 +144,18 @@ func (d *datadogMetricsRequestDec) WrapError(err error) error {
 		return errors.NewUnmarshalError(err)
 		//return err
 	}
-	path := ""
+	var path strings.Builder
 	for _, i := range d.path {
 		switch i := i.(type) {
 		case string:
-			path += "." + i
+			path.WriteString(".")
+			path.WriteString(i)
 		case *int:
-			path += "." + fmt.Sprintf("%d", *(i))
+			fmt.Fprintf(&path, ".%d", *i)
 		}
 	}
 
-	return errors.NewUnmarshalError(fmt.Errorf("json error path: %s; error: %s", path, err.Error()))
+	return errors.NewUnmarshalError(fmt.Errorf("json error path: %s; error: %s", path.String(), err.Error()))
 }
 
 var UnmarshallDatadogMetricsV2JSONV2 = Build(

--- a/writer/utils/unmarshal/go_pprof.go
+++ b/writer/utils/unmarshal/go_pprof.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,7 +45,7 @@ type ProfileIR struct {
 	TimeStampNao     int64
 	Payload          *bytes.Buffer
 	PayloadType      PayloadType
-	ValueAggregation interface{}
+	ValueAggregation any
 	Profile          *pprof_proto.Profile
 }
 
@@ -328,8 +329,8 @@ func Parse(data *bytes.Buffer) ([]ProfileIR, error) {
 		ValueAggregation: valueAggregates,
 		Type:             profileTypeInfo,
 		Profile:          pProfData,
+		Payload:          new(bytes.Buffer),
 	}
-	profile.Payload = new(bytes.Buffer)
 	pProfData.WriteUncompressed(profile.Payload)
 	// Append the profile to the result
 	profiles = append(profiles, profile)
@@ -361,8 +362,7 @@ func postProcessProf(profile *pprof_proto.Profile) ([]*model.Function, []*profTr
 	}
 	for _, sample := range profile.Sample {
 		parentId := uint64(0)
-		for i := len(sample.Location) - 1; i >= 0; i-- {
-			loc := sample.Location[i]
+		for i, loc := range slices.Backward(sample.Location) {
 			name := "n/a"
 			if len(loc.Line) > 0 {
 				name = loc.Line[0].Function.Name

--- a/writer/utils/unmarshal/otlp_metrics.go
+++ b/writer/utils/unmarshal/otlp_metrics.go
@@ -3,9 +3,12 @@ package unmarshal
 import (
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/metrico/qryn/v5/writer/model"
 	otlpcommon "go.opentelemetry.io/proto/otlp/common/v1"
@@ -28,10 +31,8 @@ type OTLPMetricsStats struct {
 
 func (s *OTLPMetricsStats) reject(count int, reason string) {
 	s.rejected += int64(count)
-	for _, r := range s.reasons {
-		if r == reason {
-			return
-		}
+	if slices.Contains(s.reasons, reason) {
+		return
 	}
 	if len(s.reasons) < maxRejectionReasons {
 		s.reasons = append(s.reasons, reason)
@@ -53,11 +54,13 @@ func (s *OTLPMetricsStats) ErrorMessage() string {
 	case 1:
 		return s.reasons[0]
 	}
-	msg := s.reasons[0]
+	var msg strings.Builder
+	msg.WriteString(s.reasons[0])
 	for _, r := range s.reasons[1:] {
-		msg += "; " + r
+		msg.WriteString("; ")
+		msg.WriteString(r)
 	}
-	return msg
+	return msg.String()
 }
 
 // identifyingResourceAttrs are the resource attributes that become the job and
@@ -108,11 +111,13 @@ func mergeSanitizedAttrs(dst map[string]string, prefix string, attrs []*otlpcomm
 		if len(entries) > 1 {
 			sort.Slice(entries, func(i, j int) bool { return entries[i][0] < entries[j][0] })
 		}
-		val := entries[0][1]
+		var val strings.Builder
+		val.WriteString(entries[0][1])
 		for _, e := range entries[1:] {
-			val += ";" + e[1]
+			val.WriteString(";")
+			val.WriteString(e[1])
 		}
-		dst[key] = val
+		dst[key] = val.String()
 	}
 }
 
@@ -497,9 +502,7 @@ func (d *otlpMetricsDec) emitTargetInfo(rs *resourceScope) error {
 		return nil
 	}
 	merged := make(map[string]string, len(rs.targetAttrs)+3)
-	for k, v := range rs.targetAttrs {
-		merged[k] = v
-	}
+	maps.Copy(merged, rs.targetAttrs)
 	merged["__name__"] = "target_info"
 	if rs.job != "" {
 		merged["job"] = rs.job

--- a/writer/utils/unmarshal/otlp_profile.go
+++ b/writer/utils/unmarshal/otlp_profile.go
@@ -3,11 +3,12 @@ package unmarshal
 import (
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 
 	"github.com/go-faster/city"
-	"github.com/metrico/qryn/v5/writer/model"
 	sharedotlp "github.com/metrico/qryn/v5/shared/otlp"
+	"github.com/metrico/qryn/v5/writer/model"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/pprofile/pprofileotlp"
@@ -42,7 +43,7 @@ func sortedInt32Keys(m map[int32]struct{}) []int32 {
 	for k := range m {
 		out = append(out, k)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	slices.Sort(out)
 	return out
 }
 

--- a/writer/utils/unmarshal/otlp_profile_test.go
+++ b/writer/utils/unmarshal/otlp_profile_test.go
@@ -199,10 +199,10 @@ func TestExtractOTLPMeta(t *testing.T) {
 	p := sp.Profiles().AppendEmpty()
 	p.SetTime(pcommon.Timestamp(1_700_000_000_000_000_000))
 	p.SetDurationNano(5_000_000_000)
-	p.SampleType().SetTypeStrindex(1)  // "cpu"
-	p.SampleType().SetUnitStrindex(2)  // "nanoseconds"
-	p.PeriodType().SetTypeStrindex(1)  // "cpu"
-	p.PeriodType().SetUnitStrindex(2)  // "nanoseconds"
+	p.SampleType().SetTypeStrindex(1) // "cpu"
+	p.SampleType().SetUnitStrindex(2) // "nanoseconds"
+	p.PeriodType().SetTypeStrindex(1) // "cpu"
+	p.PeriodType().SetUnitStrindex(2) // "nanoseconds"
 
 	m := extractOTLPMeta(rp.Resource(), sp.Scope(), p, dict)
 
@@ -514,11 +514,11 @@ func TestSliceOTLPProfilePrunesAndRoundTrips(t *testing.T) {
 		a.SetUnitStrindex(unit)
 		a.Value().SetStr(val)
 	}
-	mkAttr(7, 8, "loc-attr")     // 0
-	mkAttr(7, 8, "map-attr")     // 1
-	mkAttr(7, 8, "prof-attr")    // 2
-	mkAttr(7, 8, "sample-attr")  // 3
-	mkAttr(9, 9, "decoy-attr")   // 4 (unreferenced)
+	mkAttr(7, 8, "loc-attr")    // 0
+	mkAttr(7, 8, "map-attr")    // 1
+	mkAttr(7, 8, "prof-attr")   // 2
+	mkAttr(7, 8, "sample-attr") // 3
+	mkAttr(9, 9, "decoy-attr")  // 4 (unreferenced)
 
 	// mappings: m0=lib.so w/ attr1, m1=decoy
 	m0 := dict.MappingTable().AppendEmpty()

--- a/writer/utils/unmarshal/otlplogs.go
+++ b/writer/utils/unmarshal/otlplogs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 	"regexp"
 	"strconv"
 	"time"
@@ -36,12 +37,8 @@ func (e *otlpLogDec) Decode() error {
 				var labels [][]string
 				// Merge resource and scope attributes
 				attrsMap := make(map[string]string)
-				for k, v := range resourceAttrs {
-					attrsMap[k] = v
-				}
-				for k, v := range scopeAttrs {
-					attrsMap[k] = v
-				}
+				maps.Copy(attrsMap, resourceAttrs)
+				maps.Copy(attrsMap, scopeAttrs)
 				// Extract log record attributes
 				e.initAttributesMap(logRecord.Attributes, "", &attrsMap)
 

--- a/writer/utils/unmarshal/otlplogs_grpc_test.go
+++ b/writer/utils/unmarshal/otlplogs_grpc_test.go
@@ -2,6 +2,7 @@ package unmarshal
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 	"unsafe"
@@ -71,10 +72,5 @@ func collectMessages(t *testing.T, ld *logsv1.LogsData) []string {
 }
 
 func containsMessage(messages []string, want string) bool {
-	for _, m := range messages {
-		if m == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(messages, want)
 }

--- a/writer/utils/unmarshal/zipkin_json.go
+++ b/writer/utils/unmarshal/zipkin_json.go
@@ -224,7 +224,7 @@ func (z *zipkinDecoderV2) decodeHexStr(hexStr []byte, leng int) ([]byte, error) 
 	}
 	if len(hexStr) < leng {
 		prefix := make([]byte, leng)
-		for i := 0; i < leng; i++ {
+		for i := range leng {
 			prefix[i] = '0'
 		}
 		copy(prefix[leng-len(hexStr):], hexStr)


### PR DESCRIPTION
Go 1.27 moved the gopls modernize analyzers into the toolchain, so `go fix`
now rewrites constructs that gained stdlib replacements over the last few
releases. One pass over the tree, so this churn does not land in feature
diffs later.

Commands: `go fix ./...`, then `gofmt -w .` (go fix does not reformat after
itself), then `go build ./...` and `go test ./...` — both exit 0, 28 packages
ok. Re-running `go fix -json ./...` afterwards confirms nothing actionable is
left.

171 diagnostics in handwritten code, all but five applied. The other 106 ar
in generated `.pb.go` files, untouched here.

| Analyzer | n | Change |
| --- | ---: | --- |
| `any` | 101 | `interface{}` to `any` |
| `embedlit` | 13 | Promoted fields set directly in composite literals |
| `mapsloop` | 9 | Copy loop to `maps.Copy` |
| `rangeint` | 8 | `for i := 0; i < n; i++` to `for i := range n` |
| `inline` | 5 | Call inlinable wrappers directly; 2 need type inference the tool lacks |
| `slicescontains` | 5 | Scan loop to `slices.Contains` |
| `stringsseq` | 4 | `range strings.Split` to `strings.SplitSeq` |
| `slicesbackward` | 4 | Reverse index loop to `range slices.Backward` |
| `minmax` | 3 | `math.Min`/`math.Max` and if-else to the builtins |
| `stringsbuilder` | 3 | `+=` accumulation to `strings.Builder` |
| `newexpr` | 3 | Left as is, see below |
| `atomictypes` | 2 | `atomic.AddInt32(&x, …)` to `atomic.Int32` |
| `forvar` | 2 | Drop the `x := x` loop copy, unneeded since 1.22 |
| `stringscutprefix` | 2 | `HasPrefix`+slice to `strings.CutPrefix` |
| `waitgroupgo` | 2 | `wg.Add(1)` + `go func()` to `wg.Go` |
| `errorsastype` | 1 | `errors.As` to `errors.AsType[T]` |
| `plusbuild` | 1 | Drop `// +build`, `//go:build` covers it |
| `reflecttypefor` | 1 | `reflect.TypeOf((*T)(nil)).Elem()` to `reflect.TypeFor[T]()` |
| `slicessort` | 1 | `sort.Slice` with a plain less func to `slices.Sort` |
| `stringscut` | 1 | `strings.Index` + two slices to `strings.Cut` |

Not everything here is straight `go fix` output. Three hand edits on top:

- **Layout in 5 files.** The rewrites leave a closing brace on the value line
  and blank lines where code was removed. gofmt does not fix either.
- **Reverted `newexpr` in 2 files.** It stamps the helper `//go:fix inline`,
  which is an instruction for a later pass, and it converted only one of
  `float64p`'s two calls, since `new(20)` is a `*int`.
- **`strings.Builder` in 2 files.** `stringsbuilder` emitted
  `b.WriteString("; " + r)`, concatenating right back. Split into two writes,
  and one became `fmt.Fprintf(&path, ".%d", *i)`.