### PR TITLE
all: switch to math/rand/v2

### DIFF
--- a/ctrl/qryn/maintenance/update.go
+++ b/ctrl/qryn/maintenance/update.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	rand2 "math/rand"
+	"math/rand/v2"
 	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/metrico/qryn/v5/ctrl/logger"
@@ -129,7 +128,6 @@ func getSQLFile(strContents string) ([]string, error) {
 }
 
 func getDBExec(db clickhouse.Conn, env map[string]string, logger logger.ILogger) func(query string, args ...[]interface{}) error {
-	rand := rand2.New(rand2.NewSource(time.Now().UnixNano()))
 	return func(query string, args ...[]interface{}) error {
 		name := fmt.Sprintf("tpl_%d", rand.Uint64())
 		tpl, err := template.New(name).Parse(query)

--- a/reader/promql/promql_transpiler/optimizer/vector_agg.go
+++ b/reader/promql/promql_transpiler/optimizer/vector_agg.go
@@ -2,7 +2,7 @@ package optimizer
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
 	"github.com/metrico/qryn/v5/reader/promql/promql_transpiler/planner"
@@ -82,7 +82,7 @@ func (v *Aggregate) aggregate(fn string) prom_parser.Expr {
 		p.Main = planner.NewInstantVectorPlanner(&fp)
 	}
 
-	metricName := fmt.Sprintf("__metric_subst__%d", rand.Int63())
+	metricName := fmt.Sprintf("__metric_subst__%d", rand.Int64())
 	v.gExpr.Substitutes[metricName] = &promql_parser.Substitute{
 		MetricName: metricName,
 		Node:       v.expr,

--- a/reader/promql/promql_transpiler/optimizer/vector_range.go
+++ b/reader/promql/promql_transpiler/optimizer/vector_range.go
@@ -2,7 +2,7 @@ package optimizer
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 
 	"github.com/metrico/qryn/v5/reader/logql/logql_transpiler/clickhouse_planner"
@@ -104,7 +104,7 @@ func (v *VectorRange) fpPlanner() shared.SQLRequestPlanner {
 // substitute swaps the call out for a synthetic vector selector and registers
 // the planner that produces it.
 func (v *VectorRange) substitute(p shared.SQLRequestPlanner) prom_parser.Expr {
-	metricName := fmt.Sprintf("__metric_subst__%d", rand.Int63())
+	metricName := fmt.Sprintf("__metric_subst__%d", rand.Int64())
 	v.gExpr.Substitutes[metricName] = &promql_parser.Substitute{
 		MetricName: metricName,
 		Node:       v.expr,

--- a/reader/registry/static.go
+++ b/reader/registry/static.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -12,7 +12,6 @@ import (
 
 type staticDBRegistry struct {
 	databases    []*model.DataDatabasesMap
-	rand         *rand.Rand
 	mtx          sync.Mutex
 	lastPingTime time.Time
 }
@@ -21,7 +20,6 @@ var _ model.IDBRegistry = &staticDBRegistry{}
 
 func NewStaticDBRegistry(databases map[string]*model.DataDatabasesMap) model.IDBRegistry {
 	res := staticDBRegistry{
-		rand:         rand.New(rand.NewSource(time.Now().UnixNano())),
 		lastPingTime: time.Now(),
 	}
 	for _, d := range databases {
@@ -33,7 +31,7 @@ func NewStaticDBRegistry(databases map[string]*model.DataDatabasesMap) model.IDB
 func (s *staticDBRegistry) GetDB(ctx context.Context) (*model.DataDatabasesMap, error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	idx := s.rand.Intn(len(s.databases))
+	idx := rand.IntN(len(s.databases))
 	return s.databases[idx], nil
 }
 
@@ -51,7 +49,6 @@ func (s *staticDBRegistry) Stop() {
 	}
 	s.databases = nil
 	s.lastPingTime = time.Time{}
-	s.rand = nil
 }
 
 func (s *staticDBRegistry) Ping() error {

--- a/reader/service/prom_queryable.go
+++ b/reader/service/prom_queryable.go
@@ -8,7 +8,6 @@ import (
 	"github.com/metrico/qryn/v5/reader/config"
 	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
 	"github.com/prometheus/prometheus/util/annotations"
-	"math/rand"
 	"slices"
 	"sort"
 	"strconv"
@@ -78,16 +77,12 @@ func (s *StatsStore) AsMap() map[string]float64 {
 
 type CLokiQueriable struct {
 	model.ServiceData
-	random *rand.Rand
-	Ctx    context.Context
-	Stats  *StatsStore
-	Expr   *promql_parser.Expr
+	Ctx   context.Context
+	Stats *StatsStore
+	Expr  *promql_parser.Expr
 }
 
 func (c *CLokiQueriable) Querier(mint, maxt int64) (storage.Querier, error) {
-	if c.random == nil {
-		c.random = rand.New(rand.NewSource(time.Now().UnixNano()))
-	}
 	db, err := c.ServiceData.Session.GetDB(c.Ctx)
 	if err != nil {
 		return nil, err
@@ -102,7 +97,6 @@ func (c *CLokiQueriable) Querier(mint, maxt int64) (storage.Querier, error) {
 func (c *CLokiQueriable) SetOidAndDB(ctx context.Context, expr *promql_parser.Expr) *CLokiQueriable {
 	return &CLokiQueriable{
 		ServiceData: c.ServiceData,
-		random:      c.random,
 		Ctx:         ctx,
 		Expr:        expr,
 	}

--- a/writer/chwrapper/general_purpose_ch_client.go
+++ b/writer/chwrapper/general_purpose_ch_client.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	rand2 "math/rand"
+	"math/rand/v2"
 	"strconv"
 	"text/template"
-	"time"
 
 	"github.com/ClickHouse/ch-go"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -123,7 +122,6 @@ func (c *Client) Exec(ctx context.Context, query string, args ...any) error {
 }
 
 func (c *Client) GetDBExec(env map[string]string) func(ctx context.Context, query string, args ...[]interface{}) error {
-	rand := rand2.New(rand2.NewSource(time.Now().UnixNano()))
 	return func(ctx context.Context, query string, args ...[]interface{}) error {
 		name := fmt.Sprintf("tpl_%d", rand.Uint64())
 		tpl, err := template.New(name).Parse(query)

--- a/writer/pattern/controller/controller.go
+++ b/writer/pattern/controller/controller.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,8 +28,6 @@ var (
 var (
 	tokPool     = sync.Pool{}
 	tokPoolSize int32
-	random      *rand.Rand
-	mtx         sync.Mutex
 	done        chan struct{}
 )
 
@@ -45,9 +43,7 @@ func skipLine() bool {
 	if config.Cloki.Setting.DRILLDOWN_SETTINGS.LogPatternsDownsampling == 1 {
 		return false
 	}
-	mtx.Lock()
-	defer mtx.Unlock()
-	return random.Float64() < (1 - config.Cloki.Setting.DRILLDOWN_SETTINGS.LogPatternsDownsampling)
+	return rand.Float64() < (1 - config.Cloki.Setting.DRILLDOWN_SETTINGS.LogPatternsDownsampling)
 }
 
 func getToks() []clustering.Token {

--- a/writer/service/generic_insert.go
+++ b/writer/service/generic_insert.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -353,7 +353,6 @@ type InsertServiceV2RoundRobin struct {
 	running bool
 
 	services []*InsertServiceV2
-	rand     *rand.Rand
 	mtx      sync.Mutex
 }
 
@@ -403,7 +402,6 @@ func (svc *InsertServiceV2RoundRobin) init() {
 	}
 	logger.Info(fmt.Sprintf("creating %d services", svc.svcNum))
 	svc.services = make([]*InsertServiceV2, svc.svcNum)
-	svc.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := range svc.services {
 		svc.services[i] = &InsertServiceV2{
 			ID:             fmt.Sprintf("%s-%s-%v", svc.DatabaseNode.Node, svc.insertRequest, svc.AsyncInsert),
@@ -469,9 +467,7 @@ func (svc *InsertServiceV2RoundRobin) Request(req helpers.SizeGetter, insertMode
 			idleSvcs = append(idleSvcs, _svc)
 		}
 	}
-	svc.mtx.Lock()
-	randomIdx := svc.rand.Float64()
-	svc.mtx.Unlock()
+	randomIdx := rand.Float64()
 	if len(insertingSvcs) > 0 {
 		return insertingSvcs[int(randomIdx*float64(len(insertingSvcs)))].Request(req, insertMode)
 	} else if len(idleSvcs) > 0 {

--- a/writer/service/registry/static.go
+++ b/writer/service/registry/static.go
@@ -1,9 +1,7 @@
 package registry
 
 import (
-	"math/rand"
-	"sync"
-	"time"
+	"math/rand/v2"
 
 	"github.com/metrico/qryn/v5/writer/service"
 )
@@ -16,8 +14,6 @@ type staticServiceRegistry struct {
 	TempoTagsSvcs     []service.IInsertServiceV2
 	ProfileInsertSvcs []service.IInsertServiceV2
 	PatternInsertSvcs []service.IInsertServiceV2
-	rand              *rand.Rand
-	mtx               sync.Mutex
 }
 
 type StaticServiceRegistryOpts struct {
@@ -39,9 +35,7 @@ func mapToSlice(m map[string]service.IInsertServiceV2) []service.IInsertServiceV
 }
 
 func NewStaticServiceRegistry(opts StaticServiceRegistryOpts) ServiceRegistry {
-	res := staticServiceRegistry{
-		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
-	}
+	res := staticServiceRegistry{}
 	res.TimeSeriesSvcs = mapToSlice(opts.TimeSeriesSvcs)
 	res.SamplesSvcs = mapToSlice(opts.SamplesSvcs)
 	res.MetricSvcs = mapToSlice(opts.MetricSvcs)
@@ -62,9 +56,7 @@ func staticServiceRegistryGetService[T interface{ GetNodeName() string }](r *sta
 			}
 		}
 	}
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
-	idx := r.rand.Intn(len(svcs))
+	idx := rand.IntN(len(svcs))
 	return svcs[idx], nil
 }
 


### PR DESCRIPTION
The top-level math/rand/v2 functions are safe for concurrent use and need no seeding, so the per-struct *rand.Rand fields and the locks guarding them can go. Two of those locks guarded nothing else: the one in the writer service registry, and the global one in the pattern controller, which was taken on every single log line whenever pattern downsampling was enabled.

Two bugs fell out along the way:
 - writer/pattern/controller: random was declared but never assigned, so skipLine() dereferenced a nil *rand.Rand as soon as LogPatternsDownsampling was configured below 1.
 - CLokiQueriable.random was written and copied but never read — removed.

Mutexes that protect more than the generator (reader/registry/static.go, writer/service/generic_insert.go) are kept; only the lock around the rand call itself is dropped.

9 files, −29 lines. go build ./... and go test ./... pass.