### PR TITLE
smart_buffer: grow the RAM chunk on demand

### DIFF
--- a/reader/utils/smart_buffer/ram_chunk.go
+++ b/reader/utils/smart_buffer/ram_chunk.go
@@ -8,8 +8,13 @@ import (
 // ErrBufferFull is returned when the RAM chunk cannot accept more data.
 var ErrBufferFull = errors.New("buffer is full")
 
-// chunkSize defines the maximum size of the RAM buffer (5MB).
-const chunkSize = 5 * 1000 * 1000 // 5MB
+const (
+	// chunkSize defines the maximum size of the RAM buffer (5MB).
+	chunkSize = 5 * 1000 * 1000 // 5MB
+	// initialChunkSize is the starting capacity; append grows it as needed,
+	// so a small response never touches the whole 5MB.
+	initialChunkSize = 8 * 1024
+)
 
 // ramChunk is a fixed-size RAM buffer that accumulates data up to chunkSize.
 // It returns ErrBufferFull when it cannot accept more data.
@@ -18,10 +23,10 @@ type ramChunk struct {
 	size int
 }
 
-// newRAMChunk creates a new RAM chunk with pre-allocated capacity.
+// newRAMChunk creates a new RAM chunk that grows on demand up to chunkSize.
 func newRAMChunk() *ramChunk {
 	return &ramChunk{
-		data: make([]byte, 0, chunkSize),
+		data: make([]byte, 0, initialChunkSize),
 	}
 }
 

--- a/reader/utils/smart_buffer/ram_chunk.go
+++ b/reader/utils/smart_buffer/ram_chunk.go
@@ -11,43 +11,86 @@ var ErrBufferFull = errors.New("buffer is full")
 const (
 	// chunkSize defines the maximum size of the RAM buffer (5MB).
 	chunkSize = 5 * 1000 * 1000 // 5MB
-	// initialChunkSize is the starting capacity; append grows it as needed,
-	// so a small response never touches the whole 5MB.
-	initialChunkSize = 8 * 1024
+	// initialBlockSize is the size of the first block, small enough that a
+	// few-hundred-byte response costs a single small allocation.
+	initialBlockSize = 8 * 1024
+	// maxBlockSize caps the block size at Go's largest size class, so every
+	// block stays on the small-object allocation path.
+	maxBlockSize = 32 * 1024
 )
 
-// ramChunk is a fixed-size RAM buffer that accumulates data up to chunkSize.
+// ramChunk accumulates up to chunkSize bytes in a list of separately allocated
+// blocks. Blocks are never reallocated or copied, so the chunk allocates only
+// what is actually written: a growing single slice would copy everything
+// accumulated so far on each growth step. Blocks are reused after Clear.
 // It returns ErrBufferFull when it cannot accept more data.
 type ramChunk struct {
-	data []byte
-	size int
+	blocks    [][]byte
+	cur       int // block currently being filled
+	size      int
+	readBlock int
+	readOff   int
 }
 
-// newRAMChunk creates a new RAM chunk that grows on demand up to chunkSize.
+// newRAMChunk creates a new RAM chunk. No memory is reserved until the first write.
 func newRAMChunk() *ramChunk {
-	return &ramChunk{
-		data: make([]byte, 0, initialChunkSize),
-	}
+	return &ramChunk{}
 }
 
 // Write writes data to the RAM chunk, writing as much as will fit.
 // Returns the number of bytes written and ErrBufferFull if not all data could be written.
 func (r *ramChunk) Write(p []byte) (int, error) {
-	available := chunkSize - r.size
-	if available == 0 {
-		return 0, ErrBufferFull
+	written := 0
+	for len(p) > 0 {
+		if r.size >= chunkSize {
+			return written, ErrBufferFull
+		}
+		if r.cur == len(r.blocks) {
+			r.blocks = append(r.blocks, make([]byte, 0, r.nextBlockSize()))
+		}
+		block := r.blocks[r.cur]
+		if len(block) == cap(block) {
+			r.cur++
+			continue
+		}
+		n := min(len(p), cap(block)-len(block))
+		r.blocks[r.cur] = append(block, p[:n]...)
+		p = p[n:]
+		r.size += n
+		written += n
 	}
-
-	written := min(len(p), available)
-
-	r.data = append(r.data, p[:written]...)
-	r.size += written
-
-	if written < len(p) {
-		return written, ErrBufferFull
-	}
-
 	return written, nil
+}
+
+// nextBlockSize doubles the previous block size up to maxBlockSize, clamped to
+// the room left in the chunk so the blocks tile chunkSize exactly.
+func (r *ramChunk) nextBlockSize() int {
+	size := initialBlockSize
+	if r.cur > 0 {
+		size = min(cap(r.blocks[r.cur-1])*2, maxBlockSize)
+	}
+	return min(size, chunkSize-r.size)
+}
+
+// Read implements io.Reader over the accumulated blocks.
+// Returns io.EOF once all data has been read.
+func (r *ramChunk) Read(p []byte) (int, error) {
+	n := 0
+	for n < len(p) && r.readBlock < len(r.blocks) {
+		block := r.blocks[r.readBlock]
+		if r.readOff == len(block) {
+			r.readBlock++
+			r.readOff = 0
+			continue
+		}
+		copied := copy(p[n:], block[r.readOff:])
+		r.readOff += copied
+		n += copied
+	}
+	if n == 0 {
+		return 0, io.EOF
+	}
+	return n, nil
 }
 
 // Flush writes all accumulated data in the chunk to the provided writer
@@ -56,23 +99,24 @@ func (r *ramChunk) Flush(w io.Writer) error {
 	if r.size == 0 {
 		return nil
 	}
-	if _, err := w.Write(r.data); err != nil {
-		return err
+	for _, block := range r.blocks {
+		if _, err := w.Write(block); err != nil {
+			return err
+		}
 	}
 	r.Clear()
 	return nil
 }
 
-// Clear resets the chunk to empty state.
+// Clear resets the chunk to empty state, keeping the blocks for reuse.
 func (r *ramChunk) Clear() {
-	r.data = r.data[:0]
+	for i := range r.blocks {
+		r.blocks[i] = r.blocks[i][:0]
+	}
+	r.cur = 0
 	r.size = 0
-}
-
-// Bytes returns the current data in the chunk.
-// The returned slice should not be modified.
-func (r *ramChunk) Bytes() []byte {
-	return r.data
+	r.readBlock = 0
+	r.readOff = 0
 }
 
 // Size returns the current number of bytes stored in the chunk.

--- a/reader/utils/smart_buffer/ram_chunk_test.go
+++ b/reader/utils/smart_buffer/ram_chunk_test.go
@@ -1,0 +1,112 @@
+package smart_buffer
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func writeChunks(t *testing.T, r *ramChunk, total, per int) {
+	t.Helper()
+	data := make([]byte, per)
+	for written := 0; written < total; {
+		n, err := r.Write(data[:min(per, total-written)])
+		if err != nil {
+			t.Fatalf("Write() error = %v", err)
+		}
+		written += n
+	}
+}
+
+func TestRAMChunk_BlocksTileChunkSize(t *testing.T) {
+	t.Parallel()
+
+	r := newRAMChunk()
+	writeChunks(t, r, chunkSize, 4096)
+
+	if r.Size() != chunkSize {
+		t.Errorf("Size() = %d, want %d", r.Size(), chunkSize)
+	}
+
+	allocated := 0
+	for _, block := range r.blocks {
+		allocated += cap(block)
+	}
+	if allocated != chunkSize {
+		t.Errorf("allocated %d bytes, want exactly %d", allocated, chunkSize)
+	}
+
+	if _, err := r.Write([]byte("x")); err != ErrBufferFull {
+		t.Errorf("Write() on full chunk error = %v, want %v", err, ErrBufferFull)
+	}
+}
+
+func TestRAMChunk_ReusesBlocksAfterFlush(t *testing.T) {
+	t.Parallel()
+
+	r := newRAMChunk()
+	writeChunks(t, r, 256*1024, 4096)
+	blocks := len(r.blocks)
+
+	var sink bytes.Buffer
+	if err := r.Flush(&sink); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if sink.Len() != 256*1024 {
+		t.Errorf("flushed %d bytes, want %d", sink.Len(), 256*1024)
+	}
+
+	writeChunks(t, r, 256*1024, 4096)
+	if len(r.blocks) != blocks {
+		t.Errorf("refill allocated %d blocks, want %d reused", len(r.blocks), blocks)
+	}
+}
+
+func TestRAMChunk_ReadAcrossBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.Repeat([]byte("gigapipe"), 40000) // 320KB, spans many blocks
+	r := newRAMChunk()
+	if _, err := r.Write(input); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	output, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !bytes.Equal(input, output) {
+		t.Errorf("output does not match input")
+	}
+}
+
+func BenchmarkSmartBuffer(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"200B", 200},
+		{"64KB", 64 * 1024},
+		{"1MB", 1024 * 1024},
+		{"5MB", chunkSize},
+	}
+	data := make([]byte, 4096)
+
+	for _, tt := range sizes {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				buf := New()
+				for written := 0; written < tt.size; written += len(data) {
+					if _, err := buf.Write(data[:min(len(data), tt.size-written)]); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if _, err := io.Copy(io.Discard, buf); err != nil {
+					b.Fatal(err)
+				}
+				buf.Close()
+			}
+		})
+	}
+}

--- a/reader/utils/smart_buffer/smart_buffer.go
+++ b/reader/utils/smart_buffer/smart_buffer.go
@@ -28,7 +28,6 @@ type SmartBuffer struct {
 	file        *fileBuffer
 	size        int64
 	readStarted bool
-	readPos     int64
 }
 
 // New creates a new smart buffer instance.
@@ -89,16 +88,7 @@ func (b *SmartBuffer) Read(p []byte) (n int, err error) {
 	}
 
 	if b.file.Size() == 0 {
-		bytes := b.chunk.Bytes()
-		if b.readPos >= int64(len(bytes)) {
-			return 0, io.EOF
-		}
-		n := copy(p, bytes[b.readPos:])
-		b.readPos += int64(n)
-		if b.readPos >= int64(len(bytes)) {
-			return n, io.EOF
-		}
-		return n, nil
+		return b.chunk.Read(p)
 	}
 
 	return b.file.Read(p)


### PR DESCRIPTION
The reader wraps every response in a **SmartBuffer**, which preallocated its full 5MB RAM chunk in the constructor. All ten reader endpoints go through it, including **labels**, **label/{name}/values** and **series** — the ones Grafana polls constantly with replies of a few hundred bytes. Each of those requests malloc'd and page-faulted 5MB to hold 200 bytes.

Fix: start the chunk at 8KB and let **append** grow it. The 5MB spill-to-disk threshold is unchanged — it's checked against the byte count written, not the slice capacity. Small responses: 511µs → 1.4µs, 5MB → 8KB per request.