### PR TITLE
fix(logql): drop log entries whose fingerprint has no labels yet

### DIFF
--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner.go
@@ -78,7 +78,10 @@ func (l *LabelsJoinPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, er
 		*l.LabelsCache = withTS
 	}
 
-	joinType := "ANY LEFT "
+	// The labels map and the samples are two independent reads of ClickHouse,
+	// so a fingerprint written between them appears in the samples with nothing
+	// to resolve its labels against. Such an entry belongs to no stream, so it
+	// is dropped rather than emitted with an empty label set.
 	if ctx.IsCluster {
 		withTSRef := sql.NewWithRef(withTS)
 		withTSSelect := sql.NewSelect().
@@ -100,7 +103,8 @@ func (l *LabelsJoinPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, er
 				sql.NewCol(labelsCol, "labels"),
 				sql.NewSimpleCol("main.string", "string"),
 				sql.NewSimpleCol("main.value", "value")).
-			From(sql.NewWithRef(withMain)), nil
+			From(sql.NewWithRef(withMain)).
+			AndWhere(sql.Gt(sql.NewRawObject("length(labels)"), sql.NewIntVal(0))), nil
 
 	}
 	return sql.NewSelect().
@@ -113,7 +117,7 @@ func (l *LabelsJoinPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, er
 			sql.NewSimpleCol("main.value", "value")).
 		From(sql.NewWithRef(withMain)).
 		Join(sql.NewJoin(
-			joinType,
+			"ANY INNER ",
 			sql.NewWithRef(withTS),
 			sql.Eq(sql.NewRawObject("main.fingerprint"), sql.NewRawObject("_time_series.fingerprint")))), nil
 }

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner_test.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner_test.go
@@ -86,3 +86,35 @@ func TestLabelsJoinBoundsSingleNodeJoinToMainFingerprints(t *testing.T) {
 		t.Fatalf("single-node labels join not bounded to main fingerprints, got:\n%s", got)
 	}
 }
+
+// A sample whose fingerprint has no time_series row yet belongs to no stream, so
+// it must not reach the client carrying an empty label set.
+func TestLabelsJoinDropsUnresolvedFingerprints(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cluster bool
+		want    string
+	}{
+		{"cluster", true, "WHERE ((length(labels)) > (0))"},
+		{"single node", false, "ANY INNER  JOIN _time_series"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			planner := &LabelsJoinPlanner{
+				NoStreamSelect: true,
+				Main:           staticPlanner{mockMain()},
+				TimeSeries:     staticPlanner{mockTimeSeries()},
+			}
+			sel, err := planner.Process(&shared.PlannerContext{IsCluster: tc.cluster})
+			if err != nil {
+				t.Fatalf("Process() error = %v", err)
+			}
+			got, err := sel.String(newCtx())
+			if err != nil {
+				t.Fatalf("String() error = %v", err)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("unresolved fingerprints not dropped (want %q), got:\n%s", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
LabelsJoinPlanner resolves stream labels from time_series, but the labels and the samples are two independent reads of ClickHouse. In cluster mode the map lookup runs as a scalar subquery, which ClickHouse evaluates during analysis, before the pipeline that scans samples_v3_dist. A fingerprint that becomes visible between the two reads returns samples with no map entry, and a missing key in a Map yields the value type's default, so the entry reached the client as a stream with no labels at all. The single-node path produced the same result via ANY LEFT JOIN.

The window opens whenever the writer's separate time_series and samples inserters, plus async Distributed forwarding, make one table current before the other. It is widest for a stream selector matching series that shard apart, since each shard settles independently.

Resolve nothing rather than resolve wrongly: an entry that cannot be attributed to a stream is dropped, via length(labels) > 0 in cluster mode and ANY INNER JOIN on a single node. No data is lost, since the labels become visible within a second and the entry is returned by any later query. The join cannot shed settled rows either: the writer keys its dedup cache on (sample day, fingerprint), so every sample has a time_series row dated inside the query window.

by/without and drop/keep label resolution share the race but are left alone, since an empty label set is a legitimate projection there.

Reproduced on a two-shard e2e cluster with an immediate read-back after push: 3 failures in 35 runs before, 0 in 60 after.