### PR TITLE
promql: fetch series labels once per sort

### DIFF
--- a/reader/service/prom_queryable.go
+++ b/reader/service/prom_queryable.go
@@ -365,14 +365,28 @@ func (c *CLokiQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 		return &model.SeriesSet{Error: err}
 	}
 	res.Series = c.ReshuffleSeries(res.Series)
-	slices.SortFunc(res.Series, func(a, b *model.SeriesV2) int {
-		return slices.CompareFunc(a.LabelsArray(), b.LabelsArray(), func(l1, l2 labels.Label) int {
+	// LabelsArray() is not a field read: it rebuilds the label set from the
+	// fingerprint and sorts it on every call. Fetch it once per series instead
+	// of twice per comparison.
+	type keyedSeries struct {
+		lbls   model.Labels
+		series *model.SeriesV2
+	}
+	keyed := make([]keyedSeries, len(res.Series))
+	for i, s := range res.Series {
+		keyed[i] = keyedSeries{s.LabelsArray(), s}
+	}
+	slices.SortFunc(keyed, func(a, b keyedSeries) int {
+		return slices.CompareFunc(a.lbls, b.lbls, func(l1, l2 labels.Label) int {
 			if c := cmp.Compare(l1.Name, l2.Name); c != 0 {
 				return c
 			}
 			return cmp.Compare(l1.Value, l2.Value)
 		})
 	})
+	for i := range keyed {
+		res.Series[i] = keyed[i].series
+	}
 	return &res
 }
 


### PR DESCRIPTION
Follow-up to the review note on #959:
https://github.com/metrico/gigapipe/pull/959#pullrequestreview-5104401620

`labelsGetter.Get` already lost its `sort.Slice` in #959, so what is left is the
call count, not the cost of one call. `LabelsArray()` reads like a field access,
but it rebuilds the label set from the fingerprint and sorts it on every call:

```go
slices.SortFunc(res.Series, func(a, b *model.SeriesV2) int {
	return slices.CompareFunc(a.LabelsArray(), b.LabelsArray(), ...)
})
```

Both sides are rebuilt for every comparison, so a sort of N series does
~2·N·log₂N of them where N would do. Ordering 2000 series costs 44892 calls,
each one an allocation plus a sort of the label set.

So the labels are fetched once per series into a keyed slice, and that slice is
sorted. Same comparator, same resulting order — `TestSortVariantsAgree` checks
the two orders match on 300 series.

Two alternatives did not survive the measurement. Caching inside `labelsGetter`
keeps all 44892 calls and only makes them cheaper — 7.7x against the 10.2x
below, and it puts mutable state on the getter. Hoisting alone is not available
any more: after #959 the comparator already calls `LabelsArray()` exactly twice,
not once per label.

## The sort itself

`BenchmarkSeriesSort`, i5-14600KF, `-benchtime 300x -count 6`, medians. Labels
are stored shuffled, as they come back from ClickHouse; the first two carry the
same value in every series, so the comparator has to look past them.

| series x labels | master | this PR |
|---|---|---|
| 10 x 8 | 18.7 µs · 21 KB · 64 allocs | **10.0 µs · 8 KB · 13 allocs** (1.9x) |
| 100 x 8 | 275.7 µs · 320 KB · 1256 allocs | **40.7 µs · 34 KB · 103 allocs** (6.8x) |
| 500 x 8 | 2075 µs · 2.34 MB · 9534 allocs | **219 µs · 150 KB · 503 allocs** (9.5x) |
| 2000 x 8 | 9781 µs · 10.98 MB · 44894 allocs | **958 µs · 585 KB · 2003 allocs** (10.2x) |
| 100 x 20 | 865.7 µs · 868 KB · 1256 allocs | **99.8 µs · 78 KB · 103 allocs** (8.7x) |

## End to end

One ClickHouse, one gigapipe built from the checkout, Prometheus scraping
node-exporter into `remote_write`: 3923 series, 7.7M samples, real metrics. The
two images differ only by this commit. Runs alternate master/PR across three
rounds of 30 requests, the query window is pinned to a fixed timestamp so every
run reads the same data. `CPU` is the gigapipe container's own cgroup time,
which keeps ClickHouse out of the number.

| query | series into `Select` | master | this PR |
|---|---|---|---|
| `node_cpu_seconds_total`, 1h/15s | 160 | 38.6 ms · 19.5 ms CPU | 38.0 ms · 19.4 ms CPU |
| `{__name__!=""}`, 10m/60s | 3899 | 68.6 ms · 54.1 ms CPU | **61.3 ms · 46.3 ms CPU** (−10.6% / −14.4%) |
| `count({__name__!=""})`, 1h/15s | 1, pushed down | 187.6 ms · 10.0 ms CPU | 186.9 ms · 10.2 ms CPU |
| `sum by (mode) (rate(node_cpu_seconds_total[1m]))`, 1h/15s | 1, pushed down | 62.4 ms · 4.6 ms CPU | 61.4 ms · 4.5 ms CPU |

What the saving is: ~2 µs of reader CPU per series, independent of how many
points each series carries. Aggregations that ClickHouse computes never reach
this sort — one series arrives, there is nothing to order — so they show
nothing, as expected. The gain is on raw selectors with many series, and it
grows with cardinality, not with the range.
