### PR TITLE
fix(logql): keep all lines of a multi-line stream on a single node

### DIFF
--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner.go
@@ -107,6 +107,12 @@ func (l *LabelsJoinPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, er
 			AndWhere(sql.Gt(sql.NewRawObject("length(labels)"), sql.NewIntVal(0))), nil
 
 	}
+	// `main` holds one row per log line and joins many-to-one onto
+	// `_time_series` (one row per fingerprint). An ANY INNER JOIN keeps at most
+	// one matched pair per key and would collapse every multi-line stream to a
+	// single line, so the samples side is preserved with ANY LEFT JOIN and the
+	// unresolved fingerprints are dropped by the same length(labels) > 0 filter
+	// used above, rather than by the join type.
 	return sql.NewSelect().
 		With(withMain, withTS).
 		Select(
@@ -117,7 +123,8 @@ func (l *LabelsJoinPlanner) Process(ctx *shared.PlannerContext) (sql.ISelect, er
 			sql.NewSimpleCol("main.value", "value")).
 		From(sql.NewWithRef(withMain)).
 		Join(sql.NewJoin(
-			"ANY INNER ",
+			"ANY LEFT ",
 			sql.NewWithRef(withTS),
-			sql.Eq(sql.NewRawObject("main.fingerprint"), sql.NewRawObject("_time_series.fingerprint")))), nil
+			sql.Eq(sql.NewRawObject("main.fingerprint"), sql.NewRawObject("_time_series.fingerprint")))).
+		AndWhere(sql.Gt(sql.NewRawObject("length(_time_series.labels)"), sql.NewIntVal(0))), nil
 }

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner_test.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_labels_joiner_test.go
@@ -88,7 +88,11 @@ func TestLabelsJoinBoundsSingleNodeJoinToMainFingerprints(t *testing.T) {
 }
 
 // A sample whose fingerprint has no time_series row yet belongs to no stream, so
-// it must not reach the client carrying an empty label set.
+// it must not reach the client carrying an empty label set. Both modes drop such
+// rows with a length(labels) > 0 filter. The single-node path keeps ANY LEFT
+// JOIN so it does not collapse multi-line streams (one row per line in `main`)
+// down to one row per fingerprint; the filter, not the join type, sheds the
+// unresolved rows.
 func TestLabelsJoinDropsUnresolvedFingerprints(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -96,7 +100,7 @@ func TestLabelsJoinDropsUnresolvedFingerprints(t *testing.T) {
 		want    string
 	}{
 		{"cluster", true, "WHERE ((length(labels)) > (0))"},
-		{"single node", false, "ANY INNER  JOIN _time_series"},
+		{"single node", false, "WHERE ((length(_time_series.labels)) > (0))"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			planner := &LabelsJoinPlanner{

--- a/test/integration/logql_multiline_stream_test.go
+++ b/test/integration/logql_multiline_stream_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+// Regression test for issue #964: on a single node, a LogQL query that matches
+// a stream with several log lines must return all of them, not one.
+//
+// The label-resolution join in LabelsJoinPlanner joins the samples (one row per
+// log line) to the time_series labels (one row per fingerprint). An ANY INNER
+// JOIN keeps at most one matched pair per key and collapses every multi-line
+// stream to a single line; the fix keeps ANY LEFT JOIN and drops unresolved
+// rows with a length(labels) > 0 filter instead.
+//
+// This drives the real push and query HTTP paths, so it fails on the collapse
+// and passes on the fix without asserting any SQL. Run via test/integration/run.sh
+// or against a running stack:
+//
+//	GIGAPIPE_URL=http://localhost:3100 go test -tags integration ./test/integration/... -v
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// pushStreams sends log lines to gigapipe using the Loki push v1 JSON format.
+// Each element of streams maps a label set to its lines.
+func pushStreams(t *testing.T, streams []lokiPushStream) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"streams": streams})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(baseURL()+"/loki/api/v1/push", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("push status = %d, body = %q", resp.StatusCode, raw)
+	}
+}
+
+type lokiPushStream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"` // [ [ "<ns ts>", "<line>" ], ... ]
+}
+
+// queryStreamLineCounts runs an instant query and returns line counts keyed by
+// the value of the given label, so the assertion does not depend on label
+// ordering or fingerprint internals.
+func queryStreamLineCounts(t *testing.T, query, labelKey string) map[string]int {
+	t.Helper()
+	u := fmt.Sprintf("%s/loki/api/v1/query?query=%s", baseURL(), urlQueryEscape(query))
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("query status = %d, body = %q", resp.StatusCode, raw)
+	}
+
+	var out struct {
+		Data struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Stream map[string]string `json:"stream"`
+				Values [][]string        `json:"values"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode query response: %v\nbody: %s", err, raw)
+	}
+	if out.Data.ResultType != "streams" {
+		t.Fatalf("resultType = %q, want streams\nbody: %s", out.Data.ResultType, raw)
+	}
+
+	counts := map[string]int{}
+	for _, s := range out.Data.Result {
+		counts[s.Stream[labelKey]] += len(s.Values)
+	}
+	return counts
+}
+
+// TestLogQLReturnsAllLinesOfAMultiLineStream reproduces issue #964: a stream
+// with three lines must come back with three lines, not one.
+func TestLogQLReturnsAllLinesOfAMultiLineStream(t *testing.T) {
+	waitReady(t)
+
+	// Unique label value per run so repeated runs against a shared ClickHouse
+	// don't read each other's data.
+	nodeA := "itest_node_a_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	nodeB := "itest_node_b_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	nowNs := time.Now().UnixNano()
+
+	ns := func(offset int64) string { return strconv.FormatInt(nowNs+offset, 10) }
+
+	// nodeA is one stream with three lines; nodeB is one stream with one line.
+	pushStreams(t, []lokiPushStream{
+		{
+			Stream: map[string]string{"itest_stream": nodeA},
+			Values: [][]string{
+				{ns(0), "line-a-1"},
+				{ns(1), "line-a-2"},
+				{ns(2), "line-a-3"},
+			},
+		},
+		{
+			Stream: map[string]string{"itest_stream": nodeB},
+			Values: [][]string{
+				{ns(3), "line-b-1"},
+			},
+		},
+	})
+
+	query := fmt.Sprintf(`{itest_stream=~"%s|%s"}`, nodeA, nodeB)
+
+	// Ingestion is asynchronous (bulk flush); poll until both streams are
+	// visible, then assert the per-stream line counts.
+	deadline := time.Now().Add(30 * time.Second)
+	var counts map[string]int
+	for {
+		counts = queryStreamLineCounts(t, query, "itest_stream")
+		if counts[nodeA] >= 1 && counts[nodeB] >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("streams never became queryable; got counts %v", counts)
+		}
+		time.Sleep(time.Second)
+	}
+
+	if got := counts[nodeA]; got != 3 {
+		t.Errorf("multi-line stream returned %d lines, want 3 (issue #964: labels join collapses multi-line streams)", got)
+	}
+	if got := counts[nodeB]; got != 1 {
+		t.Errorf("single-line stream returned %d lines, want 1", got)
+	}
+}
+
+func urlQueryEscape(s string) string {
+	// Minimal escaping for the LogQL selector characters we use; net/url would
+	// also work but keeps the dependency surface identical to the sibling test.
+	repl := map[rune]string{
+		'{': "%7B", '}': "%7D", '"': "%22", '=': "%3D",
+		'~': "%7E", '|': "%7C", ' ': "%20",
+	}
+	var b bytes.Buffer
+	for _, r := range s {
+		if v, ok := repl[r]; ok {
+			b.WriteString(v)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Fixes #964.

On a single node, a LogQL query that matches a stream with several log lines returns only **one** line for that stream instead of all of them. Both `/loki/api/v1/query` and `/loki/api/v1/query_range` are affected, since they share the same label-resolution planner.

## Root cause

`LabelsJoinPlanner.Process` resolves stream labels by joining the samples subquery (`main`) to the labels subquery (`_time_series`) on `fingerprint`. #961 changed the single-node join from `ANY LEFT JOIN` to `ANY INNER JOIN` to drop samples whose fingerprint has no labels row yet.

But the relationship is one-to-many: `main` has one row **per log line** (many per fingerprint), while `_time_series` has one row **per fingerprint**. ClickHouse's `ANY` modifier keeps at most one matched pair per join key, so `ANY INNER JOIN` collapses all sample rows sharing a fingerprint into a single row — every multi-line stream is reduced to one line.

The cluster-mode branch was not affected: it sheds unresolved rows with an explicit `WHERE length(labels) > 0` filter rather than by changing the join type.

## Fix

Keep the samples-preserving `ANY LEFT JOIN` on the single-node path and drop unresolved fingerprints with `length(_time_series.labels) > 0`, mirroring the cluster branch. This still discards samples whose labels are not yet visible (the intent of #961) without collapsing resolved multi-line streams.

```sql
FROM main
ANY LEFT JOIN _time_series
  ON main.fingerprint = _time_series.fingerprint
WHERE length(_time_series.labels) > 0
```

## Tests

- Updated the single-node case of `TestLabelsJoinDropsUnresolvedFingerprints` to assert the `length(_time_series.labels) > 0` filter instead of the `ANY INNER JOIN` keyword. (The prior string assertion is what let the regression through — it checked the join keyword, not the observable outcome.)
- Added `test/integration/logql_multiline_stream_test.go`: pushes a three-line stream and a one-line stream over `/loki/api/v1/push`, queries them back via `/loki/api/v1/query`, and asserts the line counts. It asserts behavior over HTTP, not SQL.

### Verification

Against a live gigapipe + ClickHouse stack built from this branch:

- **Buggy build** (`ANY INNER JOIN`): integration test fails — `multi-line stream returned 1 lines, want 3`.
- **Fixed build**: integration test passes; three-line stream returns 3, one-line stream returns 1.
- `go test ./...` passes; `gofmt` clean; static build succeeds.

The integration test runs in the existing `Integration` CI job (it provisions ClickHouse and runs `-tags integration ./test/integration/...`).
