### PR TITLE
Split samples by signal

### DIFF
--- a/cmd/gigapipe/main.go
+++ b/cmd/gigapipe/main.go
@@ -28,6 +28,7 @@ import (
 	rulerrouter "github.com/metrico/qryn/v5/ruler/router"
 	"github.com/metrico/qryn/v5/shared/commonroutes"
 	"github.com/metrico/qryn/v5/shared/distconfig"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/view"
 	"github.com/metrico/qryn/v5/writer"
 	writergrpc "github.com/metrico/qryn/v5/writer/grpc"
@@ -286,6 +287,9 @@ func main() {
 
 func start() {
 	distconfig.Init()
+	if err := samplesconfig.Init(); err != nil {
+		panic(err)
+	}
 	tables.InitDistTableNames()
 	var configPaths []string
 	if _, err := os.Stat(*appFlags.ConfigPath); err == nil {

--- a/ctrl/qryn/maintenance/aggr.go
+++ b/ctrl/qryn/maintenance/aggr.go
@@ -86,6 +86,24 @@ func aggrDropDays(configured, fallback int) int {
 	return configured
 }
 
+// parseAggrEnabled reads the enabled flag back out of a stored state string.
+// ok is false for an absent or unrecognised string, which the caller reads as
+// "no prior state" rather than "was disabled".
+func parseAggrEnabled(state string) (enabled bool, ok bool) {
+	for _, field := range strings.Fields(state) {
+		raw, found := strings.CutPrefix(field, "enabled=")
+		if !found {
+			continue
+		}
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return false, false
+		}
+		return v, true
+	}
+	return false, false
+}
+
 // SyncMetricsAggrMV brings metrics_aggr_mv in line with the configuration,
 // doing nothing when it already matches. It must run after the split tables
 // exist, since a materialized view needs both its source and its target.
@@ -114,6 +132,12 @@ func SyncMetricsAggrMV(db clickhouse.Conn, dbname, clusterName string,
 		return err
 	}
 	if samplesconfig.MetricsAggrEnabled() {
+		if wasEnabled, ok := parseAggrEnabled(have); !ok || !wasEnabled {
+			logger.Info(
+				"metrics_aggr_mv re-enabled: metrics_aggr holds nothing for the period " +
+					"it was absent (or has never run); queries over it will read that " +
+					"period as empty until it is rebuilt from samples_metrics")
+		}
 		logger.Info(fmt.Sprintf("Creating metrics_aggr_mv at %s buckets", interval))
 		if err := exec(metricsAggrMVQuery); err != nil {
 			return err

--- a/ctrl/qryn/maintenance/aggr.go
+++ b/ctrl/qryn/maintenance/aggr.go
@@ -1,0 +1,125 @@
+package maintenance
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/metrico/qryn/v5/ctrl/logger"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
+)
+
+// metricsAggrMVQuery is not part of the versioned migration on purpose. A
+// versioned script runs once, so it cannot express enabling, disabling or
+// re-intervalling the view; SyncMetricsAggrMV drives it from stored state
+// instead, the same way rotateTables drives TTL.
+const metricsAggrMVQuery = `CREATE MATERIALIZED VIEW IF NOT EXISTS {{.DB}}.metrics_aggr_mv {{.OnCluster}} TO {{.DB}}.metrics_aggr
+AS SELECT
+    fingerprint,
+    intDiv(samples.timestamp_ns, {{.AGGR_INTERVAL_NS}}) * {{.AGGR_INTERVAL_NS}} as timestamp_ns,
+    argMaxState(value, samples.timestamp_ns) as last,
+    maxSimpleState(value) as max,
+    minSimpleState(value) as min,
+    countState() as count,
+    sumSimpleState(value) as sum,
+    type
+FROM {{.DB}}.samples_metrics as samples
+GROUP BY fingerprint, timestamp_ns, type`
+
+const aggrSettingType = "aggr"
+const aggrSettingName = "metrics_aggr_mv"
+
+func aggrStateString(enabled bool, interval time.Duration) string {
+	return fmt.Sprintf("enabled=%v interval=%d", enabled, interval.Nanoseconds())
+}
+
+// parseAggrInterval reads the bucket width back out of a stored state string.
+// An unrecognised string reports absent, so the caller recreates the view rather
+// than validating a change against a granularity it cannot confirm.
+func parseAggrInterval(state string) (time.Duration, bool) {
+	for _, field := range strings.Fields(state) {
+		raw, ok := strings.CutPrefix(field, "interval=")
+		if !ok {
+			continue
+		}
+		ns, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || ns <= 0 {
+			return 0, false
+		}
+		return time.Duration(ns), true
+	}
+	return 0, false
+}
+
+// checkIntervalChange reports whether re-bucketing metrics_aggr from oldIv to
+// newIv keeps the rows already stored readable.
+//
+// Reads re-bucket the stored aggregate states with intDiv(timestamp_ns, step) *
+// step, so old rows fold onto a coarser grid only when newIv is a whole
+// multiple of oldIv. Otherwise the table ends up holding buckets coarser than
+// the interval the read path assumes, and a step at the new width finds a whole
+// old bucket's aggregate in its first sub-bucket and nothing in the rest.
+func checkIntervalChange(oldIv, newIv time.Duration) error {
+	if oldIv <= 0 || oldIv == newIv {
+		return nil
+	}
+	if newIv%oldIv != 0 {
+		return fmt.Errorf(
+			"METRICS_AGGR_INTERVAL changed from %s to %s, which is not a whole multiple: "+
+				"rows already in metrics_aggr would be coarser than the new interval and "+
+				"would read back wrong. Either pick a multiple of %s, or clear the table "+
+				"first (TRUNCATE TABLE metrics_aggr) and optionally rebuild it from "+
+				"samples_metrics",
+			oldIv, newIv, oldIv)
+	}
+	return nil
+}
+
+// aggrDropDays resolves METRICS_AGGR_DAYS, where 0 means inherit the samples
+// retention. Only the caller holds the db config that carries the fallback.
+func aggrDropDays(configured, fallback int) int {
+	if configured <= 0 {
+		return fallback
+	}
+	return configured
+}
+
+// SyncMetricsAggrMV brings metrics_aggr_mv in line with the configuration,
+// doing nothing when it already matches. It must run after the split tables
+// exist, since a materialized view needs both its source and its target.
+func SyncMetricsAggrMV(db clickhouse.Conn, dbname, clusterName string,
+	distributed, replicated bool, logger logger.ILogger) error {
+	if !samplesconfig.SplitBySignal() {
+		return nil
+	}
+	interval := samplesconfig.MetricsAggrInterval()
+	want := aggrStateString(samplesconfig.MetricsAggrEnabled(), interval)
+	have, err := getSetting(db, distributed, aggrSettingType, aggrSettingName)
+	if err != nil || have == want {
+		return err
+	}
+	// Validate against whatever width the stored rows were built at, whether or
+	// not the view was enabled at the time: the rows outlive the view.
+	if oldIv, ok := parseAggrInterval(have); ok {
+		if err := checkIntervalChange(oldIv, interval); err != nil {
+			return err
+		}
+	}
+
+	env := scriptEnv(dbname, clusterName, "", "", 0, replicated, false)
+	exec := getDBExec(db, env, logger)
+	if err := exec("DROP VIEW IF EXISTS {{.DB}}.metrics_aggr_mv {{.OnCluster}}"); err != nil {
+		return err
+	}
+	if samplesconfig.MetricsAggrEnabled() {
+		logger.Info(fmt.Sprintf("Creating metrics_aggr_mv at %s buckets", interval))
+		if err := exec(metricsAggrMVQuery); err != nil {
+			return err
+		}
+	} else {
+		logger.Info("metrics_aggr_mv disabled; metric queries will read samples_metrics")
+	}
+	return putSetting(db, aggrSettingType, aggrSettingName, want)
+}

--- a/ctrl/qryn/maintenance/aggr_test.go
+++ b/ctrl/qryn/maintenance/aggr_test.go
@@ -1,0 +1,111 @@
+package maintenance
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The stored state must survive a round trip: SyncMetricsAggrMV compares the
+// desired string against the stored one and only reads the interval back when
+// it needs to validate a change.
+func TestAggrStateRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		enabled  bool
+		interval time.Duration
+	}{
+		{true, 15 * time.Second},
+		{false, time.Minute},
+		{true, 5 * time.Minute},
+	} {
+		state := aggrStateString(tc.enabled, tc.interval)
+		got, ok := parseAggrInterval(state)
+		if !ok {
+			t.Fatalf("parseAggrInterval(%q) failed", state)
+		}
+		if got != tc.interval {
+			t.Errorf("%q: interval = %v, want %v", state, got, tc.interval)
+		}
+	}
+}
+
+// A state string this code did not write is treated as absent, which makes the
+// caller recreate the view instead of trusting an unknown granularity.
+func TestParseAggrIntervalRejectsGarbage(t *testing.T) {
+	for _, s := range []string{"", "enabled=true", "interval=abc", "interval=", "nonsense"} {
+		if _, ok := parseAggrInterval(s); ok {
+			t.Errorf("parseAggrInterval(%q) accepted", s)
+		}
+	}
+}
+
+// Growing the bucket by a whole factor is safe: stored rows are aggregate
+// states and the read path re-buckets them onto the coarser grid. Anything else
+// leaves buckets coarser than the interval the read path assumes -- a 15s step
+// over 60s buckets finds the whole minute in the first sub-bucket and nothing
+// in the other three -- so it must be refused, not silently applied.
+func TestCheckIntervalChange(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		old     time.Duration
+		new     time.Duration
+		wantErr bool
+	}{
+		{"no previous state", 0, 15 * time.Second, false},
+		{"unchanged", 15 * time.Second, 15 * time.Second, false},
+		{"grow by 4", 15 * time.Second, time.Minute, false},
+		{"grow by 3", 15 * time.Second, 45 * time.Second, false},
+		{"grow, not a multiple", 15 * time.Second, 20 * time.Second, true},
+		{"shrink", time.Minute, 15 * time.Second, true},
+		{"shrink, not a multiple", time.Minute, 25 * time.Second, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkIntervalChange(tc.old, tc.new)
+			if tc.wantErr && err == nil {
+				t.Errorf("checkIntervalChange(%v, %v) = nil, want error", tc.old, tc.new)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("checkIntervalChange(%v, %v) = %v, want nil", tc.old, tc.new, err)
+			}
+		})
+	}
+}
+
+// METRICS_AGGR_DAYS = 0 means inherit the samples retention; the db config is
+// the only place that value exists, so resolution happens at the call site.
+func TestAggrDropDays(t *testing.T) {
+	for _, tc := range []struct {
+		configured, fallback, want int
+	}{
+		{0, 7, 7},
+		{90, 7, 90},
+		{1, 30, 1},
+	} {
+		if got := aggrDropDays(tc.configured, tc.fallback); got != tc.want {
+			t.Errorf("aggrDropDays(%d, %d) = %d, want %d",
+				tc.configured, tc.fallback, got, tc.want)
+		}
+	}
+}
+
+// The view must read samples_metrics, write metrics_aggr, bucket at the
+// configured width and carry no bytes column (metrics have no string to measure).
+func TestMetricsAggrMVRenders(t *testing.T) {
+	env := scriptEnv("qryn", "", "", "timestamp_ns", 7, false, false)
+	env["AGGR_INTERVAL_NS"] = "60000000000"
+	got := render(t, metricsAggrMVQuery, env)
+	for _, want := range []string{
+		"qryn.metrics_aggr_mv", "TO qryn.metrics_aggr",
+		"FROM qryn.samples_metrics", "60000000000",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered view missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "bytes") {
+		t.Errorf("metrics_aggr_mv must not select bytes:\n%s", got)
+	}
+	if strings.Contains(got, "15000000000") {
+		t.Errorf("metrics_aggr_mv has a hardcoded interval:\n%s", got)
+	}
+}

--- a/ctrl/qryn/maintenance/aggr_test.go
+++ b/ctrl/qryn/maintenance/aggr_test.go
@@ -39,6 +39,30 @@ func TestParseAggrIntervalRejectsGarbage(t *testing.T) {
 	}
 }
 
+// A state string this code did not write is treated as absent, mirroring
+// parseAggrInterval: the caller must not assume "was disabled" when it really
+// means "no prior run".
+func TestParseAggrEnabledRoundTrip(t *testing.T) {
+	for _, tc := range []bool{true, false} {
+		state := aggrStateString(tc, 15*time.Second)
+		got, ok := parseAggrEnabled(state)
+		if !ok {
+			t.Fatalf("parseAggrEnabled(%q) failed", state)
+		}
+		if got != tc {
+			t.Errorf("%q: enabled = %v, want %v", state, got, tc)
+		}
+	}
+}
+
+func TestParseAggrEnabledRejectsGarbage(t *testing.T) {
+	for _, s := range []string{"", "interval=15", "enabled=maybe", "nonsense"} {
+		if _, ok := parseAggrEnabled(s); ok {
+			t.Errorf("parseAggrEnabled(%q) accepted", s)
+		}
+	}
+}
+
 // Growing the bucket by a whole factor is safe: stored rows are aggregate
 // states and the read path re-buckets them onto the coarser grid. Anything else
 // leaves buckets coarser than the interval the read path assumes -- a 15s step

--- a/ctrl/qryn/maintenance/rotate.go
+++ b/ctrl/qryn/maintenance/rotate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/metrico/qryn/v5/ctrl/logger"
 	"github.com/metrico/qryn/v5/ctrl/qryn/helputils"
 	"github.com/metrico/qryn/v5/shared/distconfig"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 )
 
 func getSetting(db clickhouse.Conn, dist bool, tp string, name string) (string, error) {
@@ -207,6 +208,43 @@ func Rotate(db clickhouse.Conn, clusterName string, distributed bool, days []Rot
 		logger, "patterns")
 	if err != nil {
 		return err
+	}
+
+	if samplesconfig.SplitBySignal() {
+		err = storagePolicyUpdate(db, clusterName, distributed, storagePolicy,
+			"v5_split_storage_policy", "samples_logs", "samples_metrics", "logs_aggr", "metrics_aggr")
+		if err != nil {
+			return err
+		}
+		err = rotateTables(db, clusterName, distributed, days,
+			minTTL,
+			"toDateTime(timestamp_ns / 1000000000)",
+			logDefaultTTLString("toDateTime(timestamp_ns / 1000000000)"),
+			"v5_split_samples_days", logger, "samples_logs", "samples_metrics")
+		if err != nil {
+			return err
+		}
+		err = rotateTables(db, clusterName, distributed, days,
+			minTTL,
+			"toDateTime(timestamp_ns / 1000000000)",
+			logDefaultTTLString("toDateTime(timestamp_ns / 1000000000)"),
+			"logs_aggr", logger, "logs_aggr")
+		if err != nil {
+			return err
+		}
+		// The metrics preaggregate is the one table with its own retention: it is
+		// a derivative, so keeping it longer or shorter than the raw samples is a
+		// legitimate trade the operator makes.
+		aggrTTL := fmt.Sprintf("toDateTime(timestamp_ns / 1000000000) + toIntervalDay(%d)",
+			aggrDropDays(samplesconfig.MetricsAggrDays(), dropTTLDays))
+		err = rotateTables(db, clusterName, distributed, days,
+			minTTL,
+			"toDateTime(timestamp_ns / 1000000000)",
+			aggrTTL,
+			"metrics_aggr", logger, "metrics_aggr")
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/ctrl/qryn/maintenance/scripts_test.go
+++ b/ctrl/qryn/maintenance/scripts_test.go
@@ -1,0 +1,152 @@
+package maintenance
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/metrico/qryn/v5/ctrl/qryn/sql"
+)
+
+// TestScriptsResolveEveryToken renders every statement of every DDL script with
+// the same environment updateScripts builds, refusing any unknown token.
+//
+// text/template resolves a missing map key to the value type's zero — an empty
+// string — so a typo'd token silently renders as nothing and produces a broken
+// CREATE TABLE that only fails at runtime, on someone's cluster.
+// missingkey=error turns that into a test failure here instead.
+func TestScriptsResolveEveryToken(t *testing.T) {
+	env := scriptEnv("qryn", "mycluster", "mypolicy", "fingerprint, timestamp_ns",
+		7, true, true)
+	scripts := map[string]string{
+		"log.sql":            sql.LogScript,
+		"log_dist.sql":       sql.LogDistScript,
+		"log_split.sql":      sql.LogSplitScript,
+		"log_split_dist.sql": sql.LogSplitDistScript,
+		"traces.sql":         sql.TracesScript,
+		"traces_dist.sql":    sql.TracesDistScript,
+		"profiles.sql":       sql.ProfilesScript,
+		"profiles_dist.sql":  sql.ProfilesDistScript,
+		"rules.sql":          sql.RulesScript,
+		"rules_dist.sql":     sql.RulesDistScript,
+	}
+	for name, script := range scripts {
+		assertRenders(t, name, script, env)
+	}
+}
+
+// The read-dist scripts get a much smaller environment (update.go:160), so they
+// must not reach for a token only scriptEnv supplies.
+func TestReadDistScriptsResolveEveryToken(t *testing.T) {
+	env := readDistEnv("qryn", "mycluster", "readcluster", "_read")
+	scripts := map[string]string{
+		"log_read_dist.sql":       sql.LogReadDistScript,
+		"log_split_read_dist.sql": sql.LogSplitReadDistScript,
+		"traces_read_dist.sql":    sql.TracesReadDistScript,
+		"profiles_read_dist.sql":  sql.ProfilesReadDistScript,
+	}
+	for name, script := range scripts {
+		assertRenders(t, name, script, env)
+	}
+}
+
+func assertRenders(t *testing.T, name, script string, env map[string]string) {
+	t.Helper()
+	stmts, err := getSQLFile(script)
+	if err != nil {
+		t.Fatalf("%s: getSQLFile: %v", name, err)
+	}
+	if len(stmts) == 0 {
+		t.Fatalf("%s: no statements parsed", name)
+	}
+	for i, stmt := range stmts {
+		tpl, err := template.New(name).Option("missingkey=error").Parse(stmt)
+		if err != nil {
+			t.Fatalf("%s stmt %d: parse: %v", name, i, err)
+		}
+		buf := bytes.NewBuffer(nil)
+		if err := tpl.Execute(buf, env); err != nil {
+			t.Errorf("%s stmt %d: %v\n%s", name, i, err, stmt)
+			continue
+		}
+		if strings.Contains(buf.String(), "{{") {
+			t.Errorf("%s stmt %d: unresolved token in output\n%s", name, i, buf.String())
+		}
+	}
+}
+
+// The split file must carry the two tables the rest of the plan relies on, and
+// must not create metrics_aggr_mv: that view is state-managed (see aggr.go),
+// because a once-only migration cannot express enable, disable or reinterval.
+func TestSplitScriptContents(t *testing.T) {
+	env := scriptEnv("qryn", "", "", "timestamp_ns", 7, false, false)
+	stmts, err := getSQLFile(sql.LogSplitScript)
+	if err != nil {
+		t.Fatalf("getSQLFile: %v", err)
+	}
+	// getSQLFile returns raw, unrendered statements ({{.DB}} and friends still
+	// literal), so the table names below only appear after templating.
+	rendered := make([]string, len(stmts))
+	for i, s := range stmts {
+		rendered[i] = render(t, s, env)
+	}
+	all := strings.Join(rendered, "\n")
+	for _, want := range []string{
+		"qryn.samples_logs", "qryn.samples_metrics",
+		"qryn.logs_aggr", "qryn.metrics_aggr", "qryn.logs_aggr_mv",
+	} {
+		if !strings.Contains(all, want) {
+			t.Errorf("log_split.sql does not create %s", want)
+		}
+	}
+	if strings.Contains(all, "metrics_aggr_mv") {
+		t.Error("metrics_aggr_mv must not be created by the versioned migration")
+	}
+
+	// samples_metrics carries no string column: nothing on the metrics read path
+	// selects it, and dropping it stops OTLP exemplar trace ids from being
+	// stored where no reader can reach them.
+	metrics := statementContaining(t, rendered, "CREATE TABLE IF NOT EXISTS qryn.samples_metrics")
+	if strings.Contains(metrics, "string") {
+		t.Errorf("samples_metrics must have no string column:\n%s", metrics)
+	}
+	// metrics_aggr carries no bytes column: it is sum(length(string)), always
+	// zero for metrics.
+	aggr := statementContaining(t, rendered, "CREATE TABLE IF NOT EXISTS qryn.metrics_aggr")
+	if strings.Contains(aggr, "bytes") {
+		t.Errorf("metrics_aggr must have no bytes column:\n%s", aggr)
+	}
+
+	// The metrics ordering token must be wired, not hardcoded.
+	metricsRaw := statementContaining(t, stmts, "CREATE TABLE IF NOT EXISTS {{.DB}}.samples_metrics")
+	env["METRICS_ORDER_RUL"] = "MARKER_ORDER"
+	rerendered := render(t, metricsRaw, env)
+	if !strings.Contains(rerendered, "MARKER_ORDER") {
+		t.Errorf("samples_metrics ignores METRICS_ORDER_RUL:\n%s", rerendered)
+	}
+}
+
+func statementContaining(t *testing.T, stmts []string, needle string) string {
+	t.Helper()
+	for _, s := range stmts {
+		if strings.Contains(s, needle) {
+			return s
+		}
+	}
+	t.Fatalf("no statement containing %q", needle)
+	return ""
+}
+
+func render(t *testing.T, stmt string, env map[string]string) string {
+	t.Helper()
+	tpl, err := template.New("t").Option("missingkey=error").Parse(stmt)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	buf := bytes.NewBuffer(nil)
+	if err := tpl.Execute(buf, env); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return buf.String()
+}

--- a/ctrl/qryn/maintenance/update.go
+++ b/ctrl/qryn/maintenance/update.go
@@ -63,6 +63,11 @@ func UpdateWithReadCluster(db clickhouse.Conn, dbname string, clusterName string
 				return err
 			}
 		}
+		err = SyncMetricsAggrMV(db, dbname, clusterName,
+			checkMode(CLUST_MODE_DISTRIBUTED), checkMode(CLUST_MODE_CLOUD), logger)
+		if err != nil {
+			return err
+		}
 	}
 	err = updateScripts(db, dbname, clusterName, 2, sql.TracesScript,
 		checkMode(CLUST_MODE_CLOUD), ttlDays, storagePolicy, advancedSamplesOrdering, skipUnavailableShards, logger)

--- a/ctrl/qryn/maintenance/update.go
+++ b/ctrl/qryn/maintenance/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/metrico/qryn/v5/ctrl/logger"
 	"github.com/metrico/qryn/v5/ctrl/qryn/sql"
 	"github.com/metrico/qryn/v5/shared/distconfig"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 )
 
 const (
@@ -45,6 +46,22 @@ func UpdateWithReadCluster(db clickhouse.Conn, dbname string, clusterName string
 			checkMode(CLUST_MODE_CLOUD), ttlDays, storagePolicy, advancedSamplesOrdering, skipUnavailableShards, logger)
 		if err != nil {
 			return err
+		}
+	}
+	if samplesconfig.SplitBySignal() {
+		err = updateScripts(db, dbname, clusterName, 12, sql.LogSplitScript,
+			checkMode(CLUST_MODE_CLOUD), ttlDays, storagePolicy, advancedSamplesOrdering,
+			skipUnavailableShards, logger)
+		if err != nil {
+			return err
+		}
+		if checkMode(CLUST_MODE_DISTRIBUTED) {
+			err = updateScripts(db, dbname, clusterName, 13, sql.LogSplitDistScript,
+				checkMode(CLUST_MODE_CLOUD), ttlDays, storagePolicy, advancedSamplesOrdering,
+				skipUnavailableShards, logger)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	err = updateScripts(db, dbname, clusterName, 2, sql.TracesScript,
@@ -105,6 +122,13 @@ func UpdateWithReadCluster(db clickhouse.Conn, dbname string, clusterName string
 		if err != nil {
 			return err
 		}
+		if samplesconfig.SplitBySignal() {
+			err = updateReadDistScripts(db, dbname, clusterName, readCluster, readSuffix,
+				14, sql.LogSplitReadDistScript, logger)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	err = Cleanup(db, clusterName, checkMode(CLUST_MODE_DISTRIBUTED), dbname, logger)
@@ -130,7 +154,7 @@ func getSQLFile(strContents string) ([]string, error) {
 func getDBExec(db clickhouse.Conn, env map[string]string, logger logger.ILogger) func(query string, args ...[]any) error {
 	return func(query string, args ...[]any) error {
 		name := fmt.Sprintf("tpl_%d", rand.Uint64())
-		tpl, err := template.New(name).Parse(query)
+		tpl, err := template.New(name).Option("missingkey=error").Parse(query)
 		if err != nil {
 			logger.Error(query)
 			return err
@@ -157,13 +181,7 @@ func updateReadDistScripts(db clickhouse.Conn, dbname string, clusterName string
 	if err != nil {
 		return err
 	}
-	env := map[string]string{
-		"DB":           dbname,
-		"CLUSTER":      clusterName,
-		"OnCluster":    "ON CLUSTER `" + clusterName + "`",
-		"READ_CLUSTER": readCluster,
-		"READ_SUFFIX":  readSuffix,
-	}
+	env := readDistEnv(dbname, clusterName, readCluster, readSuffix)
 	exec := getDBExec(db, env, logger)
 	verTable := "ver" + distconfig.Suffix()
 	var ver uint64 = 0
@@ -196,13 +214,11 @@ func updateReadDistScripts(db clickhouse.Conn, dbname string, clusterName string
 	return nil
 }
 
-func updateScripts(db clickhouse.Conn, dbname string, clusterName string, k int64, file string, replicated bool,
-	ttlDays int, storagePolicy string, advancedSamplesOrdering string, skipUnavailableShards bool, logger logger.ILogger) error {
-	scripts, err := getSQLFile(file)
-	if err != nil {
-		return err
-	}
-	verTable := "ver"
+// scriptEnv builds the template environment for the versioned DDL scripts. It
+// is separate from updateScripts so a test can render every script against the
+// exact environment production supplies.
+func scriptEnv(dbname, clusterName, storagePolicy, advancedSamplesOrdering string,
+	ttlDays int, replicated, skipUnavailableShards bool) map[string]string {
 	env := map[string]string{
 		"DB":                   dbname,
 		"CLUSTER":              clusterName,
@@ -211,6 +227,7 @@ func updateScripts(db clickhouse.Conn, dbname string, clusterName string, k int6
 		"CREATE_SETTINGS":      "",
 		"SAMPLES_ORDER_RUL":    "timestamp_ns",
 		"DIST_CREATE_SETTINGS": "",
+		"AGGR_INTERVAL_NS":     strconv.FormatInt(samplesconfig.MetricsAggrInterval().Nanoseconds(), 10),
 	}
 	if storagePolicy != "" {
 		env["CREATE_SETTINGS"] = fmt.Sprintf("SETTINGS storage_policy = '%s'", storagePolicy)
@@ -219,6 +236,12 @@ func updateScripts(db clickhouse.Conn, dbname string, clusterName string, k int6
 	if advancedSamplesOrdering != "" {
 		env["SAMPLES_ORDER_RUL"] = advancedSamplesOrdering
 	}
+	// The metrics table falls back to the shared ordering rule, so an operator
+	// who only sets ADVANCED_SAMPLES_ORDERING still gets it applied to both.
+	env["METRICS_ORDER_RUL"] = env["SAMPLES_ORDER_RUL"]
+	if o := samplesconfig.MetricsOrdering(); o != "" {
+		env["METRICS_ORDER_RUL"] = o
+	}
 	//TODO: move to the config package
 	if skipUnavailableShards {
 		env["DIST_CREATE_SETTINGS"] += " SETTINGS skip_unavailable_shards = 1"
@@ -226,7 +249,6 @@ func updateScripts(db clickhouse.Conn, dbname string, clusterName string, k int6
 	if ttlDays != 0 {
 		env["DefaultTtlDays"] = strconv.FormatInt(int64(ttlDays), 10)
 	}
-
 	if clusterName != "" {
 		env["OnCluster"] = "ON CLUSTER `" + clusterName + "`"
 	}
@@ -239,6 +261,30 @@ func updateScripts(db clickhouse.Conn, dbname string, clusterName string, k int6
 		env["MergeTree"] = "MergeTree"
 		env["AggregatingMergeTree"] = "AggregatingMergeTree"
 	}
+	return env
+}
+
+// readDistEnv builds the template environment for the cross-cluster read-path
+// scripts, which is deliberately smaller than scriptEnv's.
+func readDistEnv(dbname, clusterName, readCluster, readSuffix string) map[string]string {
+	return map[string]string{
+		"DB":           dbname,
+		"CLUSTER":      clusterName,
+		"OnCluster":    "ON CLUSTER `" + clusterName + "`",
+		"READ_CLUSTER": readCluster,
+		"READ_SUFFIX":  readSuffix,
+	}
+}
+
+func updateScripts(db clickhouse.Conn, dbname string, clusterName string, k int64, file string, replicated bool,
+	ttlDays int, storagePolicy string, advancedSamplesOrdering string, skipUnavailableShards bool, logger logger.ILogger) error {
+	scripts, err := getSQLFile(file)
+	if err != nil {
+		return err
+	}
+	verTable := "ver"
+	env := scriptEnv(dbname, clusterName, storagePolicy, advancedSamplesOrdering,
+		ttlDays, replicated, skipUnavailableShards)
 	exec := getDBExec(db, env, logger)
 	err = exec(`CREATE TABLE IF NOT EXISTS ver {{.OnCluster}} (k UInt64, ver UInt64) 
 ENGINE={{.ReplacingMergeTree}}(ver) ORDER BY k`)

--- a/ctrl/qryn/sql/log_split.sql
+++ b/ctrl/qryn/sql/log_split.sql
@@ -1,0 +1,67 @@
+## Split-by-signal tables: logs and metrics stored apart.
+## Executed only when SAMPLES_SPLIT_BY_SIGNAL is on.
+## Queries are separated with ";" and one empty string
+## APPEND ONLY!!!!!
+## Templating tokens: see log.sql, plus
+##   {{.METRICS_ORDER_RUL}} - ordering rule for samples_metrics
+##   {{.AGGR_INTERVAL_NS}}  - metrics aggregation bucket width, nanoseconds
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.samples_logs {{.OnCluster}} (
+  type UInt8,
+  fingerprint UInt64 CODEC(Delta, ZSTD(1)),
+  timestamp_ns Int64 CODEC(DoubleDelta, ZSTD(1)),
+  value Float64 CODEC(Gorilla, ZSTD(1)),
+  string String CODEC(ZSTD(1))
+) ENGINE = {{.MergeTree}}
+PARTITION BY toStartOfDay(toDateTime(timestamp_ns / 1000000000))
+ORDER BY ({{.SAMPLES_ORDER_RUL}}) {{.CREATE_SETTINGS}};
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.samples_metrics {{.OnCluster}} (
+  type UInt8,
+  fingerprint UInt64 CODEC(Delta, ZSTD(1)),
+  timestamp_ns Int64 CODEC(DoubleDelta, ZSTD(1)),
+  value Float64 CODEC(Gorilla, ZSTD(1))
+) ENGINE = {{.MergeTree}}
+PARTITION BY toStartOfDay(toDateTime(timestamp_ns / 1000000000))
+ORDER BY ({{.METRICS_ORDER_RUL}}) {{.CREATE_SETTINGS}};
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.logs_aggr {{.OnCluster}} (
+  fingerprint UInt64 CODEC(Delta, ZSTD(1)),
+  timestamp_ns Int64 CODEC(DoubleDelta, ZSTD(1)),
+  last AggregateFunction(argMax, Float64, Int64) CODEC(ZSTD(1)),
+  max SimpleAggregateFunction(max, Float64) CODEC(Gorilla, ZSTD(1)),
+  min SimpleAggregateFunction(min, Float64) CODEC(Gorilla, ZSTD(1)),
+  count AggregateFunction(count) CODEC(ZSTD(1)),
+  sum SimpleAggregateFunction(sum, Float64) CODEC(Gorilla, ZSTD(1)),
+  bytes SimpleAggregateFunction(sum, Float64) CODEC(Gorilla, ZSTD(1)),
+  type UInt8
+) ENGINE = {{.AggregatingMergeTree}}
+PARTITION BY toDate(toDateTime(intDiv(timestamp_ns, 1000000000)))
+ORDER BY (fingerprint, timestamp_ns, type) {{.CREATE_SETTINGS}};
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.metrics_aggr {{.OnCluster}} (
+  fingerprint UInt64 CODEC(Delta, ZSTD(1)),
+  timestamp_ns Int64 CODEC(DoubleDelta, ZSTD(1)),
+  last AggregateFunction(argMax, Float64, Int64) CODEC(ZSTD(1)),
+  max SimpleAggregateFunction(max, Float64) CODEC(Gorilla, ZSTD(1)),
+  min SimpleAggregateFunction(min, Float64) CODEC(Gorilla, ZSTD(1)),
+  count AggregateFunction(count) CODEC(ZSTD(1)),
+  sum SimpleAggregateFunction(sum, Float64) CODEC(Gorilla, ZSTD(1)),
+  type UInt8
+) ENGINE = {{.AggregatingMergeTree}}
+PARTITION BY toDate(toDateTime(intDiv(timestamp_ns, 1000000000)))
+ORDER BY (fingerprint, timestamp_ns, type) {{.CREATE_SETTINGS}};
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS {{.DB}}.logs_aggr_mv {{.OnCluster}} TO {{.DB}}.logs_aggr
+AS SELECT
+    fingerprint,
+    intDiv(samples.timestamp_ns, 15000000000) * 15000000000 as timestamp_ns,
+    argMaxState(value, samples.timestamp_ns) as last,
+    maxSimpleState(value) as max,
+    minSimpleState(value) as min,
+    countState() as count,
+    sumSimpleState(value) as sum,
+    sumSimpleState(length(string)) as bytes,
+    type
+FROM {{.DB}}.samples_logs as samples
+GROUP BY fingerprint, timestamp_ns, type;

--- a/ctrl/qryn/sql/log_split.sql
+++ b/ctrl/qryn/sql/log_split.sql
@@ -4,7 +4,6 @@
 ## APPEND ONLY!!!!!
 ## Templating tokens: see log.sql, plus
 ##   {{.METRICS_ORDER_RUL}} - ordering rule for samples_metrics
-##   {{.AGGR_INTERVAL_NS}}  - metrics aggregation bucket width, nanoseconds
 
 CREATE TABLE IF NOT EXISTS {{.DB}}.samples_logs {{.OnCluster}} (
   type UInt8,

--- a/ctrl/qryn/sql/log_split_dist.sql
+++ b/ctrl/qryn/sql/log_split_dist.sql
@@ -1,0 +1,43 @@
+## Distributed wrappers for the split-by-signal tables.
+## Executed only when SAMPLES_SPLIT_BY_SIGNAL is on and a cluster is configured.
+## Queries are separated with ";" and one empty string
+## APPEND ONLY!!!!!
+## Templating tokens: see log.sql
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.samples_logs_dist {{.OnCluster}} (
+  `type` UInt8,
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `value` Float64 CODEC(Gorilla),
+  `string` String
+) ENGINE = Distributed('{{.CLUSTER}}','{{.DB}}', 'samples_logs', fingerprint) {{.DIST_CREATE_SETTINGS}};
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.samples_metrics_dist {{.OnCluster}} (
+  `type` UInt8,
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `value` Float64 CODEC(Gorilla)
+) ENGINE = Distributed('{{.CLUSTER}}','{{.DB}}', 'samples_metrics', fingerprint) {{.DIST_CREATE_SETTINGS}};
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.logs_aggr_dist {{.OnCluster}} (
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `last` AggregateFunction(argMax, Float64, Int64),
+  `max` SimpleAggregateFunction(max, Float64),
+  `min` SimpleAggregateFunction(min, Float64),
+  `count` AggregateFunction(count),
+  `sum` SimpleAggregateFunction(sum, Float64),
+  `bytes` SimpleAggregateFunction(sum, Float64),
+  `type` UInt8
+) ENGINE = Distributed('{{.CLUSTER}}', '{{.DB}}', 'logs_aggr', fingerprint) {{.DIST_CREATE_SETTINGS}};
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.metrics_aggr_dist {{.OnCluster}} (
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `last` AggregateFunction(argMax, Float64, Int64),
+  `max` SimpleAggregateFunction(max, Float64),
+  `min` SimpleAggregateFunction(min, Float64),
+  `count` AggregateFunction(count),
+  `sum` SimpleAggregateFunction(sum, Float64),
+  `type` UInt8
+) ENGINE = Distributed('{{.CLUSTER}}', '{{.DB}}', 'metrics_aggr', fingerprint) {{.DIST_CREATE_SETTINGS}};

--- a/ctrl/qryn/sql/log_split_read_dist.sql
+++ b/ctrl/qryn/sql/log_split_read_dist.sql
@@ -1,0 +1,42 @@
+## Cross-cluster read-path wrappers for the split-by-signal tables.
+## Used when CLICKHOUSE_READ_CLUSTER is set and SAMPLES_SPLIT_BY_SIGNAL is on.
+## Queries are separated with ";" and one empty string
+## APPEND ONLY!!!!!
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.samples_logs{{.READ_SUFFIX}} {{.OnCluster}} (
+  `type` UInt8,
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `value` Float64 CODEC(Gorilla),
+  `string` String
+) ENGINE = Distributed('{{.READ_CLUSTER}}','{{.DB}}', 'samples_logs', fingerprint) SETTINGS skip_unavailable_shards = 1;
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.samples_metrics{{.READ_SUFFIX}} {{.OnCluster}} (
+  `type` UInt8,
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `value` Float64 CODEC(Gorilla)
+) ENGINE = Distributed('{{.READ_CLUSTER}}','{{.DB}}', 'samples_metrics', fingerprint) SETTINGS skip_unavailable_shards = 1;
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.logs_aggr{{.READ_SUFFIX}} {{.OnCluster}} (
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `last` AggregateFunction(argMax, Float64, Int64),
+  `max` SimpleAggregateFunction(max, Float64),
+  `min` SimpleAggregateFunction(min, Float64),
+  `count` AggregateFunction(count),
+  `sum` SimpleAggregateFunction(sum, Float64),
+  `bytes` SimpleAggregateFunction(sum, Float64),
+  `type` UInt8
+) ENGINE = Distributed('{{.READ_CLUSTER}}', '{{.DB}}', 'logs_aggr', fingerprint) SETTINGS skip_unavailable_shards = 1;
+
+CREATE TABLE IF NOT EXISTS {{.DB}}.metrics_aggr{{.READ_SUFFIX}} {{.OnCluster}} (
+  `fingerprint` UInt64,
+  `timestamp_ns` Int64 CODEC(DoubleDelta),
+  `last` AggregateFunction(argMax, Float64, Int64),
+  `max` SimpleAggregateFunction(max, Float64),
+  `min` SimpleAggregateFunction(min, Float64),
+  `count` AggregateFunction(count),
+  `sum` SimpleAggregateFunction(sum, Float64),
+  `type` UInt8
+) ENGINE = Distributed('{{.READ_CLUSTER}}', '{{.DB}}', 'metrics_aggr', fingerprint) SETTINGS skip_unavailable_shards = 1;

--- a/ctrl/qryn/sql/sql.go
+++ b/ctrl/qryn/sql/sql.go
@@ -34,3 +34,12 @@ var RulesScript string
 
 //go:embed rules_dist.sql
 var RulesDistScript string
+
+//go:embed log_split.sql
+var LogSplitScript string
+
+//go:embed log_split_dist.sql
+var LogSplitDistScript string
+
+//go:embed log_split_read_dist.sql
+var LogSplitReadDistScript string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 - **`SAMPLES_DAYS`** - TTL in days for stored samples (default: `7`)
 - **`STORAGE_POLICY`** - ClickHouse storage policy name for data placement
 - **`SAMPLES_SPLIT_BY_SIGNAL`** - Store logs and metrics in separate tables `samples_logs` and `samples_metrics` instead of the shared `samples_v3` (`true`, `false`, default `false`). Intended for new installations: once enabled, data already in `samples_v3` is no longer read.
-- **`METRICS_AGGR_ENABLED`** - Build the metrics preaggregate `metrics_aggr` (`true`, `false`, default `true`). When `false`, metric queries read raw samples. Requires `SAMPLES_SPLIT_BY_SIGNAL`.
+- **`METRICS_AGGR_ENABLED`** - Build the metrics preaggregate `metrics_aggr` (`true`, `false`, default `true`). When `false`, metric queries read raw samples. Requires `SAMPLES_SPLIT_BY_SIGNAL`. Re-enabling does not backfill: `metrics_aggr` holds nothing for the window it was off, and queries over that window read as empty until the table is rebuilt from `samples_metrics`.
 - **`METRICS_AGGR_INTERVAL`** - Bucket width of the metrics preaggregate (default `15s`). A later change must be a whole multiple of the previous value, otherwise startup fails rather than leaving buckets coarser than the read path assumes.
 - **`METRICS_AGGR_DAYS`** - TTL in days for the metrics preaggregate (defaults to `SAMPLES_DAYS`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 - **`STORAGE_POLICY`** - ClickHouse storage policy name for data placement
 - **`SAMPLES_SPLIT_BY_SIGNAL`** - Store logs and metrics in separate tables `samples_logs` and `samples_metrics` instead of the shared `samples_v3` (`true`, `false`, default `false`). Intended for new installations: once enabled, data already in `samples_v3` is no longer read.
 - **`METRICS_AGGR_ENABLED`** - Build the metrics preaggregate `metrics_aggr` (`true`, `false`, default `true`). When `false`, metric queries read raw samples. Requires `SAMPLES_SPLIT_BY_SIGNAL`. Re-enabling does not backfill: `metrics_aggr` holds nothing for the window it was off, and queries over that window read as empty until the table is rebuilt from `samples_metrics`.
-- **`METRICS_AGGR_INTERVAL`** - Bucket width of the metrics preaggregate (default `15s`). A later change must be a whole multiple of the previous value, otherwise startup fails rather than leaving buckets coarser than the read path assumes.
+- **`METRICS_AGGR_INTERVAL`** - Bucket width of the metrics preaggregate (default `15s`), a whole number of seconds. A later change must be a whole multiple of the previous value, otherwise startup fails rather than leaving buckets coarser than the read path assumes. Widths below the scrape interval are accepted but pointless: the preaggregate then holds about a row per sample and costs more than reading raw samples.
 - **`METRICS_AGGR_DAYS`** - TTL in days for the metrics preaggregate (defaults to `SAMPLES_DAYS`)
 
 ## Mode

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 ## Advanced Settings
 
 - **`ADVANCED_SAMPLES_ORDERING`** - Custom ordering for samples table (ClickHouse ORDER BY clause)
+- **`ADVANCED_METRICS_ORDERING`** - Custom ordering for the metrics samples table when `SAMPLES_SPLIT_BY_SIGNAL` is on (defaults to `ADVANCED_SAMPLES_ORDERING`)
 - **`ADVANCED_PROMETHEUS_MAX_SAMPLES`** - Maximum number of samples returned in Prometheus queries
 - **`ADVANCED_OMIT_EMPTY_VALUES`** - Omit empty values in query results (`true`, `false`)
 - **`OMIT_CREATE_TABLES`** - Skip table creation on startup (`true`, `false`)
@@ -60,6 +61,10 @@ The container image is published to `ghcr.io/metrico/gigapipe:latest` with multi
 
 - **`SAMPLES_DAYS`** - TTL in days for stored samples (default: `7`)
 - **`STORAGE_POLICY`** - ClickHouse storage policy name for data placement
+- **`SAMPLES_SPLIT_BY_SIGNAL`** - Store logs and metrics in separate tables `samples_logs` and `samples_metrics` instead of the shared `samples_v3` (`true`, `false`, default `false`). Intended for new installations: once enabled, data already in `samples_v3` is no longer read.
+- **`METRICS_AGGR_ENABLED`** - Build the metrics preaggregate `metrics_aggr` (`true`, `false`, default `true`). When `false`, metric queries read raw samples. Requires `SAMPLES_SPLIT_BY_SIGNAL`.
+- **`METRICS_AGGR_INTERVAL`** - Bucket width of the metrics preaggregate (default `15s`). A later change must be a whole multiple of the previous value, otherwise startup fails rather than leaving buckets coarser than the read path assumes.
+- **`METRICS_AGGR_DAYS`** - TTL in days for the metrics preaggregate (defaults to `SAMPLES_DAYS`)
 
 ## Mode
 

--- a/reader/logql/logql_transpiler/clickhouse_planner/planner_metrics15s_shortcut.go
+++ b/reader/logql/logql_transpiler/clickhouse_planner/planner_metrics15s_shortcut.go
@@ -7,6 +7,7 @@ import (
 	"github.com/metrico/qryn/v5/reader/logql/logql_transpiler/shared"
 	"github.com/metrico/qryn/v5/reader/plugins"
 	sql "github.com/metrico/qryn/v5/reader/utils/sql_select"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 )
 
 type Metrics15ShortcutPlanner struct {
@@ -31,6 +32,13 @@ func NewMetrics15ShortcutPlanner(function string, duration time.Duration,
 func (m *Metrics15ShortcutPlanner) GetQuery(ctx *shared.PlannerContext, col sql.SQLObject, table string) sql.ISelect {
 	from := ctx.From
 	to := ctx.To
+	// The window must snap to the bucket grid of the table being read. A context
+	// built without an interval would divide by zero here, so fall back to the
+	// logs width, which is what this planner reads.
+	bucketNs := ctx.AggrInterval.Nanoseconds()
+	if bucketNs <= 0 {
+		bucketNs = samplesconfig.LogsAggrInterval().Nanoseconds()
+	}
 	offsetNsStr := ""
 	if m.Offset != nil {
 		from = from.Add(*m.Offset)
@@ -51,9 +59,9 @@ func (m *Metrics15ShortcutPlanner) GetQuery(ctx *shared.PlannerContext, col sql.
 		From(sql.NewSimpleCol(table, "samples")).
 		AndWhere(
 			sql.Ge(sql.NewRawObject("samples.timestamp_ns"),
-				sql.NewIntVal(from.UnixNano()/15000000000*15000000000)),
+				sql.NewIntVal(from.UnixNano()/bucketNs*bucketNs)),
 			sql.Lt(sql.NewRawObject("samples.timestamp_ns"),
-				sql.NewIntVal((to.UnixNano()/15000000000)*15000000000)),
+				sql.NewIntVal((to.UnixNano()/bucketNs)*bucketNs)),
 			GetTypes(ctx)).
 		GroupBy(sql.NewRawObject("fingerprint"), sql.NewRawObject("timestamp_ns"))
 }

--- a/reader/logql/logql_transpiler/shared/types.go
+++ b/reader/logql/logql_transpiler/shared/types.go
@@ -39,7 +39,10 @@ type PlannerContext struct {
 	TimeSeriesDistTableName    string
 	Metrics15sTableName        string
 	Metrics15sDistTableName    string
-	PatternsTable              string
+	// AggrInterval is the bucket width of the preaggregate this context reads,
+	// or 0 when there is none and raw samples must be used.
+	AggrInterval  time.Duration
+	PatternsTable string
 
 	TracesAttrsTable     string
 	TracesAttrsDistTable string

--- a/reader/promql/promql_transpiler/transpiler_v2.go
+++ b/reader/promql/promql_transpiler/transpiler_v2.go
@@ -4,6 +4,7 @@ import (
 	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
 	"github.com/metrico/qryn/v5/reader/promql/promql_transpiler/optimizer"
 	"github.com/metrico/qryn/v5/reader/promql/promql_transpiler/planner"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
@@ -13,6 +14,14 @@ var optimizers = []func() optimizer.Optimizer{
 }
 
 func TranspileExpressionV2(expr *promql_parser.Expr) (*promql_parser.Expr, error) {
+	// Every optimizer here rewrites a range function into a Substitute that
+	// reads the metrics preaggregate, and transpileLabelMatchers resolves a
+	// substitute before it consults useRawData. With no aggregate to read there
+	// is nothing to accelerate, and leaving them on would point every such query
+	// at a view that does not exist.
+	if !samplesconfig.MetricsAggrAvailable() {
+		return expr, nil
+	}
 	_expr, err := Walk(expr, expr.Expr, func(node parser.Expr) (parser.Expr, error) {
 		for _, opt := range optimizers {
 			_opt := opt()

--- a/reader/promql/promql_transpiler/vector_range_test.go
+++ b/reader/promql/promql_transpiler/vector_range_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/metrico/qryn/v5/reader/logql/logql_transpiler/clickhouse_planner"
 	"github.com/metrico/qryn/v5/reader/logql/logql_transpiler/shared"
 	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
 	dbversion "github.com/metrico/qryn/v5/reader/utils/dbVersion"
@@ -356,5 +357,48 @@ func assertOuterUnionOrdered(t *testing.T, got string) {
 	}
 	if !strings.Contains(got, "FROM ((") {
 		t.Errorf("union must be wrapped in its own parens:\n%s", got)
+	}
+}
+
+// The LogQL shortcut and the bucket read must use the configured window, not a
+// baked-in 15s. A context that does not set AggrInterval (every hand-built test
+// context) must still render, since a zero would divide by zero.
+func TestMetrics15ShortcutUsesContextInterval(t *testing.T) {
+	from := time.Unix(1700000000, 0)
+	ctx := &shared.PlannerContext{
+		From:                    from.Add(-time.Hour),
+		To:                      from,
+		Step:                    time.Minute,
+		Metrics15sTableName:     "metrics_aggr",
+		Metrics15sDistTableName: "metrics_aggr",
+		Type:                    shared.SAMPLES_TYPE_LOGS,
+		AggrInterval:            time.Minute,
+	}
+	planner := clickhouse_planner.NewMetrics15ShortcutPlanner("count_over_time", time.Minute, nil)
+	sel, err := planner.Process(ctx)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	got, err := sel.String(sql.DefaultCtx())
+	if err != nil {
+		t.Fatalf("String: %v", err)
+	}
+	// The read window must snap to the 1m bucket grid carried by the context,
+	// not the 15s grid: from/to truncate to different literals under each.
+	if !strings.Contains(got, "1699996380000000000") || !strings.Contains(got, "1699999980000000000") {
+		t.Errorf("read window is not snapped to the configured 1m grid:\n%s", got)
+	}
+	if strings.Contains(got, "1699996395000000000") || strings.Contains(got, "1699999995000000000") {
+		t.Errorf("read window still snapped to the 15s grid:\n%s", got)
+	}
+
+	// A context with no interval falls back rather than dividing by zero.
+	ctx.AggrInterval = 0
+	sel, err = planner.Process(ctx)
+	if err != nil {
+		t.Fatalf("Process with zero interval: %v", err)
+	}
+	if _, err := sel.String(sql.DefaultCtx()); err != nil {
+		t.Fatalf("String with zero interval: %v", err)
 	}
 }

--- a/reader/promql/promql_transpiler/vector_range_test.go
+++ b/reader/promql/promql_transpiler/vector_range_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/metrico/qryn/v5/reader/promql/promql_parser"
 	dbversion "github.com/metrico/qryn/v5/reader/utils/dbVersion"
 	sql "github.com/metrico/qryn/v5/reader/utils/sql_select"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 )
 
 // rangeTestCtxCap builds a planner context. staleness selects whether the server
@@ -400,5 +401,60 @@ func TestMetrics15ShortcutUsesContextInterval(t *testing.T) {
 	}
 	if _, err := sel.String(sql.DefaultCtx()); err != nil {
 		t.Fatalf("String with zero interval: %v", err)
+	}
+}
+
+// With no metrics preaggregate the optimizers must not fire. They rewrite range
+// functions into Substitutes that select from the aggregate table, and
+// transpileLabelMatchers resolves a substitute before it ever consults
+// useRawData -- so leaving them on aims every accelerated query at a view that
+// does not exist.
+func TestOptimizersOffWithoutAggregate(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	t.Setenv("METRICS_AGGR_ENABLED", "false")
+	if err := samplesconfig.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+		t.Setenv("METRICS_AGGR_ENABLED", "true")
+		_ = samplesconfig.Reload()
+	})
+
+	expr, err := promql_parser.Parse(`rate(test_metric[5m])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expr, err = TranspileExpressionV2(expr)
+	if err != nil {
+		t.Fatalf("TranspileExpressionV2: %v", err)
+	}
+	if len(expr.Substitutes) != 0 {
+		t.Errorf("got %d substitutes, want 0 with the aggregate off", len(expr.Substitutes))
+	}
+}
+
+// With an aggregate present the optimizers still fire: this is the accelerated
+// path and it must not regress.
+func TestOptimizersOnWithAggregate(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+	if err := samplesconfig.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+		_ = samplesconfig.Reload()
+	})
+
+	expr, err := promql_parser.Parse(`rate(test_metric[5m])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expr, err = TranspileExpressionV2(expr)
+	if err != nil {
+		t.Fatalf("TranspileExpressionV2: %v", err)
+	}
+	if len(expr.Substitutes) != 1 {
+		t.Errorf("got %d substitutes, want 1", len(expr.Substitutes))
 	}
 }

--- a/reader/service/prom_queryable.go
+++ b/reader/service/prom_queryable.go
@@ -22,6 +22,7 @@ import (
 	"github.com/metrico/qryn/v5/reader/utils/dbVersion"
 	"github.com/metrico/qryn/v5/reader/utils/logger"
 	"github.com/metrico/qryn/v5/reader/utils/tables"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 
 	"github.com/metrico/qryn/v5/reader/promql/promql_transpiler"
 	sql "github.com/metrico/qryn/v5/reader/utils/sql_select"
@@ -139,15 +140,21 @@ func (c *CLokiQuerier) transpileLabelMatchers(hints *storage.SelectHints,
 	matchers []*labels.Matcher, versionInfo dbversion.VersionInfo) (*promql_transpiler.TranspileResponse, error) {
 	isSupported, ok := supportedFunctions[hints.Func]
 
-	c.adjustHintsForRate(hints)
+	// The step grid is the preaggregate's bucket grid. It is the configured
+	// width whether or not the aggregate is enabled, so turning the aggregate
+	// off changes which table is read, not the shape of the answer.
+	bucketMs := samplesconfig.MetricsAggrIntervalMs()
+
+	c.adjustHintsForRate(hints, bucketMs)
 
 	if !config.Cloki.Setting.ClokiReader.Compat_4_0_19 {
-		hints.Start = hints.Start / 15000 * 15000
+		hints.Start = hints.Start / bucketMs * bucketMs
 	}
 
-	useRawData := hints.Start%15000 != 0 ||
-		hints.Step < 15000 ||
-		(hints.Range > 0 && hints.Range < 15000) ||
+	useRawData := !samplesconfig.MetricsAggrAvailable() ||
+		hints.Start%bucketMs != 0 ||
+		hints.Step < bucketMs ||
+		(hints.Range > 0 && hints.Range < bucketMs) ||
 		!(isSupported || !ok)
 
 	start := hints.Start - hints.Range
@@ -186,10 +193,14 @@ func (c *CLokiQuerier) transpileLabelMatchers(hints *storage.SelectHints,
 
 var rateFunctions = []string{"deriv", "rate", "delta"}
 
-func (c *CLokiQuerier) adjustHintsForRate(hints *storage.SelectHints) {
+// adjustHintsForRate floors the step for the rate-like functions, which cannot
+// be answered off a grid coarser than half their range. floorMs is the
+// preaggregate bucket width: no step finer than one bucket is answerable from
+// the aggregate.
+func (c *CLokiQuerier) adjustHintsForRate(hints *storage.SelectHints, floorMs int64) {
 	step := hints.Step
 	if slices.Contains(rateFunctions, hints.Func) && hints.Step > (hints.Range/2) || hints.Step == 0 {
-		step = max(hints.Range/2, 15000)
+		step = max(hints.Range/2, floorMs)
 	}
 	hints.Step = step
 }

--- a/reader/utils/dbVersion/version.go
+++ b/reader/utils/dbVersion/version.go
@@ -109,25 +109,6 @@ FROM %s WHERE type='update' GROUP BY fingerprint HAVING _name!=''`, tableName))
 		}
 	}
 
-	tables, err := db.QueryCtx(ctx, `SHOW TABLES`)
-	if err != nil {
-		return nil, err
-	}
-	defer tables.Close()
-	metrics15sV1 := false
-	for tables.Next() {
-		var tableName string
-		err = tables.Scan(&tableName)
-		if err != nil {
-			fmt.Println(err)
-			continue
-		}
-		metrics15sV1 = metrics15sV1 || tableName == "metrics_15s" || tableName == "metrics_15s_dist"
-	}
-	if !metrics15sV1 {
-		_versions["v5"] = 0
-	}
-
 	// Probe the server for optional SQL features. A failed probe leaves the
 	// capability absent, which degrades to the compatible path rather than an
 	// error, so a transient error here is not fatal to the query.

--- a/reader/utils/tables/tables.go
+++ b/reader/utils/tables/tables.go
@@ -3,11 +3,13 @@ package tables
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/metrico/qryn/v5/reader/logql/logql_transpiler/shared"
 	"github.com/metrico/qryn/v5/reader/model"
 	"github.com/metrico/qryn/v5/reader/plugins"
 	"github.com/metrico/qryn/v5/shared/distconfig"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 )
 
 var tableNames = func() map[string]string {
@@ -38,6 +40,12 @@ func init() {
 	tableNames["tempo_traces_attrs_gin"] = "tempo_traces_attrs_gin"
 	tableNames["tempo_traces_attrs_gin_dist"] = "tempo_traces_attrs_gin_dist"
 	tableNames["patterns"] = "patterns"
+	tableNames["samples_logs"] = "samples_logs"
+	tableNames["samples_logs_dist"] = "samples_logs_dist"
+	tableNames["samples_metrics"] = "samples_metrics"
+	tableNames["samples_metrics_dist"] = "samples_metrics_dist"
+	tableNames["logs_aggr"] = "logs_aggr"
+	tableNames["metrics_aggr"] = "metrics_aggr"
 }
 
 // InitDistTableNames re-registers dist table names using the configured suffix.
@@ -53,6 +61,8 @@ func InitDistTableNames() {
 	tableNames["time_series_gin_dist"] = "time_series_gin" + suffix
 	tableNames["samples_v3_dist"] = "samples_v3" + suffix
 	tableNames["tempo_traces_attrs_gin_dist"] = "tempo_traces_attrs_gin" + suffix
+	tableNames["samples_logs_dist"] = "samples_logs" + suffix
+	tableNames["samples_metrics_dist"] = "samples_metrics" + suffix
 }
 
 func GetTableName(name string) string {
@@ -70,14 +80,18 @@ func GetTableName(name string) string {
 }
 
 func PopulateTableNames(ctx *shared.PlannerContext, db *model.DataDatabasesMap) *shared.PlannerContext {
-	ctx.SamplesTableName = GetTableName("samples_v3")
-	ctx.SamplesDistTableName = GetTableName("samples_v3")
+	// Type is the signal selector every reader entry point already sets: PromQL
+	// and the prometheus label routes pass 2, the loki ones pass 1 or 0.
+	metrics := ctx.Type == shared.SAMPLES_TYPE_METRICS
+	ctx.SamplesTableName = GetTableName(samplesconfig.SamplesTable(metrics))
+	ctx.SamplesDistTableName = ctx.SamplesTableName
 	ctx.TimeSeriesTableName = GetTableName("time_series")
 	ctx.TimeSeriesDistTableName = GetTableName("time_series")
 	ctx.TimeSeriesGinTableName = GetTableName("time_series_gin")
 	ctx.TimeSeriesGinDistTableName = GetTableName("time_series_gin")
-	ctx.Metrics15sTableName = GetTableName("metrics_15s")
-	ctx.Metrics15sDistTableName = GetTableName("metrics_15s")
+	ctx.Metrics15sTableName = GetTableName(samplesconfig.AggrTable(metrics))
+	ctx.Metrics15sDistTableName = ctx.Metrics15sTableName
+	ctx.AggrInterval = aggrInterval(metrics)
 
 	ctx.ProfilesSeriesGinTable = GetTableName("profiles_series_gin")
 	ctx.ProfilesSeriesGinDistTable = GetTableName("profiles_series_gin")
@@ -114,4 +128,18 @@ func PopulateTableNames(ctx *shared.PlannerContext, db *model.DataDatabasesMap) 
 		ctx.TracesKVDistTable = fmt.Sprintf("`%s`.%s%s", db.Config.Name, ctx.TracesKVTable, suffix)
 	}
 	return ctx
+}
+
+// aggrInterval is the bucket width of the preaggregate one signal reads, or 0
+// when it has none. Logs always have one, fixed at 15s. Metrics have one only
+// while the aggregation switch holds -- and without the split that switch does
+// not apply, since the shared metrics_15s view is always there.
+func aggrInterval(metrics bool) time.Duration {
+	if metrics && samplesconfig.SplitBySignal() && !samplesconfig.MetricsAggrEnabled() {
+		return 0
+	}
+	if metrics && samplesconfig.SplitBySignal() {
+		return samplesconfig.MetricsAggrInterval()
+	}
+	return samplesconfig.LogsAggrInterval()
 }

--- a/reader/utils/tables/tables_test.go
+++ b/reader/utils/tables/tables_test.go
@@ -1,0 +1,128 @@
+package tables
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/reader/logql/logql_transpiler/shared"
+	"github.com/metrico/qryn/v5/reader/model"
+	"github.com/metrico/qryn/v5/shared/distconfig"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
+)
+
+func reload(t *testing.T) {
+	t.Helper()
+	if err := samplesconfig.Reload(); err != nil {
+		t.Fatalf("samplesconfig reload: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+		t.Setenv("METRICS_AGGR_ENABLED", "true")
+		t.Setenv("METRICS_AGGR_INTERVAL", "")
+		_ = samplesconfig.Reload()
+	})
+}
+
+func singleNodeDB() *model.DataDatabasesMap {
+	return &model.DataDatabasesMap{Config: &clokiconfig.ClokiBaseDataBase{Name: "qryn"}}
+}
+
+// PopulateTableNames appends distconfig.Suffix() to the dist names, and that
+// suffix is empty until Init runs.
+func TestMain(m *testing.M) {
+	distconfig.Init()
+	os.Exit(m.Run())
+}
+
+// Without the split both signals read the shared tables, exactly as before.
+func TestPopulateTableNamesNoSplit(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+	reload(t)
+
+	for _, tp := range []uint8{shared.SAMPLES_TYPE_LOGS, shared.SAMPLES_TYPE_METRICS, shared.SAMPLES_TYPE_BOTH} {
+		ctx := PopulateTableNames(&shared.PlannerContext{Type: tp}, singleNodeDB())
+		if ctx.SamplesTableName != "samples_v3" {
+			t.Errorf("type %d: samples table = %q, want samples_v3", tp, ctx.SamplesTableName)
+		}
+		if ctx.Metrics15sTableName != "metrics_15s" {
+			t.Errorf("type %d: aggr table = %q, want metrics_15s", tp, ctx.Metrics15sTableName)
+		}
+		if ctx.AggrInterval != 15*time.Second {
+			t.Errorf("type %d: interval = %v, want 15s", tp, ctx.AggrInterval)
+		}
+	}
+}
+
+// With the split the metrics context reads the metrics tables and every other
+// context reads the log ones. Type is the selector every reader entry point
+// already sets.
+func TestPopulateTableNamesSplit(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	t.Setenv("METRICS_AGGR_INTERVAL", "60s")
+	reload(t)
+
+	metrics := PopulateTableNames(&shared.PlannerContext{Type: shared.SAMPLES_TYPE_METRICS}, singleNodeDB())
+	if metrics.SamplesTableName != "samples_metrics" {
+		t.Errorf("metrics samples table = %q", metrics.SamplesTableName)
+	}
+	if metrics.Metrics15sTableName != "metrics_aggr" {
+		t.Errorf("metrics aggr table = %q", metrics.Metrics15sTableName)
+	}
+	if metrics.AggrInterval != time.Minute {
+		t.Errorf("metrics interval = %v, want 1m", metrics.AggrInterval)
+	}
+
+	for _, tp := range []uint8{shared.SAMPLES_TYPE_LOGS, shared.SAMPLES_TYPE_BOTH} {
+		logs := PopulateTableNames(&shared.PlannerContext{Type: tp}, singleNodeDB())
+		if logs.SamplesTableName != "samples_logs" {
+			t.Errorf("type %d: samples table = %q", tp, logs.SamplesTableName)
+		}
+		if logs.Metrics15sTableName != "logs_aggr" {
+			t.Errorf("type %d: aggr table = %q", tp, logs.Metrics15sTableName)
+		}
+		// Logs keep their 15s preaggregate whatever the metrics interval is.
+		if logs.AggrInterval != 15*time.Second {
+			t.Errorf("type %d: interval = %v, want 15s", tp, logs.AggrInterval)
+		}
+	}
+}
+
+// A disabled metrics aggregate reports interval 0, which is how the read path
+// learns to go to raw samples.
+func TestPopulateTableNamesAggrDisabled(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	t.Setenv("METRICS_AGGR_ENABLED", "false")
+	reload(t)
+
+	metrics := PopulateTableNames(&shared.PlannerContext{Type: shared.SAMPLES_TYPE_METRICS}, singleNodeDB())
+	if metrics.AggrInterval != 0 {
+		t.Errorf("metrics interval = %v, want 0", metrics.AggrInterval)
+	}
+	if metrics.SamplesTableName != "samples_metrics" {
+		t.Errorf("metrics samples table = %q", metrics.SamplesTableName)
+	}
+	// Logs are unaffected by the metrics switch.
+	logs := PopulateTableNames(&shared.PlannerContext{Type: shared.SAMPLES_TYPE_LOGS}, singleNodeDB())
+	if logs.AggrInterval != 15*time.Second {
+		t.Errorf("logs interval = %v, want 15s", logs.AggrInterval)
+	}
+}
+
+// In cluster mode the dist names carry the db prefix and the configured suffix.
+func TestPopulateTableNamesCluster(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reload(t)
+
+	db := &model.DataDatabasesMap{Config: &clokiconfig.ClokiBaseDataBase{
+		Name: "qryn", ClusterName: "c",
+	}}
+	ctx := PopulateTableNames(&shared.PlannerContext{Type: shared.SAMPLES_TYPE_METRICS}, db)
+	if ctx.SamplesDistTableName != "`qryn`.samples_metrics_dist" {
+		t.Errorf("dist samples table = %q", ctx.SamplesDistTableName)
+	}
+	if ctx.Metrics15sDistTableName != "`qryn`.metrics_aggr_dist" {
+		t.Errorf("dist aggr table = %q", ctx.Metrics15sDistTableName)
+	}
+}

--- a/shared/samplesconfig/samplesconfig.go
+++ b/shared/samplesconfig/samplesconfig.go
@@ -40,6 +40,10 @@ func Init() error {
 	return initErr
 }
 
+// Reload re-reads the environment, bypassing the once guard. It exists for
+// tests, which need to exercise both layouts in one process.
+func Reload() error { return load() }
+
 func load() error {
 	var err error
 	if splitBySignal, err = boolEnv("SAMPLES_SPLIT_BY_SIGNAL", false); err != nil {

--- a/shared/samplesconfig/samplesconfig.go
+++ b/shared/samplesconfig/samplesconfig.go
@@ -26,16 +26,18 @@ var (
 	aggrInterval  = logsAggrInterval
 	aggrDays      int
 	metricsOrder  string
+	initErr       error
 
 	once sync.Once
 )
 
 // Init reads the environment once at startup. Call it before anything reads a
-// getter, and before tables.InitDistTableNames.
+// getter, and before tables.InitDistTableNames. Every call reports the result
+// of the single load, so a later caller cannot mistake a failed load for a
+// successful one.
 func Init() error {
-	var err error
-	once.Do(func() { err = load() })
-	return err
+	once.Do(func() { initErr = load() })
+	return initErr
 }
 
 func load() error {

--- a/shared/samplesconfig/samplesconfig.go
+++ b/shared/samplesconfig/samplesconfig.go
@@ -58,8 +58,12 @@ func load() error {
 		if err != nil {
 			return fmt.Errorf("METRICS_AGGR_INTERVAL: %w", err)
 		}
-		if d <= 0 {
-			return fmt.Errorf("METRICS_AGGR_INTERVAL must be positive, got %s", v)
+		// Whole seconds only. The view buckets on nanoseconds while the read
+		// path snaps the step grid on milliseconds, so a width that is not a
+		// round number of milliseconds would have the two disagree, and a
+		// sub-millisecond one would truncate to a zero divisor.
+		if d < time.Second || d%time.Second != 0 {
+			return fmt.Errorf("METRICS_AGGR_INTERVAL must be a whole number of seconds, got %s", v)
 		}
 		aggrInterval = d
 	}

--- a/shared/samplesconfig/samplesconfig.go
+++ b/shared/samplesconfig/samplesconfig.go
@@ -1,0 +1,142 @@
+// Package samplesconfig carries the samples-storage layout: whether logs and
+// metrics live in separate tables, and how the metrics preaggregate is built.
+//
+// It is a standalone env-backed package rather than fields on the main config
+// because ctrl, writer and reader all need these values, while the config
+// struct itself lives in an external module.
+package samplesconfig
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// logsAggrInterval is the bucket width of the logs preaggregate. It stays fixed
+// because the LogQL shortcut planner and the stored logs_aggr rows were built
+// against it; only the metrics side is tunable so far.
+const logsAggrInterval = 15 * time.Second
+
+var (
+	splitBySignal bool
+	aggrEnabled   = true
+	aggrInterval  = logsAggrInterval
+	aggrDays      int
+	metricsOrder  string
+
+	once sync.Once
+)
+
+// Init reads the environment once at startup. Call it before anything reads a
+// getter, and before tables.InitDistTableNames.
+func Init() error {
+	var err error
+	once.Do(func() { err = load() })
+	return err
+}
+
+func load() error {
+	var err error
+	if splitBySignal, err = boolEnv("SAMPLES_SPLIT_BY_SIGNAL", false); err != nil {
+		return err
+	}
+	if aggrEnabled, err = boolEnv("METRICS_AGGR_ENABLED", true); err != nil {
+		return err
+	}
+	aggrInterval = logsAggrInterval
+	if v := os.Getenv("METRICS_AGGR_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("METRICS_AGGR_INTERVAL: %w", err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("METRICS_AGGR_INTERVAL must be positive, got %s", v)
+		}
+		aggrInterval = d
+	}
+	aggrDays = 0
+	if v := os.Getenv("METRICS_AGGR_DAYS"); v != "" {
+		d, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("METRICS_AGGR_DAYS: %w", err)
+		}
+		if d < 0 {
+			return fmt.Errorf("METRICS_AGGR_DAYS must not be negative, got %s", v)
+		}
+		aggrDays = d
+	}
+	metricsOrder = os.Getenv("ADVANCED_METRICS_ORDERING")
+	return nil
+}
+
+func boolEnv(key string, def bool) (bool, error) {
+	val := os.Getenv(key)
+	if val == "" {
+		return def, nil
+	}
+	if slices.Contains([]string{"true", "1", "yes", "y"}, val) {
+		return true, nil
+	}
+	if slices.Contains([]string{"false", "0", "no", "n"}, val) {
+		return false, nil
+	}
+	return false, fmt.Errorf("%s value must be one of [no, n, false, 0, yes, y, true, 1]", key)
+}
+
+// SplitBySignal reports whether logs and metrics are stored apart.
+func SplitBySignal() bool { return splitBySignal }
+
+// MetricsAggrEnabled reports whether metrics_aggr_mv should exist. It is
+// meaningful only under SplitBySignal; without the split the shared metrics_15s
+// view is always present.
+func MetricsAggrEnabled() bool { return aggrEnabled }
+
+// MetricsAggrAvailable reports whether a metrics preaggregate exists to read
+// from. This is the question the read path asks, and it differs from
+// MetricsAggrEnabled precisely when the split is off.
+func MetricsAggrAvailable() bool { return !splitBySignal || aggrEnabled }
+
+// MetricsAggrInterval is the metrics bucket width. It is the configured value
+// whether or not the aggregate is enabled, so the read path's step arithmetic
+// stays on one grid either way.
+func MetricsAggrInterval() time.Duration { return aggrInterval }
+
+// MetricsAggrIntervalMs is MetricsAggrInterval in milliseconds, the unit
+// prometheus SelectHints use.
+func MetricsAggrIntervalMs() int64 { return aggrInterval.Milliseconds() }
+
+// LogsAggrInterval is the logs bucket width, fixed at 15s.
+func LogsAggrInterval() time.Duration { return logsAggrInterval }
+
+// MetricsAggrDays is the metrics_aggr retention in days; 0 means inherit the
+// samples retention, which only the caller holding the db config can resolve.
+func MetricsAggrDays() int { return aggrDays }
+
+// MetricsOrdering is the ORDER BY rule for samples_metrics; empty means inherit
+// the samples ordering.
+func MetricsOrdering() string { return metricsOrder }
+
+// SamplesTable names the raw samples table for one signal.
+func SamplesTable(metrics bool) string {
+	if !splitBySignal {
+		return "samples_v3"
+	}
+	if metrics {
+		return "samples_metrics"
+	}
+	return "samples_logs"
+}
+
+// AggrTable names the preaggregate table for one signal.
+func AggrTable(metrics bool) string {
+	if !splitBySignal {
+		return "metrics_15s"
+	}
+	if metrics {
+		return "metrics_aggr"
+	}
+	return "logs_aggr"
+}

--- a/shared/samplesconfig/samplesconfig_test.go
+++ b/shared/samplesconfig/samplesconfig_test.go
@@ -1,0 +1,159 @@
+package samplesconfig
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	reset(t)
+	if err := load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if SplitBySignal() {
+		t.Error("split must default to off")
+	}
+	if !MetricsAggrEnabled() {
+		t.Error("aggregation must default to on")
+	}
+	if got := MetricsAggrInterval(); got != 15*time.Second {
+		t.Errorf("interval = %v, want 15s", got)
+	}
+	if got := MetricsAggrDays(); got != 0 {
+		t.Errorf("days = %d, want 0 (inherit)", got)
+	}
+	if got := MetricsOrdering(); got != "" {
+		t.Errorf("ordering = %q, want empty (inherit)", got)
+	}
+}
+
+func TestLoadOverrides(t *testing.T) {
+	reset(t)
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	t.Setenv("METRICS_AGGR_ENABLED", "false")
+	t.Setenv("METRICS_AGGR_INTERVAL", "60s")
+	t.Setenv("METRICS_AGGR_DAYS", "90")
+	t.Setenv("ADVANCED_METRICS_ORDERING", "fingerprint, timestamp_ns")
+	if err := load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !SplitBySignal() {
+		t.Error("split must be on")
+	}
+	if MetricsAggrEnabled() {
+		t.Error("aggregation must be off")
+	}
+	if got := MetricsAggrInterval(); got != time.Minute {
+		t.Errorf("interval = %v, want 1m", got)
+	}
+	if got := MetricsAggrIntervalMs(); got != 60000 {
+		t.Errorf("interval ms = %d, want 60000", got)
+	}
+	if got := MetricsAggrDays(); got != 90 {
+		t.Errorf("days = %d, want 90", got)
+	}
+	if got := MetricsOrdering(); got != "fingerprint, timestamp_ns" {
+		t.Errorf("ordering = %q", got)
+	}
+}
+
+// A malformed value must be fatal, not silently ignored: a typo in the interval
+// would otherwise build the aggregate at the wrong granularity, and the error
+// would only surface as wrong query results much later.
+func TestLoadRejectsMalformed(t *testing.T) {
+	for _, tc := range []struct{ key, val string }{
+		{"SAMPLES_SPLIT_BY_SIGNAL", "maybe"},
+		{"METRICS_AGGR_ENABLED", "sometimes"},
+		{"METRICS_AGGR_INTERVAL", "15 seconds"},
+		{"METRICS_AGGR_INTERVAL", "0s"},
+		{"METRICS_AGGR_INTERVAL", "-5s"},
+		{"METRICS_AGGR_DAYS", "many"},
+		{"METRICS_AGGR_DAYS", "-1"},
+	} {
+		t.Run(tc.key+"="+tc.val, func(t *testing.T) {
+			reset(t)
+			t.Setenv(tc.key, tc.val)
+			if err := load(); err == nil {
+				t.Errorf("%s=%q accepted, want error", tc.key, tc.val)
+			}
+		})
+	}
+}
+
+func TestTableNames(t *testing.T) {
+	reset(t)
+	if err := load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := SamplesTable(false); got != "samples_v3" {
+		t.Errorf("logs samples table = %q", got)
+	}
+	if got := SamplesTable(true); got != "samples_v3" {
+		t.Errorf("metrics samples table = %q", got)
+	}
+	if got := AggrTable(true); got != "metrics_15s" {
+		t.Errorf("metrics aggr table = %q", got)
+	}
+
+	reset(t)
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "1")
+	if err := load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	for _, tc := range []struct {
+		got, want string
+	}{
+		{SamplesTable(false), "samples_logs"},
+		{SamplesTable(true), "samples_metrics"},
+		{AggrTable(false), "logs_aggr"},
+		{AggrTable(true), "metrics_aggr"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("got %q, want %q", tc.got, tc.want)
+		}
+	}
+}
+
+// MetricsAggrAvailable answers "is there a metrics preaggregate to read", which
+// is the question the read path asks. Without the split there always is one
+// (metrics_15s); with it, only while METRICS_AGGR_ENABLED holds.
+func TestMetricsAggrAvailable(t *testing.T) {
+	for _, tc := range []struct {
+		split, enabled, want bool
+	}{
+		{false, true, true},
+		{false, false, true},
+		{true, true, true},
+		{true, false, false},
+	} {
+		reset(t)
+		t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", boolStr(tc.split))
+		t.Setenv("METRICS_AGGR_ENABLED", boolStr(tc.enabled))
+		if err := load(); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if got := MetricsAggrAvailable(); got != tc.want {
+			t.Errorf("split=%v enabled=%v: available = %v, want %v",
+				tc.split, tc.enabled, got, tc.want)
+		}
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// reset clears every variable the package reads so each case starts from the
+// documented defaults regardless of the ambient environment.
+func reset(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"SAMPLES_SPLIT_BY_SIGNAL", "METRICS_AGGR_ENABLED", "METRICS_AGGR_INTERVAL",
+		"METRICS_AGGR_DAYS", "ADVANCED_METRICS_ORDERING",
+	} {
+		t.Setenv(k, "")
+	}
+}

--- a/shared/samplesconfig/samplesconfig_test.go
+++ b/shared/samplesconfig/samplesconfig_test.go
@@ -19,6 +19,9 @@ func TestLoadDefaults(t *testing.T) {
 	if got := MetricsAggrInterval(); got != 15*time.Second {
 		t.Errorf("interval = %v, want 15s", got)
 	}
+	if got := MetricsAggrIntervalMs(); got != 15000 {
+		t.Errorf("interval ms = %d, want 15000", got)
+	}
 	if got := MetricsAggrDays(); got != 0 {
 		t.Errorf("days = %d, want 0 (inherit)", got)
 	}
@@ -91,6 +94,9 @@ func TestTableNames(t *testing.T) {
 	if got := SamplesTable(true); got != "samples_v3" {
 		t.Errorf("metrics samples table = %q", got)
 	}
+	if got := AggrTable(false); got != "metrics_15s" {
+		t.Errorf("logs aggr table = %q", got)
+	}
 	if got := AggrTable(true); got != "metrics_15s" {
 		t.Errorf("metrics aggr table = %q", got)
 	}
@@ -136,6 +142,21 @@ func TestMetricsAggrAvailable(t *testing.T) {
 			t.Errorf("split=%v enabled=%v: available = %v, want %v",
 				tc.split, tc.enabled, got, tc.want)
 		}
+	}
+}
+
+// Init reports the same result to every caller, not just the first: it runs
+// load exactly once, so a later caller must not read a failed load as success.
+func TestInitReportsTheLoadErrorToEveryCaller(t *testing.T) {
+	reset(t)
+	t.Setenv("METRICS_AGGR_INTERVAL", "not a duration")
+
+	first := Init()
+	if first == nil {
+		t.Fatal("first Init accepted a malformed interval")
+	}
+	if second := Init(); second == nil {
+		t.Error("second Init returned nil after a failed load")
 	}
 }
 

--- a/shared/samplesconfig/samplesconfig_test.go
+++ b/shared/samplesconfig/samplesconfig_test.go
@@ -70,6 +70,8 @@ func TestLoadRejectsMalformed(t *testing.T) {
 		{"METRICS_AGGR_INTERVAL", "15 seconds"},
 		{"METRICS_AGGR_INTERVAL", "0s"},
 		{"METRICS_AGGR_INTERVAL", "-5s"},
+		{"METRICS_AGGR_INTERVAL", "100us"},
+		{"METRICS_AGGR_INTERVAL", "1500ms"},
 		{"METRICS_AGGR_DAYS", "many"},
 		{"METRICS_AGGR_DAYS", "-1"},
 	} {

--- a/writer/controller/builder.go
+++ b/writer/controller/builder.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	retry "github.com/avast/retry-go"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/config"
 	"github.com/metrico/qryn/v5/writer/model"
 	"github.com/metrico/qryn/v5/writer/pattern/controller"
@@ -223,6 +224,52 @@ func doLogsPattern(s *model.TimeSamplesData) {
 	controller.ClusterLines(s.MMessage, s.MFingerprint, s.MTimestampNS)
 }
 
+// splitByType divides a samples request into its log and metric halves for a
+// split store. Either half is nil when it has no rows, which doPush reads as
+// nothing to send.
+//
+// The halves must answer the queries the shared table answered. Reads filter
+// with `type IN (wanted, 0)` (GetTypes), so a dual-typed row cannot be written
+// as-is -- 3 matches neither signal -- and is written as a log row in one half
+// and a metric row in the other. An undefined type stays 0 in both halves,
+// where it keeps matching both, exactly as it did in the shared table.
+func splitByType(s *model.TimeSamplesData) (*model.TimeSamplesData, *model.TimeSamplesData) {
+	logs := &model.TimeSamplesData{}
+	metrics := &model.TimeSamplesData{}
+	for i, tp := range s.MType {
+		if tp == model.SAMPLE_TYPE_LOG_AND_METRIC || tp&model.SAMPLE_TYPE_LOG != 0 {
+			appendSample(logs, s, i, model.SAMPLE_TYPE_LOG)
+		}
+		if tp == model.SAMPLE_TYPE_LOG_AND_METRIC || tp&model.SAMPLE_TYPE_METRIC != 0 {
+			appendSample(metrics, s, i, model.SAMPLE_TYPE_METRIC)
+		}
+		if tp == model.SAMPLE_TYPE_UNDEF {
+			appendSample(logs, s, i, model.SAMPLE_TYPE_UNDEF)
+			appendSample(metrics, s, i, model.SAMPLE_TYPE_UNDEF)
+		}
+	}
+	if len(logs.MFingerprint) == 0 {
+		logs = nil
+	}
+	if len(metrics.MFingerprint) == 0 {
+		metrics = nil
+	}
+	return logs, metrics
+}
+
+// appendSample copies row i of src into dst under type tp. Size follows the
+// same per-row formula the parser uses (unmarshal/builder.go:368), so queue
+// accounting stays comparable across the split.
+func appendSample(dst, src *model.TimeSamplesData, i int, tp uint8) {
+	dst.MFingerprint = append(dst.MFingerprint, src.MFingerprint[i])
+	dst.MTimestampNS = append(dst.MTimestampNS, src.MTimestampNS[i])
+	dst.MValue = append(dst.MValue, src.MValue[i])
+	dst.MMessage = append(dst.MMessage, src.MMessage[i])
+	dst.MTTLDays = append(dst.MTTLDays, src.MTTLDays[i])
+	dst.MType = append(dst.MType, tp)
+	dst.Size += len(src.MMessage[i]) + 26
+}
+
 // IngestParsed runs parser and pushes each ParserResponse to the given
 // per-tenant insert services. It is the transport-agnostic core shared by the
 // HTTP handlers and the gRPC receiver.
@@ -238,15 +285,31 @@ func IngestParsed(ctx context.Context, parser BoundParser, svcs InsertServices) 
 			}()
 			return response.Error
 		}
+		samples := response.SamplesRequest
+		var metricSamples helpers.SizeGetter
+		if samplesconfig.SplitBySignal() {
+			if spl, ok := samples.(*model.TimeSamplesData); ok {
+				logHalf, metricHalf := splitByType(spl)
+				samples, metricSamples = nil, nil
+				if logHalf != nil {
+					samples = logHalf
+				}
+				if metricHalf != nil {
+					metricSamples = metricHalf
+				}
+			}
+		}
 		promises = append(promises,
 			doPush(response.TimeSeriesRequest, service.INSERT_MODE_SYNC, svcs.Ts),
-			doPush(response.SamplesRequest, service.INSERT_MODE_SYNC, svcs.Spl),
+			doPush(samples, service.INSERT_MODE_SYNC, svcs.Spl),
+			doPush(metricSamples, service.INSERT_MODE_SYNC, svcs.Mtr),
 			doPush(response.SpansAttrsRequest, service.INSERT_MODE_SYNC, svcs.SpanAttrs),
 			doPush(response.SpansRequest, service.INSERT_MODE_SYNC, svcs.Spans),
 			doPush(response.ProfileRequest, service.INSERT_MODE_SYNC, svcs.Profile),
 		)
-		if response.SamplesRequest != nil {
-			doLogsPattern(response.SamplesRequest.(*model.TimeSamplesData))
+		// Pattern clustering reads log lines, so it sees the log half only.
+		if s, ok := samples.(*model.TimeSamplesData); ok && s != nil {
+			doLogsPattern(s)
 		}
 	}
 	for _, p := range promises {

--- a/writer/controller/builder.go
+++ b/writer/controller/builder.go
@@ -237,10 +237,10 @@ func splitByType(s *model.TimeSamplesData) (*model.TimeSamplesData, *model.TimeS
 	logs := &model.TimeSamplesData{}
 	metrics := &model.TimeSamplesData{}
 	for i, tp := range s.MType {
-		if tp == model.SAMPLE_TYPE_LOG_AND_METRIC || tp&model.SAMPLE_TYPE_LOG != 0 {
+		if tp&model.SAMPLE_TYPE_LOG != 0 {
 			appendSample(logs, s, i, model.SAMPLE_TYPE_LOG)
 		}
-		if tp == model.SAMPLE_TYPE_LOG_AND_METRIC || tp&model.SAMPLE_TYPE_METRIC != 0 {
+		if tp&model.SAMPLE_TYPE_METRIC != 0 {
 			appendSample(metrics, s, i, model.SAMPLE_TYPE_METRIC)
 		}
 		if tp == model.SAMPLE_TYPE_UNDEF {

--- a/writer/controller/builder.go
+++ b/writer/controller/builder.go
@@ -238,14 +238,14 @@ func splitByType(s *model.TimeSamplesData) (*model.TimeSamplesData, *model.TimeS
 	metrics := &model.TimeSamplesData{}
 	for i, tp := range s.MType {
 		if tp&model.SAMPLE_TYPE_LOG != 0 {
-			appendSample(logs, s, i, model.SAMPLE_TYPE_LOG)
+			appendSample(logs, s, i, model.SAMPLE_TYPE_LOG, true)
 		}
 		if tp&model.SAMPLE_TYPE_METRIC != 0 {
-			appendSample(metrics, s, i, model.SAMPLE_TYPE_METRIC)
+			appendSample(metrics, s, i, model.SAMPLE_TYPE_METRIC, false)
 		}
 		if tp == model.SAMPLE_TYPE_UNDEF {
-			appendSample(logs, s, i, model.SAMPLE_TYPE_UNDEF)
-			appendSample(metrics, s, i, model.SAMPLE_TYPE_UNDEF)
+			appendSample(logs, s, i, model.SAMPLE_TYPE_UNDEF, true)
+			appendSample(metrics, s, i, model.SAMPLE_TYPE_UNDEF, false)
 		}
 	}
 	if len(logs.MFingerprint) == 0 {
@@ -259,15 +259,22 @@ func splitByType(s *model.TimeSamplesData) (*model.TimeSamplesData, *model.TimeS
 
 // appendSample copies row i of src into dst under type tp. Size follows the
 // same per-row formula the parser uses (unmarshal/builder.go:368), so queue
-// accounting stays comparable across the split.
-func appendSample(dst, src *model.TimeSamplesData, i int, tp uint8) {
+// accounting stays comparable across the split. hasMessage tells it whether
+// dst is the logs half: samples_metrics has no string column and
+// NewMetricsInsertService's insert never writes one, so the message length is
+// only real for the logs half, not for tp (an undefined row is written to
+// both halves under the same tp).
+func appendSample(dst, src *model.TimeSamplesData, i int, tp uint8, hasMessage bool) {
 	dst.MFingerprint = append(dst.MFingerprint, src.MFingerprint[i])
 	dst.MTimestampNS = append(dst.MTimestampNS, src.MTimestampNS[i])
 	dst.MValue = append(dst.MValue, src.MValue[i])
 	dst.MMessage = append(dst.MMessage, src.MMessage[i])
 	dst.MTTLDays = append(dst.MTTLDays, src.MTTLDays[i])
 	dst.MType = append(dst.MType, tp)
-	dst.Size += len(src.MMessage[i]) + 26
+	dst.Size += 26
+	if hasMessage {
+		dst.Size += len(src.MMessage[i])
+	}
 }
 
 // IngestParsed runs parser and pushes each ParserResponse to the given

--- a/writer/controller/builder.go
+++ b/writer/controller/builder.go
@@ -261,6 +261,7 @@ func doParse(r *http.Request, parser Parser) error {
 	svcs := InsertServices{
 		Ts:        getService(r, utils.ContextKeyTsService),
 		Spl:       getService(r, utils.ContextKeySplService),
+		Mtr:       getService(r, utils.ContextKeyMtrService),
 		SpanAttrs: getService(r, utils.ContextKeySpanAttrsService),
 		Spans:     getService(r, utils.ContextKeySpansService),
 		Profile:   getService(r, utils.ContextKeyProfileService),

--- a/writer/controller/middleware.go
+++ b/writer/controller/middleware.go
@@ -229,6 +229,7 @@ var withTSAndSampleService = WithPreRequest(func(w http.ResponseWriter, r *http.
 		return err
 	}
 	ctx = context.WithValue(ctx, utils.ContextKeySplService, logSvcs.Spl)
+	ctx = context.WithValue(ctx, utils.ContextKeyMtrService, logSvcs.Mtr)
 	ctx = context.WithValue(ctx, utils.ContextKeyTsService, logSvcs.Ts)
 	ctx = context.WithValue(ctx, utils.ContextKeyProfileService, profileSvcs.Profile)
 	ctx = context.WithValue(ctx, utils.ContextKeyNode, logSvcs.Node)

--- a/writer/controller/otlp_metrics_test.go
+++ b/writer/controller/otlp_metrics_test.go
@@ -23,12 +23,13 @@ import (
 )
 
 // metricsFakeRegistry satisfies registry.ServiceRegistry with recorder-backed
-// samples, time-series and profile services, which is the set
+// samples, time-series, metrics and profile services, which is the set
 // withTSAndSampleService resolves.
 type metricsFakeRegistry struct {
-	samples    *recorderSvc
-	timeSeries *recorderSvc
-	profile    *recorderSvc
+	samples    service.IInsertServiceV2
+	timeSeries service.IInsertServiceV2
+	profile    service.IInsertServiceV2
+	mtr        service.IInsertServiceV2
 }
 
 func (f *metricsFakeRegistry) GetTimeSeriesService(id string) (service.IInsertServiceV2, error) {
@@ -38,7 +39,7 @@ func (f *metricsFakeRegistry) GetSamplesService(id string) (service.IInsertServi
 	return f.samples, nil
 }
 func (f *metricsFakeRegistry) GetMetricsService(id string) (service.IInsertServiceV2, error) {
-	return nil, nil
+	return f.mtr, nil
 }
 func (f *metricsFakeRegistry) GetSpansService(id string) (service.IInsertServiceV2, error) {
 	return nil, nil

--- a/writer/controller/recording_writeback.go
+++ b/writer/controller/recording_writeback.go
@@ -4,17 +4,15 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/metrico/qryn/v5/writer/service"
-	"github.com/metrico/qryn/v5/writer/utils/promise"
 	"github.com/metrico/qryn/v5/writer/utils/proto/prompb"
 	"github.com/metrico/qryn/v5/writer/utils/unmarshal"
 	"google.golang.org/protobuf/proto"
 )
 
 // PushPromWriteRequest ingests a Prometheus remote-write request in-process,
-// reusing the metrics parser (which fingerprints labels) and pushing the built
-// time_series/samples models to the static insert registry. It is the
-// in-process write-back path for recording rules: no HTTP, snappy, or auth.
+// reusing the metrics parser (which fingerprints labels) and routing it
+// through IngestParsed like every other transport. It is the in-process
+// write-back path for recording rules: no HTTP, snappy, or auth.
 //
 // The writer module must be initialized first, so Registry and FPCache are set.
 func PushPromWriteRequest(ctx context.Context, wr *prompb.WriteRequest) error {
@@ -27,37 +25,9 @@ func PushPromWriteRequest(ctx context.Context, wr *prompb.WriteRequest) error {
 		return err
 	}
 
-	tsSvc, err := Registry.GetTimeSeriesService("")
+	svcs, err := ResolveMetricServices("")
 	if err != nil {
 		return err
 	}
-	splSvc, err := Registry.GetSamplesService("")
-	if err != nil {
-		return err
-	}
-	node := tsSvc.GetNodeName()
-
-	res := unmarshal.UnmarshallMetricsWriteProtoV2(ctx, bytes.NewReader(data), FPCache.DB(node))
-
-	var promises []*promise.Promise[uint32]
-	for response := range res {
-		if response.Error != nil {
-			// Drain remaining responses so the parser goroutine can exit.
-			go func() {
-				for range res {
-				}
-			}()
-			return response.Error
-		}
-		promises = append(promises,
-			doPush(response.TimeSeriesRequest, service.INSERT_MODE_SYNC, tsSvc),
-			doPush(response.SamplesRequest, service.INSERT_MODE_SYNC, splSvc),
-		)
-	}
-	for _, p := range promises {
-		if _, err := p.Get(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return IngestParsed(ctx, Bind(Parser(unmarshal.UnmarshallMetricsWriteProtoV2), bytes.NewReader(data)), svcs)
 }

--- a/writer/controller/recording_writeback_test.go
+++ b/writer/controller/recording_writeback_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/proto/prompb"
+)
+
+// With the split on, a recording-rule write-back carries only metric rows, so
+// they must reach the metrics service and never the samples service -- the
+// same routing IngestParsed gives every other transport.
+func TestPushPromWriteRequestRoutesToMetricsService(t *testing.T) {
+	installFPCache(t, "n")
+	installConfig(t)
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	ts := &recorderSvc{}
+	mtr := &recorderSvc{}
+	installRegistry(t, spl, ts, mtr)
+
+	wr := &prompb.WriteRequest{
+		Timeseries: []*prompb.TimeSeries{
+			{
+				Labels:  []*prompb.Label{{Name: "__name__", Value: "test_rule"}},
+				Samples: []*prompb.Sample{{Value: 1, Timestamp: 1}},
+			},
+		},
+	}
+
+	if err := PushPromWriteRequest(context.Background(), wr); err != nil {
+		t.Fatalf("PushPromWriteRequest: %v", err)
+	}
+
+	if len(spl.reqs()) != 0 {
+		t.Errorf("samples service got %d requests, want 0", len(spl.reqs()))
+	}
+	mtrReqs := mtr.reqs()
+	if len(mtrReqs) != 1 {
+		t.Fatalf("metrics service got %d requests, want 1", len(mtrReqs))
+	}
+	if got := mtrReqs[0].(*model.TimeSamplesData).MFingerprint; len(got) != 1 {
+		t.Errorf("metric fingerprints = %v, want 1 row", got)
+	}
+	if len(ts.reqs()) != 1 {
+		t.Errorf("time series service got %d requests, want 1", len(ts.reqs()))
+	}
+}

--- a/writer/controller/services.go
+++ b/writer/controller/services.go
@@ -15,7 +15,7 @@ type InsertServices struct {
 	Ts  service.IInsertServiceV2
 	Spl service.IInsertServiceV2
 	// Mtr is the metrics half of a split store, nil when logs and metrics share
-	// one table. doPush treats a nil service as nothing to send.
+	// one table.
 	Mtr       service.IInsertServiceV2
 	SpanAttrs service.IInsertServiceV2
 	Spans     service.IInsertServiceV2

--- a/writer/controller/services.go
+++ b/writer/controller/services.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/service"
 )
 
@@ -11,8 +12,11 @@ import (
 // nil-safe). SIGNAL ISOLATION: each signal resolves ONLY its own services —
 // logs never resolve spans services, traces never resolve samples, etc.
 type InsertServices struct {
-	Ts        service.IInsertServiceV2
-	Spl       service.IInsertServiceV2
+	Ts  service.IInsertServiceV2
+	Spl service.IInsertServiceV2
+	// Mtr is the metrics half of a split store, nil when logs and metrics share
+	// one table. doPush treats a nil service as nothing to send.
+	Mtr       service.IInsertServiceV2
 	SpanAttrs service.IInsertServiceV2
 	Spans     service.IInsertServiceV2
 	Profile   service.IInsertServiceV2
@@ -49,15 +53,21 @@ func ResolveLogServices(dsn string) (InsertServices, error) {
 	if s.Ts, err = Registry.GetTimeSeriesService(dsn); err != nil {
 		return s, err
 	}
+	if samplesconfig.SplitBySignal() {
+		if s.Mtr, err = Registry.GetMetricsService(dsn); err != nil {
+			return s, err
+		}
+	}
 	// Node keys the fingerprint cache, which gates time_series writes — rows
 	// that go to Ts, so the cache must be namespaced by Ts's node.
 	s.Node = s.Ts.GetNodeName()
 	return s, nil
 }
 
-// ResolveMetricServices resolves only the metric insert services for a
-// tenant. Metrics and logs share the same storage (samples + time series), so
-// this delegates to ResolveLogServices; it exists so metric callers don't
+// ResolveMetricServices resolves only the metric insert services for a tenant.
+// It delegates to ResolveLogServices because both signals resolve the same
+// pair: the time series service, plus the samples service and — under
+// SAMPLES_SPLIT_BY_SIGNAL — the metrics one. It exists so metric callers don't
 // appear to violate the SIGNAL ISOLATION contract by resolving another
 // signal's services.
 func ResolveMetricServices(dsn string) (InsertServices, error) {

--- a/writer/controller/services_test.go
+++ b/writer/controller/services_test.go
@@ -88,11 +88,13 @@ func reloadSamplesConfig(t *testing.T) {
 }
 
 // installRegistry points the package-global Registry at recorder services and
-// restores the previous one on cleanup.
+// restores the previous one on cleanup. profile is a plain recorder since
+// withTSAndSampleService also resolves it, and a nil service there would
+// panic on GetNodeName rather than exercise anything this test cares about.
 func installRegistry(t *testing.T, spl, ts, mtr service.IInsertServiceV2) {
 	t.Helper()
 	old := Registry
-	Registry = &metricsFakeRegistry{samples: spl, timeSeries: ts, mtr: mtr}
+	Registry = &metricsFakeRegistry{samples: spl, timeSeries: ts, mtr: mtr, profile: &recorderSvc{}}
 	t.Cleanup(func() { Registry = old })
 }
 
@@ -161,18 +163,46 @@ func TestResolveMetricServicesWithSplit(t *testing.T) {
 	}
 }
 
-// doParse rebuilds InsertServices from context keys rather than from what
-// Resolve*Services returned, so the metrics service needs a key of its own.
-// Without it every HTTP ingest route hands IngestParsed a nil Mtr and doPush
-// silently drops the metric half.
-func TestMetricsServiceSurvivesTheContext(t *testing.T) {
-	mtr := &recorderSvc{}
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
-	ctx := context.WithValue(req.Context(), utils.ContextKeyMtrService,
-		service.IInsertServiceV2(mtr))
-	req = req.WithContext(ctx)
+// withTSAndSampleService is the only thing that puts the metrics service where
+// doParse can find it: doParse rebuilds InsertServices from context keys rather
+// than from what ResolveLogServices returned. Asserting through the real
+// middleware means reverting either half of that wiring fails this test.
+func TestMiddlewarePlantsTheMetricsService(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reloadSamplesConfig(t)
 
+	spl, ts, mtr := &recorderSvc{}, &recorderSvc{}, &recorderSvc{}
+	installRegistry(t, spl, ts, mtr)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), utils.ContextKeyDSN, ""))
+
+	pusher := withTSAndSampleService(&PusherCtx{})
+	if err := pusher.PreRequest[0](httptest.NewRecorder(), req); err != nil {
+		t.Fatalf("pre-request: %v", err)
+	}
 	if got := getService(req, utils.ContextKeyMtrService); got != mtr {
-		t.Errorf("getService returned %v, want the metrics service", got)
+		t.Errorf("metrics service = %v, want the registry's", got)
+	}
+}
+
+// Without the split the key is planted nil, which doPush reads as nothing to
+// send — the pre-split behaviour, unchanged.
+func TestMiddlewarePlantsNoMetricsServiceWithoutSplit(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+	reloadSamplesConfig(t)
+
+	spl, ts, mtr := &recorderSvc{}, &recorderSvc{}, &recorderSvc{}
+	installRegistry(t, spl, ts, mtr)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), utils.ContextKeyDSN, ""))
+
+	pusher := withTSAndSampleService(&PusherCtx{})
+	if err := pusher.PreRequest[0](httptest.NewRecorder(), req); err != nil {
+		t.Fatalf("pre-request: %v", err)
+	}
+	if got := getService(req, utils.ContextKeyMtrService); got != nil {
+		t.Errorf("metrics service = %v, want nil", got)
 	}
 }

--- a/writer/controller/services_test.go
+++ b/writer/controller/services_test.go
@@ -1,11 +1,16 @@
 package controller
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/service"
 	"github.com/metrico/qryn/v5/writer/service/registry"
+	"github.com/metrico/qryn/v5/writer/utils"
 	"github.com/metrico/qryn/v5/writer/utils/helpers"
 	"github.com/metrico/qryn/v5/writer/utils/promise"
 )
@@ -66,5 +71,108 @@ func TestResolveLogServicesNodeFollowsTimeSeries(t *testing.T) {
 	}
 	if svcs.Node != "ts-node" {
 		t.Errorf("Node=%q, want %q: the fingerprint cache must be namespaced by the node receiving time_series rows", svcs.Node, "ts-node")
+	}
+}
+
+// reloadSamplesConfig re-reads the samples environment inside a test. Init is
+// once-guarded for production; tests drive the loader directly.
+func reloadSamplesConfig(t *testing.T) {
+	t.Helper()
+	if err := samplesconfig.Reload(); err != nil {
+		t.Fatalf("samplesconfig reload: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+		_ = samplesconfig.Reload()
+	})
+}
+
+// installRegistry points the package-global Registry at recorder services and
+// restores the previous one on cleanup.
+func installRegistry(t *testing.T, spl, ts, mtr service.IInsertServiceV2) {
+	t.Helper()
+	old := Registry
+	Registry = &metricsFakeRegistry{samples: spl, timeSeries: ts, mtr: mtr}
+	t.Cleanup(func() { Registry = old })
+}
+
+// With the split off, metrics keep going to the samples service and Mtr stays
+// nil, so doPush skips it: the shared table is still the only destination.
+func TestResolveLogServicesNoSplit(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	ts := &recorderSvc{}
+	mtr := &recorderSvc{}
+	installRegistry(t, spl, ts, mtr)
+
+	svcs, err := ResolveLogServices("")
+	if err != nil {
+		t.Fatalf("ResolveLogServices: %v", err)
+	}
+	if svcs.Spl != spl {
+		t.Error("Spl not resolved to the samples service")
+	}
+	if svcs.Mtr != nil {
+		t.Error("Mtr must stay nil without the split")
+	}
+}
+
+// With the split on, a metrics service must be resolved: it is the only path to
+// samples_metrics, and IngestParsed pushes the metric half at it.
+func TestResolveLogServicesWithSplit(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	ts := &recorderSvc{}
+	mtr := &recorderSvc{}
+	installRegistry(t, spl, ts, mtr)
+
+	svcs, err := ResolveLogServices("")
+	if err != nil {
+		t.Fatalf("ResolveLogServices: %v", err)
+	}
+	if svcs.Spl != spl {
+		t.Error("Spl not resolved to the samples service")
+	}
+	if svcs.Mtr != mtr {
+		t.Error("Mtr not resolved to the metrics service")
+	}
+}
+
+// ResolveMetricServices delegates, so it must expose the same pair.
+func TestResolveMetricServicesWithSplit(t *testing.T) {
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	ts := &recorderSvc{}
+	mtr := &recorderSvc{}
+	installRegistry(t, spl, ts, mtr)
+
+	svcs, err := ResolveMetricServices("")
+	if err != nil {
+		t.Fatalf("ResolveMetricServices: %v", err)
+	}
+	if svcs.Spl != spl || svcs.Mtr != mtr {
+		t.Error("ResolveMetricServices must expose both halves")
+	}
+}
+
+// doParse rebuilds InsertServices from context keys rather than from what
+// Resolve*Services returned, so the metrics service needs a key of its own.
+// Without it every HTTP ingest route hands IngestParsed a nil Mtr and doPush
+// silently drops the metric half.
+func TestMetricsServiceSurvivesTheContext(t *testing.T) {
+	mtr := &recorderSvc{}
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	ctx := context.WithValue(req.Context(), utils.ContextKeyMtrService,
+		service.IInsertServiceV2(mtr))
+	req = req.WithContext(ctx)
+
+	if got := getService(req, utils.ContextKeyMtrService); got != mtr {
+		t.Errorf("getService returned %v, want the metrics service", got)
 	}
 }

--- a/writer/controller/split_test.go
+++ b/writer/controller/split_test.go
@@ -1,0 +1,226 @@
+package controller
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/service"
+	"github.com/metrico/qryn/v5/writer/utils"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+)
+
+// splitByType must preserve exactly what a query against the shared table saw.
+// GetTypes builds `type IN (wanted, 0)`, so a dual-typed row cannot be written
+// as 3 -- it would match neither signal -- and an undefined row must stay 0 in
+// both halves, where it keeps matching both.
+func TestSplitByType(t *testing.T) {
+	src := &model.TimeSamplesData{
+		MFingerprint: []uint64{10, 20, 30, 40},
+		MTimestampNS: []int64{1, 2, 3, 4},
+		MMessage:     []string{"log", "", "both", "undef"},
+		MValue:       []float64{0, 2.5, 3.5, 4.5},
+		MTTLDays:     []uint16{7, 7, 7, 7},
+		MType: []uint8{
+			model.SAMPLE_TYPE_LOG,
+			model.SAMPLE_TYPE_METRIC,
+			model.SAMPLE_TYPE_LOG_AND_METRIC,
+			model.SAMPLE_TYPE_UNDEF,
+		},
+		Size: 100,
+	}
+
+	logs, metrics := splitByType(src)
+
+	if got := logs.MFingerprint; len(got) != 3 || got[0] != 10 || got[1] != 30 || got[2] != 40 {
+		t.Errorf("log fingerprints = %v, want [10 30 40]", got)
+	}
+	if got := logs.MType; len(got) != 3 ||
+		got[0] != model.SAMPLE_TYPE_LOG ||
+		got[1] != model.SAMPLE_TYPE_LOG ||
+		got[2] != model.SAMPLE_TYPE_UNDEF {
+		t.Errorf("log types = %v, want [1 1 0]", got)
+	}
+	if got := logs.MMessage; len(got) != 3 || got[0] != "log" || got[1] != "both" || got[2] != "undef" {
+		t.Errorf("log messages = %v", got)
+	}
+
+	if got := metrics.MFingerprint; len(got) != 3 || got[0] != 20 || got[1] != 30 || got[2] != 40 {
+		t.Errorf("metric fingerprints = %v, want [20 30 40]", got)
+	}
+	if got := metrics.MType; len(got) != 3 ||
+		got[0] != model.SAMPLE_TYPE_METRIC ||
+		got[1] != model.SAMPLE_TYPE_METRIC ||
+		got[2] != model.SAMPLE_TYPE_UNDEF {
+		t.Errorf("metric types = %v, want [2 2 0]", got)
+	}
+	if got := metrics.MValue; len(got) != 3 || got[1] != 3.5 {
+		t.Errorf("metric values = %v", got)
+	}
+
+	// Every column of a half must be the same length, or the columnar insert
+	// builds a malformed block.
+	for name, half := range map[string]*model.TimeSamplesData{"logs": logs, "metrics": metrics} {
+		n := len(half.MFingerprint)
+		if len(half.MTimestampNS) != n || len(half.MValue) != n ||
+			len(half.MType) != n || len(half.MMessage) != n || len(half.MTTLDays) != n {
+			t.Errorf("%s: ragged columns: fp=%d ts=%d val=%d tp=%d msg=%d ttl=%d",
+				name, n, len(half.MTimestampNS), len(half.MValue),
+				len(half.MType), len(half.MMessage), len(half.MTTLDays))
+		}
+	}
+}
+
+// A half with no rows must come back nil so doPush skips it entirely rather
+// than sending an empty insert.
+func TestSplitByTypeEmptyHalf(t *testing.T) {
+	src := &model.TimeSamplesData{
+		MFingerprint: []uint64{1},
+		MTimestampNS: []int64{1},
+		MMessage:     []string{""},
+		MValue:       []float64{7},
+		MTTLDays:     []uint16{7},
+		MType:        []uint8{model.SAMPLE_TYPE_METRIC},
+	}
+	logs, metrics := splitByType(src)
+	if logs != nil {
+		t.Errorf("log half must be nil, got %d rows", len(logs.MFingerprint))
+	}
+	if metrics == nil || len(metrics.MFingerprint) != 1 {
+		t.Error("metric half must carry the single row")
+	}
+}
+
+// With the split on, IngestParsed must send each half to its own service and
+// nothing to the other.
+func TestIngestParsedSplitsSamples(t *testing.T) {
+	installFPCache(t, "n")
+	installConfig(t)
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	mtr := &recorderSvc{}
+	samples := &model.TimeSamplesData{
+		MFingerprint: []uint64{1, 2},
+		MTimestampNS: []int64{1, 2},
+		MMessage:     []string{"line", ""},
+		MValue:       []float64{0, 5},
+		MTTLDays:     []uint16{7, 7},
+		MType:        []uint8{model.SAMPLE_TYPE_LOG, model.SAMPLE_TYPE_METRIC},
+	}
+	parser := func(_ context.Context, _ numbercache.ICache[uint64]) chan *model.ParserResponse {
+		ch := make(chan *model.ParserResponse, 1)
+		ch <- &model.ParserResponse{SamplesRequest: samples}
+		close(ch)
+		return ch
+	}
+
+	err := IngestParsed(context.Background(), parser,
+		InsertServices{Spl: spl, Mtr: mtr, Node: "n"})
+	if err != nil {
+		t.Fatalf("IngestParsed: %v", err)
+	}
+
+	splReqs := spl.reqs()
+	if len(splReqs) != 1 {
+		t.Fatalf("samples service got %d requests, want 1", len(splReqs))
+	}
+	if got := splReqs[0].(*model.TimeSamplesData).MFingerprint; len(got) != 1 || got[0] != 1 {
+		t.Errorf("log half fingerprints = %v, want [1]", got)
+	}
+	mtrReqs := mtr.reqs()
+	if len(mtrReqs) != 1 {
+		t.Fatalf("metrics service got %d requests, want 1", len(mtrReqs))
+	}
+	if got := mtrReqs[0].(*model.TimeSamplesData).MFingerprint; len(got) != 1 || got[0] != 2 {
+		t.Errorf("metric half fingerprints = %v, want [2]", got)
+	}
+}
+
+// doParse rebuilds InsertServices from context keys rather than from what
+// ResolveLogServices returned, so the metric half only reaches its service if
+// doParse reads the metrics key. Task 4 proved the middleware plants that key;
+// this proves doParse reads it, which is the other half of the same defect.
+func TestDoParseRoutesTheMetricHalf(t *testing.T) {
+	installFPCache(t, "n")
+	installConfig(t)
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "true")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	mtr := &recorderSvc{}
+	samples := &model.TimeSamplesData{
+		MFingerprint: []uint64{1, 2},
+		MTimestampNS: []int64{1, 2},
+		MMessage:     []string{"line", ""},
+		MValue:       []float64{0, 5},
+		MTTLDays:     []uint16{7, 7},
+		MType:        []uint8{model.SAMPLE_TYPE_LOG, model.SAMPLE_TYPE_METRIC},
+	}
+	parser := func(_ context.Context, _ io.Reader, _ numbercache.ICache[uint64]) chan *model.ParserResponse {
+		ch := make(chan *model.ParserResponse, 1)
+		ch <- &model.ParserResponse{SamplesRequest: samples}
+		close(ch)
+		return ch
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, utils.ContextKeySplService, service.IInsertServiceV2(spl))
+	ctx = context.WithValue(ctx, utils.ContextKeyMtrService, service.IInsertServiceV2(mtr))
+	ctx = context.WithValue(ctx, utils.ContextKeyNode, "n")
+	req = req.WithContext(ctx)
+
+	if err := doParse(req, parser); err != nil {
+		t.Fatalf("doParse: %v", err)
+	}
+	if len(mtr.reqs()) != 1 {
+		t.Fatalf("metrics service got %d requests through doParse, want 1", len(mtr.reqs()))
+	}
+	if got := mtr.reqs()[0].(*model.TimeSamplesData).MFingerprint; len(got) != 1 || got[0] != 2 {
+		t.Errorf("metric half fingerprints = %v, want [2]", got)
+	}
+}
+
+// With the split off nothing changes: one request, whole, to the samples
+// service, and the metrics service untouched even when it is wired.
+func TestIngestParsedNoSplitKeepsOneRequest(t *testing.T) {
+	installFPCache(t, "n")
+	installConfig(t)
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+	reloadSamplesConfig(t)
+
+	spl := &recorderSvc{}
+	mtr := &recorderSvc{}
+	samples := &model.TimeSamplesData{
+		MFingerprint: []uint64{1, 2},
+		MTimestampNS: []int64{1, 2},
+		MMessage:     []string{"line", ""},
+		MValue:       []float64{0, 5},
+		MTTLDays:     []uint16{7, 7},
+		MType:        []uint8{model.SAMPLE_TYPE_LOG, model.SAMPLE_TYPE_METRIC},
+	}
+	parser := func(_ context.Context, _ numbercache.ICache[uint64]) chan *model.ParserResponse {
+		ch := make(chan *model.ParserResponse, 1)
+		ch <- &model.ParserResponse{SamplesRequest: samples}
+		close(ch)
+		return ch
+	}
+
+	err := IngestParsed(context.Background(), parser,
+		InsertServices{Spl: spl, Mtr: mtr, Node: "n"})
+	if err != nil {
+		t.Fatalf("IngestParsed: %v", err)
+	}
+	splReqs := spl.reqs()
+	if len(splReqs) != 1 || splReqs[0] != samples {
+		t.Errorf("samples service must get the original request unchanged")
+	}
+	if len(mtr.reqs()) != 0 {
+		t.Error("metrics service must stay untouched without the split")
+	}
+}

--- a/writer/controller/split_test.go
+++ b/writer/controller/split_test.go
@@ -74,6 +74,30 @@ func TestSplitByType(t *testing.T) {
 	}
 }
 
+// samples_metrics has no string column, so a dual-typed row's message bytes
+// must count toward the logs half's Size only -- the metrics half never
+// writes them and must not flush early over bytes it doesn't send.
+func TestSplitByTypeSizeCountsMessageOnceOnLogsHalf(t *testing.T) {
+	src := &model.TimeSamplesData{
+		MFingerprint: []uint64{1, 2},
+		MTimestampNS: []int64{1, 2},
+		MMessage:     []string{"twelve chars", ""},
+		MValue:       []float64{0, 5},
+		MTTLDays:     []uint16{7, 7},
+		MType:        []uint8{model.SAMPLE_TYPE_LOG_AND_METRIC, model.SAMPLE_TYPE_UNDEF},
+	}
+	logs, metrics := splitByType(src)
+
+	wantLogs := 26 + len("twelve chars") + 26
+	if logs.Size != wantLogs {
+		t.Errorf("logs.Size = %d, want %d", logs.Size, wantLogs)
+	}
+	wantMetrics := 26 + 26
+	if metrics.Size != wantMetrics {
+		t.Errorf("metrics.Size = %d, want %d (message bytes must not count)", metrics.Size, wantMetrics)
+	}
+}
+
 // A half with no rows must come back nil so doPush skips it entirely rather
 // than sending an empty insert.
 func TestSplitByTypeEmptyHalf(t *testing.T) {

--- a/writer/model/insert_request.go
+++ b/writer/model/insert_request.go
@@ -9,6 +9,10 @@ const (
 	SAMPLE_TYPE_LOG    = 1
 	SAMPLE_TYPE_METRIC = 2
 	SAMPLE_TYPE_UNDEF  = 0
+
+	// SAMPLE_TYPE_LOG_AND_METRIC marks a row carrying both a log line and a
+	// numeric value, which only a loki-style push can produce.
+	SAMPLE_TYPE_LOG_AND_METRIC = SAMPLE_TYPE_LOG | SAMPLE_TYPE_METRIC
 )
 
 // Our replacement for gofaster.ch StrCol

--- a/writer/plugin/qryn_writer_db.go
+++ b/writer/plugin/qryn_writer_db.go
@@ -8,6 +8,7 @@ import (
 
 	clickhouse_v2 "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/chwrapper"
 	config2 "github.com/metrico/qryn/v5/writer/config"
 	"github.com/metrico/qryn/v5/writer/model"
@@ -72,12 +73,21 @@ func (p *QrynWriterPlugin) getDataDBSession(config config.ClokiBaseSettingServer
 
 func healthCheck(conn chwrapper.IChClient, isDistributed bool) {
 	tablesToCheck := []string{
-		"time_series", "samples_v3", "settings",
+		"time_series", "settings",
 		"tempo_traces", "tempo_traces_attrs_gin",
 	}
 	distTablesToCheck := []string{
-		"samples_v3_dist", "time_series_dist",
+		"time_series_dist",
 		"tempo_traces_dist", "tempo_traces_attrs_gin_dist",
+	}
+	// The samples tables depend on the storage layout; probing the wrong ones
+	// panics a healthy install on startup.
+	if samplesconfig.SplitBySignal() {
+		tablesToCheck = append(tablesToCheck, "samples_logs", "samples_metrics")
+		distTablesToCheck = append(distTablesToCheck, "samples_logs_dist", "samples_metrics_dist")
+	} else {
+		tablesToCheck = append(tablesToCheck, "samples_v3")
+		distTablesToCheck = append(distTablesToCheck, "samples_v3_dist")
 	}
 	checkTable := func(table string) error {
 		query := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", table)

--- a/writer/plugin/qryn_writer_db.go
+++ b/writer/plugin/qryn_writer_db.go
@@ -71,24 +71,30 @@ func (p *QrynWriterPlugin) getDataDBSession(config config.ClokiBaseSettingServer
 	return dbNodeMap, dbv2Map, dbv3Map
 }
 
-func healthCheck(conn chwrapper.IChClient, isDistributed bool) {
-	tablesToCheck := []string{
+// healthCheckTables lists the tables healthCheck must probe before the writer
+// accepts traffic. The samples tables depend on the storage layout; probing
+// the wrong ones panics a healthy install on startup.
+func healthCheckTables(splitBySignal bool) (tablesToCheck, distTablesToCheck []string) {
+	tablesToCheck = []string{
 		"time_series", "settings",
 		"tempo_traces", "tempo_traces_attrs_gin",
 	}
-	distTablesToCheck := []string{
+	distTablesToCheck = []string{
 		"time_series_dist",
 		"tempo_traces_dist", "tempo_traces_attrs_gin_dist",
 	}
-	// The samples tables depend on the storage layout; probing the wrong ones
-	// panics a healthy install on startup.
-	if samplesconfig.SplitBySignal() {
+	if splitBySignal {
 		tablesToCheck = append(tablesToCheck, "samples_logs", "samples_metrics")
 		distTablesToCheck = append(distTablesToCheck, "samples_logs_dist", "samples_metrics_dist")
 	} else {
 		tablesToCheck = append(tablesToCheck, "samples_v3")
 		distTablesToCheck = append(distTablesToCheck, "samples_v3_dist")
 	}
+	return tablesToCheck, distTablesToCheck
+}
+
+func healthCheck(conn chwrapper.IChClient, isDistributed bool) {
+	tablesToCheck, distTablesToCheck := healthCheckTables(samplesconfig.SplitBySignal())
 	checkTable := func(table string) error {
 		query := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", table)
 		to, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/writer/plugin/qryn_writer_db_test.go
+++ b/writer/plugin/qryn_writer_db_test.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"slices"
+	"testing"
+)
+
+// A wrong table name here panics a healthy install at startup (healthCheck
+// calls panic on a failed probe), so the probed set for each layout is worth
+// pinning down without a live ClickHouse connection.
+func TestHealthCheckTables(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		splitBySignal  bool
+		wantTables     []string
+		wantDistTables []string
+	}{
+		{
+			name:          "shared samples table",
+			splitBySignal: false,
+			wantTables: []string{
+				"time_series", "settings",
+				"tempo_traces", "tempo_traces_attrs_gin",
+				"samples_v3",
+			},
+			wantDistTables: []string{
+				"time_series_dist",
+				"tempo_traces_dist", "tempo_traces_attrs_gin_dist",
+				"samples_v3_dist",
+			},
+		},
+		{
+			name:          "split by signal",
+			splitBySignal: true,
+			wantTables: []string{
+				"time_series", "settings",
+				"tempo_traces", "tempo_traces_attrs_gin",
+				"samples_logs", "samples_metrics",
+			},
+			wantDistTables: []string{
+				"time_series_dist",
+				"tempo_traces_dist", "tempo_traces_attrs_gin_dist",
+				"samples_logs_dist", "samples_metrics_dist",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tables, distTables := healthCheckTables(tc.splitBySignal)
+			if !slices.Equal(tables, tc.wantTables) {
+				t.Errorf("tablesToCheck = %v, want %v", tables, tc.wantTables)
+			}
+			if !slices.Equal(distTables, tc.wantDistTables) {
+				t.Errorf("distTablesToCheck = %v, want %v", distTables, tc.wantDistTables)
+			}
+		})
+	}
+}

--- a/writer/service/insert/metrics.go
+++ b/writer/service/insert/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ClickHouse/ch-go/proto"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/model"
 	"github.com/metrico/qryn/v5/writer/plugins"
 	"github.com/metrico/qryn/v5/writer/service"
@@ -50,7 +51,7 @@ func NewMetricsInsertService(opts model.InsertServiceOpts) service.IInsertServic
 	if opts.ParallelNum <= 0 {
 		opts.ParallelNum = 1
 	}
-	tableName := "samples_v3"
+	tableName := samplesconfig.SamplesTable(true)
 	if opts.Node.ClusterName != "" {
 		tableName += "_dist"
 	}

--- a/writer/service/insert/samples.go
+++ b/writer/service/insert/samples.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ClickHouse/ch-go/proto"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/model"
 	"github.com/metrico/qryn/v5/writer/plugins"
 	"github.com/metrico/qryn/v5/writer/service"
@@ -53,7 +54,7 @@ func NewSamplesInsertService(opts model.InsertServiceOpts) service.IInsertServic
 	if opts.ParallelNum <= 0 {
 		opts.ParallelNum = 1
 	}
-	table := "samples_v3"
+	table := samplesconfig.SamplesTable(false)
 	if opts.Node.ClusterName != "" {
 		table += "_dist"
 	}

--- a/writer/utils/context.go
+++ b/writer/utils/context.go
@@ -14,6 +14,7 @@ const (
 	ContextKeyTTLDays          ContextKey = "TTL_DAYS"
 	ContextKeyAsync            ContextKey = "async"
 	ContextKeySplService       ContextKey = "splService"
+	ContextKeyMtrService       ContextKey = "mtrService"
 	ContextKeyTsService        ContextKey = "tsService"
 	ContextKeyProfileService   ContextKey = "profileService"
 	ContextKeyNode             ContextKey = "node"

--- a/writer/utils/unmarshal/builder.go
+++ b/writer/utils/unmarshal/builder.go
@@ -358,8 +358,17 @@ func (p *parserDoer) onEntries(labels [][]string, timestampsNS []int64,
 	p.tsSpl.spl.MTTLDays = append(p.tsSpl.spl.MTTLDays, slices.Repeat([]uint16{ttlDays}, len(timestampsNS))...)
 	p.tsSpl.spl.MType = append(p.tsSpl.spl.MType, types...)
 
-	var tps [3]bool
+	// A dual-typed row needs a time_series row for each signal, not one row of
+	// type 3: label lookups filter with `type IN (wanted, 0)`, which a 3 matches
+	// for neither. The array is sized past the largest type so indexing by it is
+	// in range.
+	var tps [model.SAMPLE_TYPE_LOG_AND_METRIC + 1]bool
 	for _, t := range types {
+		if t == model.SAMPLE_TYPE_LOG_AND_METRIC {
+			tps[model.SAMPLE_TYPE_LOG] = true
+			tps[model.SAMPLE_TYPE_METRIC] = true
+			continue
+		}
 		tps[t] = true
 	}
 

--- a/writer/utils/unmarshal/split_test.go
+++ b/writer/utils/unmarshal/split_test.go
@@ -1,0 +1,104 @@
+package unmarshal
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	clconfig "github.com/metrico/cloki-config"
+	clokiconfig "github.com/metrico/cloki-config/config"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
+	"github.com/metrico/qryn/v5/writer/config"
+	"github.com/metrico/qryn/v5/writer/model"
+	"github.com/metrico/qryn/v5/writer/utils/numbercache"
+)
+
+// setSplitBySignal drives the samplesconfig loader directly, the same way
+// controller.reloadSamplesConfig does, and always leaves the package back at
+// its default so this test's env choice cannot leak into another test.
+func setSplitBySignal(t *testing.T, on string) {
+	t.Helper()
+	t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", on)
+	if err := samplesconfig.Reload(); err != nil {
+		t.Fatalf("samplesconfig reload: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Setenv("SAMPLES_SPLIT_BY_SIGNAL", "false")
+		_ = samplesconfig.Reload()
+	})
+}
+
+// A loki-style entry carrying both a line and a value produces type 3.
+// TestPushEntryDualTypeCollapse pins the two behaviours of the tp==3 gate this
+// package now has: kept as 3 for a split store, collapsed to 0 for a shared
+// one -- the guard the shared table's `type IN (wanted, 0)` reads depend on.
+func TestPushEntryDualTypeCollapse(t *testing.T) {
+	body := `{"streams":[{"stream":{"job":"t"},"entries":[` +
+		`{"ts":"1600000000000000000","line":"hello","value":5}]}]}`
+
+	decode := func() uint8 {
+		dec := &pushRequestDec{ctx: &ParserCtx{bodyReader: strings.NewReader(body)}}
+		var got uint8
+		dec.SetOnEntries(func(_ [][]string, _ []int64, _ []string, _ []float64, types []uint8) error {
+			got = types[0]
+			return nil
+		})
+		if err := dec.Decode(); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return got
+	}
+
+	setSplitBySignal(t, "true")
+	if got := decode(); got != model.SAMPLE_TYPE_LOG_AND_METRIC {
+		t.Errorf("split on: type = %d, want %d", got, model.SAMPLE_TYPE_LOG_AND_METRIC)
+	}
+
+	setSplitBySignal(t, "false")
+	if got := decode(); got != model.SAMPLE_TYPE_UNDEF {
+		t.Errorf("split off: type = %d, want %d", got, model.SAMPLE_TYPE_UNDEF)
+	}
+}
+
+// TestOnEntriesFansDualTypeIntoTimeSeries is the panic guard: before the tps
+// array was widened past index 2, a type-3 row indexed out of range here. It
+// must also not just survive -- label lookups filter with `type IN (wanted,
+// 0)`, so the row has to produce a time_series row of type 1 and one of type
+// 2, never a single row of type 3.
+func TestOnEntriesFansDualTypeIntoTimeSeries(t *testing.T) {
+	old := config.Cloki
+	config.Cloki = &clconfig.ClokiConfig{Setting: &clokiconfig.ClokiBaseSettingServer{}}
+	t.Cleanup(func() { config.Cloki = old })
+
+	fpCache := numbercache.NewCache(time.Minute, func(val uint64) []byte {
+		return unsafe.Slice((*byte)(unsafe.Pointer(&val)), 8)
+	}, nil)
+
+	p := &parserDoer{
+		ctx:   &ParserCtx{fpCache: fpCache},
+		tsSpl: newTimeSeriesAndSamples(make(chan *model.ParserResponse, 1), ""),
+	}
+
+	err := p.onEntries(
+		[][]string{{"job", "t"}},
+		[]int64{1600000000000000000},
+		[]string{"hello"},
+		[]float64{5},
+		[]uint8{model.SAMPLE_TYPE_LOG_AND_METRIC},
+	)
+	if err != nil {
+		t.Fatalf("onEntries: %v", err)
+	}
+
+	types := p.tsSpl.ts.MType
+	if !slices.Contains(types, uint8(model.SAMPLE_TYPE_LOG)) ||
+		!slices.Contains(types, uint8(model.SAMPLE_TYPE_METRIC)) {
+		t.Fatalf("time_series types = %v, want both %d and %d",
+			types, model.SAMPLE_TYPE_LOG, model.SAMPLE_TYPE_METRIC)
+	}
+	if slices.Contains(types, uint8(model.SAMPLE_TYPE_LOG_AND_METRIC)) {
+		t.Fatalf("time_series types = %v, must not contain %d", types, model.SAMPLE_TYPE_LOG_AND_METRIC)
+	}
+}

--- a/writer/utils/unmarshal/unmarshal.go
+++ b/writer/utils/unmarshal/unmarshal.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-faster/city"
 	"github.com/go-faster/jx"
 	clcwriter "github.com/metrico/cloki-config/config/writer"
+	"github.com/metrico/qryn/v5/shared/samplesconfig"
 	"github.com/metrico/qryn/v5/writer/config"
 	"github.com/metrico/qryn/v5/writer/model"
 	"github.com/metrico/qryn/v5/writer/utils/errors"
@@ -160,7 +161,10 @@ func (p *pushRequestDec) decodeStreamValue(d *jx.Decoder) error {
 		return nil
 	})
 
-	if tp == 3 {
+	// A split store keeps the dual type: the ingest splitter fans such a row
+	// into both tables as a log row and a metric row. A shared table cannot,
+	// since reads match `type IN (wanted, 0)`, so there it collapses to 0.
+	if tp == 3 && !samplesconfig.SplitBySignal() {
 		tp = 0
 	}
 
@@ -222,7 +226,10 @@ func (p *pushRequestDec) decodeStreamEntry(d *jx.Decoder) error {
 		return errors.NewUnmarshalError(err)
 	}
 
-	if tp == 3 {
+	// A split store keeps the dual type: the ingest splitter fans such a row
+	// into both tables as a log row and a metric row. A shared table cannot,
+	// since reads match `type IN (wanted, 0)`, so there it collapses to 0.
+	if tp == 3 && !samplesconfig.SplitBySignal() {
 		tp = 0
 	}
 


### PR DESCRIPTION
# Store metrics and logs in separate tables (opt-in)

Adds `SAMPLES_SPLIT_BY_SIGNAL`, which moves metrics out of the shared `samples_v3`
into their own table, and makes the metrics preaggregate tunable — on/off, bucket
width, retention. Off by default; with the flag unset nothing about the current
behaviour changes.

The motivation is that `metrics_15s` does not aggregate metrics. At a 15s bucket
and a 15s–30s scrape interval each bucket holds one point: measured on a real
cluster the view stores 41.6M rows for 42.6M samples, a 2% saving, while costing
as much disk as the raw data. It exists for logs, where it compresses ~100:1.
One `ORDER BY` and one MV serve both signals, so neither can be tuned for either.

## How it works

**Schema.** Four new tables in `log_split*.sql` (version keys 12/13/14), created
only when the flag is on: `samples_logs`, `samples_metrics`, `logs_aggr`,
`metrics_aggr`. `samples_metrics` has no `string` column and `metrics_aggr` has no
`bytes` — nothing on the metrics read path selects them. All carry codecs from the
start (`Delta`/`DoubleDelta`/`Gorilla` + `ZSTD(1)`).

**The metrics view is state-managed, not migrated.** Migrations here are
append-only with a per-file version counter: a statement runs exactly once, which
cannot express "disable" or "rebucket". `metrics_aggr_mv` is therefore driven from
a value stored in `settings`, the same idiom `rotateTables` already uses — compute
the desired state, compare, issue DDL only on a difference. A bucket-width change
must be a whole multiple of the previous one, or startup fails with an
instruction: stored rows are re-bucketed on read by `intDiv(timestamp_ns, step)`,
so they fold onto a coarser grid but never onto a finer one.

**Write path.** The row stream is split by `MType` in `IngestParsed`, the single
point every transport and protocol funnels through — splitting per handler would
be wrong, since influx and Loki-style push carry both signals in one request.
Reads filter `type IN (wanted, 0)`, so a dual-typed row (a Loki push with both a
line and a value) is written as a log row in one half and a metric row in the
other, and an undefined type stays 0 in both.

**Read path.** Table choice happens once, in `PopulateTableNames`, keyed on
`ctx.Type`, which every reader entry point already sets. Nothing below it knows
the split exists. The configured bucket width replaces the hardcoded 15s in the
step arithmetic, and with no aggregate present the PromQL optimizers are gated
off so accelerated queries fall back to raw samples instead of pointing at a view
that does not exist.

Also fixes `PushPromWriteRequest`, which duplicated the ingest loop inline and so
bypassed the splitter — under the split it would have written recording-rule
results where no reader looks, silently.

## Configuration

| variable | default | effect |
|---|---|---|
| `SAMPLES_SPLIT_BY_SIGNAL` | `false` | separate tables per signal |
| `METRICS_AGGR_ENABLED` | `true` | build `metrics_aggr`; when off, metric queries read raw samples |
| `METRICS_AGGR_INTERVAL` | `15s` | preaggregate bucket width |
| `METRICS_AGGR_DAYS` | `SAMPLES_DAYS` | preaggregate retention |
| `ADVANCED_METRICS_ORDERING` | `ADVANCED_SAMPLES_ORDERING` | `ORDER BY` for `samples_metrics` |

## Measurements

Stand: docker compose, ClickHouse 25.3 capped at 4 CPU / 4 GB / 200 MB/s disk.
Data: 42.6M raw samples, 54 432 series, 6h, replayed from a real
kube-prometheus-stack. Every layout below holds the same rows.

Disk, bytes per sample:

| | B/sample | vs master |
|---|---:|---:|
| master today (`samples_v3` + `metrics_15s`) | 22.57 | — |
| aggregate on, default order | 14.23 | −37% |
| aggregate off, default order | 9.82 | −56% |
| aggregate off, `ORDER BY (fingerprint, timestamp_ns)` | **1.19** | **−95%** |

Decomposed on identical rows: codecs alone −21.5%, sort order alone −83.3%, both
−90.5%. Codecs on the aggregate table −56%. Dropping the empty `string` column
saves nothing. Under the default order `fingerprint` is 64% of the table (7.98
B/sample); under `(fingerprint, timestamp_ns)` it is 0.02.

Query latency, wall ms / ClickHouse ms:

| query | aggregate on | raw, default order | raw, fp order |
|---|---|---|---|
| `avg_over_time[5m]`, 267 series | 147 / 79 | 1640 / 1555 | **125 / 38** |
| `sum(rate[5m])`, 2670 series | **439 / 429** | 770 / 552 | 699 / 481 |
| tail 5m, step 15 | 229 / 154 | **113 / 28** | 180 / 103 |
| instant, all series | 198 / 134 | **85 / 20** | 163 / 101 |

Two things follow. `ADVANCED_METRICS_ORDERING` is not optional once the aggregate
is off: without it a narrow selector scans the whole table, and that degrades
superlinearly — 54ms at 5.7M rows, 1555ms at 42.6M. With it, the same query goes
26ms → 38ms.

And the aggregate is not buying speed. Off + fp-order wins 4 of 7 query shapes,
loses on wide range aggregations by ~1.5x, and stores 12x less. Codecs are the one
real trade: +30% on a full scan for −21% disk if the default order is kept.

## Testing

`go test ./...` green with the flag off and with `SAMPLES_SPLIT_BY_SIGNAL=true`.
DDL, both materialized views and the ordering and aggregate switches were
exercised against a live ClickHouse.

## Limits

The flag is one-way in practice: once on, data already in `samples_v3` is not
read, and data written while on is not read after turning it off. Intended for new
installations; a manual backfill is possible with `INSERT ... SELECT` per day
partition. Re-enabling the aggregate does not backfill the window it was off for,
and queries over that window read as empty until the table is rebuilt.
